### PR TITLE
[release-notes-xdoc-builder] minor fixes and refactoring

### DIFF
--- a/releasenotes-xdoc-builder/pom.xml
+++ b/releasenotes-xdoc-builder/pom.xml
@@ -15,7 +15,7 @@
         <maven.plugin.jgit.version>4.1.0.201509280440-r</maven.plugin.jgit.version>
         <maven.plugin.slf4j.version>1.7.12</maven.plugin.slf4j.version>
         <maven.plugin.freemarker.version>2.3.22</maven.plugin.freemarker.version>
-        <maven.plugin.thymeleaf.version>2.1.4.RELEASE</maven.plugin.thymeleaf.version>
+        <maven.plugin.thymeleaf.version>3.0.0.BETA01</maven.plugin.thymeleaf.version>
         <maven.plugin.apache.commons.cli.version>1.3.1</maven.plugin.apache.commons.cli.version>
         <maven.plugin.apache.commons.lang.version>2.6</maven.plugin.apache.commons.lang.version>
         <tools.jar.version>1.7.0</tools.jar.version>

--- a/releasenotes-xdoc-builder/src/main/java/com/github/checkstyle/TemplateProcessor.java
+++ b/releasenotes-xdoc-builder/src/main/java/com/github/checkstyle/TemplateProcessor.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.context.IContext;
+import org.thymeleaf.templateresolver.AbstractConfigurableTemplateResolver;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
-import org.thymeleaf.templateresolver.TemplateResolver;
 
 import com.google.common.collect.Multimap;
 import freemarker.template.Configuration;
@@ -64,17 +64,16 @@ public final class TemplateProcessor {
     public static void generateWithThymeleaf(Multimap<String, ReleaseNotesMessage> releaseNotes,
         String releaseNumber, String outputFile) throws IOException {
 
-        final TemplateEngine templateEngine = new TemplateEngine();
-        final TemplateResolver templateResolver = new ClassLoaderTemplateResolver();
-        templateResolver.setPrefix(TEMPLATE_FOLDER_PATH);
-        templateEngine.addTemplateResolver(templateResolver);
+        final TemplateEngine engine = new TemplateEngine();
+        final AbstractConfigurableTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setPrefix(TEMPLATE_FOLDER_PATH);
+        engine.setTemplateResolver(resolver);
 
         final IContext ctx =
             new Context(Locale.US, getTemplateVariables(releaseNotes,releaseNumber));
 
-        final String result = templateEngine.process(THYMELEAF_TEMPLATE_FILE, ctx);
         try (Writer fileWriter = new FileWriter(outputFile)) {
-            fileWriter.write(result);
+            engine.process(THYMELEAF_TEMPLATE_FILE, ctx, fileWriter);
         }
     }
 

--- a/releasenotes-xdoc-builder/src/main/resources/com/github/checkstyle/templates/thymeleaf.template
+++ b/releasenotes-xdoc-builder/src/main/resources/com/github/checkstyle/templates/thymeleaf.template
@@ -1,5 +1,5 @@
-    <section th:name="'Release ' + ${releaseNo}">
-      <th:block th:if="${not #lists.isEmpty(breakingMessages)}">
+    <section th:name="'Release ' + ${releaseNo}"><th:block
+      th:if="${not #lists.isEmpty(breakingMessages)}">
       <p>Breaking backward compatibility:</p>
         <ul>
           <li th:each="message : ${breakingMessages}" th:inline="text">
@@ -7,9 +7,8 @@
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
             + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
-        </ul>
-      </th:block>
-      <th:block th:if="${not #lists.isEmpty(newMessages)}">
+        </ul></th:block><th:block
+      th:if="${not #lists.isEmpty(newMessages)}">
       <p>New:</p>
         <ul>
           <li th:each="message : ${newMessages}" th:inline="text">
@@ -17,9 +16,8 @@
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
             + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
-        </ul>
-      </th:block>
-      <th:block th:if="${not #lists.isEmpty(bugMessages)}">
+        </ul></th:block><th:block
+      th:if="${not #lists.isEmpty(bugMessages)}">
       <p>Bug fixes:</p>
         <ul>
           <li th:each="message : ${bugMessages}" th:inline="text">
@@ -27,9 +25,8 @@
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
             + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
-        </ul>
-      </th:block>
-      <th:block th:if="${not #lists.isEmpty(notesMessages)}">
+        </ul></th:block><th:block
+      th:if="${not #lists.isEmpty(notesMessages)}">
       <p>Notes:</p>
         <ul>
           <li th:each="message : ${notesMessages}" th:inline="text">
@@ -37,6 +34,5 @@
             th:href="'https://github.com/checkstyle/checkstyle/issues/'
             + ${message.issueNo}"> #[[${message.issueNo}]]</a>
           </li>
-        </ul>
-      </th:block>
+        </ul></th:block>
     </section>


### PR DESCRIPTION
1) Themyleaf version was updated to 3.0.0.BETA01 and as a result problem with indentation of the first line in output file has been resolved.
2) Made refactoring of TemplateProcessor to use more abstract class as template resolver and exclude unnecessary instantiation of String object.
3) Reformated thymeleaf template to resolve the problem with blank lines in output file which are violated by Checkstyle. I tried to save readability of template.
4) Please rename https://github.com/checkstyle/checkstyle/commit/89cee419943977af6e70264a10c669a4c29bf830 if you want it to be excluded from release notes.
 