### PR TITLE
Update Maven Checkstyle Plugin to 2.16. #7

### DIFF
--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<checkstyle-plugin.version>2.15</checkstyle-plugin.version>
+		<checkstyle-plugin.version>2.16</checkstyle-plugin.version>
 		<jxr-plugin.version>2.5</jxr-plugin.version>
 		<checkstyle.config.location>https://raw.githubusercontent.com/checkstyle/checkstyle/master/src/main/resources/google_checks.xml</checkstyle.config.location>
 	</properties>


### PR DESCRIPTION
Release Notes - Apache Maven Checkstyle Plugin - Version 2.16

Bug
* [MCHECKSTYLE-295] Test resources are not included
* [MCHECKSTYLE-271] checkstyle plugin fails with default ruleset and checkstyle 6.2

Improvement
* [MCHECKSTYLE-290] add a history table to show which version of Chesktyle is used by default in which version of m-checkstyle-p
* [MCHECKSTYLE-284] Remove config/sun_checks.xml and use the one built into Checkstyle 6.2+
* [MCHECKSTYLE-272] Upgrade to Checkstyle 6.2

Task
* [MCHECKSTYLE-285] Remove config/maven_checks.xml by removing the dependency on maven-shared-resources:2
* [MCHECKSTYLE-278] Require Java 7
* [MCHECKSTYLE-268] Add flag/option to use built-in Google style