### PR TITLE
'Line cannot end with this symbol' Check has been commented out from qulice-config

### DIFF
--- a/qulice/qulice-checks.xml
+++ b/qulice/qulice-checks.xml
@@ -146,11 +146,13 @@
         <property name="fileExtensions" value="java"/>
         <property name="message" value="Using class as a lock is a bad practice (use class variable instead)"/>
     </module>
+    <!-- All of its violations are false-positives.
     <module name="RegexpSingleline">
         <property name="format" value="^(?! *(/\*\*|\*|//)).*[\.\-\+%/\*&lt;&gt;] *$"/>
         <property name="fileExtensions" value="java"/>
         <property name="message" value="Line cannot end with this symbol, move it to the next line"/>
     </module>
+    -->
     <module name="RegexpSingleline">
         <property name="format" value="^ *="/>
         <property name="fileExtensions" value="java"/>


### PR DESCRIPTION
Weird Check that warns on multiline comments and generics:
```java
38  public abstract class AbstractOptionCheck<T extends Enum<T>>
```
or
```java
315         /*
316          * Remember: The lines number returned from the AST is 1-based, but
317          * the lines number in this array are 0-based. So you will often
318          * see a "lineNo-1" etc.
319          */
```