### PR TITLE
[releasenotes-xdoc-builder] minor fixes

### DIFF
--- a/releasenotes-xdoc-builder/src/main/java/com/github/checkstyle/ReleaseNotesMessage.java
+++ b/releasenotes-xdoc-builder/src/main/java/com/github/checkstyle/ReleaseNotesMessage.java
@@ -41,7 +41,7 @@ public class ReleaseNotesMessage {
      */
     public ReleaseNotesMessage(GHIssue issue, String author) {
         issueNo = issue.getNumber();
-        title = issue.getTitle();
+        title = getActualTitle(issue);
         this.author = author;
     }
 
@@ -66,5 +66,22 @@ public class ReleaseNotesMessage {
 
     public String getAuthor() {
         return author;
+    }
+
+    /**
+     * Returns actual title of issue or pull request which is represented as an issue.
+     * @param issue issue object.
+     * @return actual title of issue or pull request which is represented as an issue.
+     */
+    private String getActualTitle(GHIssue issue) {
+        final String actualTitle;
+        final String issueTitle = issue.getTitle();
+        if (issueTitle.startsWith("Pull")) {
+            actualTitle = issueTitle.substring(issueTitle.indexOf(":") + 2);
+        }
+        else {
+            actualTitle = issueTitle;
+        }
+        return actualTitle;
     }
 }

--- a/releasenotes-xdoc-builder/src/main/resources/com/github/checkstyle/templates/thymeleaf.template
+++ b/releasenotes-xdoc-builder/src/main/resources/com/github/checkstyle/templates/thymeleaf.template
@@ -3,9 +3,9 @@
       <p>Breaking backward compatibility:</p>
         <ul>
           <li th:each="message : ${breakingMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]] <a th:if="${message.issueNo} != -1"
+            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
         </ul>
       </th:block>
@@ -13,9 +13,9 @@
       <p>New:</p>
         <ul>
           <li th:each="message : ${newMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]] <a th:if="${message.issueNo} != -1"
+            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
         </ul>
       </th:block>
@@ -23,9 +23,9 @@
       <p>Bug fixes:</p>
         <ul>
           <li th:each="message : ${bugMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]] <a th:if="${message.issueNo} != -1"
+            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
         </ul>
       </th:block>
@@ -33,9 +33,9 @@
       <p>Notes:</p>
         <ul>
           <li th:each="message : ${notesMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]] <a th:if="${message.issueNo} != -1"
+            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
         </ul>
       </th:block>


### PR DESCRIPTION
@romani 

From mail-list:

1)
```
First line indentation is missed, generated :

"<section name="Release 6.13">
      
      <p>Breaking backward compatibility:</p>
        <ul>
          <li>"

should be 
"    <section name="Release 6.13">
      
      <p>Breaking backward compatibility:</p>
        <ul>
          <li>
"
```

2) Empty blank lines 

1 and 2 are Thymeleaf engine problems. I have not found the solution yet.
The only thing I can do is reformatting thymeleaf template, but it will damage readability. 

