### PR TITLE
minor: [releasenotes-xdoc-builder] exclude commits that are starting with "minor|infra"

### DIFF
--- a/releasenotes-xdoc-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
+++ b/releasenotes-xdoc-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
@@ -70,7 +70,7 @@ public final class NotesBuilder {
         Pattern.compile("^\\[maven-release-plugin\\].*(\r|\n)?$|"
             + "^update to ([0-9]|\\.)+-SNAPSHOT(\r|\n)?$|"
             + "^doc: release notes.*(\r|\n)?$|"
-            + "^config:.*(\r|\n)?$");
+            + "^(config:|minor:|infra:)(.|\n)*[\r|\n]?$");
 
     /** Default constructor. */
     private NotesBuilder() { }


### PR DESCRIPTION
```.*``` changed ```(.|\n)*``` because some commits can contain new line character in the middle of the message. For example, ```infra: releasenotes build\n\ndebug on Travis\n```. See https://github.com/checkstyle/checkstyle/commit/00c9e7cd081b82a3cd75aacf470d5b4b718da747
