### PR TITLE
add patch-diff-report-tool

### DIFF
--- a/patch-diff-report-tool/README.md
+++ b/patch-diff-report-tool/README.md
@@ -1,0 +1,18 @@
+patch-diff-report-tool - for creating a symmetrical difference from two checkstyle-result.xml files. It is useful when you have two different large checkstyle XML reports and want to know difference between them. It deletes identical lines present in both XML files, merges residues into result site.
+
+usage example:
+
+You have 2 different checkstyle repos, original and forked, for each of them do 1-4:
+
+    1. mvn clean install
+    2. go to checkstyle-tester directory, uncomment all links in projects-to-test-on.properties, edit my_check.xml
+    3. execute ./launch.sh -Dcheckstyle.config.location=my_check.xml
+    4. copy checkstyle-result.xml from checkstyle-tester/target to some other location.
+
+Now execute this utility with 4 command line args:
+
+	    1. path to the directory containing first checkstyle-result.xml;
+        2. path to the directory containing second checkstyle-result.xml;
+        3. path to the data under check (facultative, if absent, file structure for cross reference files won't be relativized, full paths will be used);
+        4. path to the resulting site (facultative, if absent then default path will be used: ~/XMLDiffGen_report_yyyy.mm.dd_hh:mm:ss); 
+        i.e. java -jar ./patch-diff-report-tool.jar ~/eclipse_workspace/tester-checkstyle/checkstyle-tester/location1 ~/eclipse_workspace/tester-checkstyle/checkstyle-tester/location2  ~/eclipse_workspace/tester-checkstyle/checkstyle-tester/src/main/java ~/eclipse_workspace/tester-checkstyle/checkstyle-tester/site_result

--- a/patch-diff-report-tool/pom.xml
+++ b/patch-diff-report-tool/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.checkstyle</groupId>
+    <artifactId>patch-diff-report-tool</artifactId>
+    <packaging>jar</packaging>
+    <version>0.1-SNAPSHOT</version>
+    <name>patch-diff-report-tool</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.apache.maven</groupId>
+        	<artifactId>maven-jxr</artifactId>
+        	<version>2.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>com.github.checkstyle.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/FilesystemUtils.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/FilesystemUtils.java
@@ -1,0 +1,152 @@
+package com.github.checkstyle;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Utility class used for common manipulations with files.
+ *
+ * @author atta_troll
+ *
+ */
+public final class FilesystemUtils {
+
+    /**
+     * Buffer size for buffered stream.
+     */
+    private static final int BUFFER_SIZE = 4096;
+
+    /**
+     * Utility class ctor.
+     */
+    private FilesystemUtils() {
+
+    }
+
+    /**
+     * Deletes the file, if it is a directory, deletes its content recursively.
+     *
+     * @param root
+     *        path to the file.
+     * @throws IOException
+     *         thrown on filesystem error.
+     */
+    public static void delete(Path root)
+            throws IOException {
+        if (Files.isDirectory(root)) {
+            DirectoryStream<Path> subPaths = Files.newDirectoryStream(root);
+            for (Path path : subPaths) {
+                delete(path);
+            }
+            subPaths.close();
+            Files.delete(root);
+        }
+        else {
+            Files.delete(root);
+        }
+    }
+
+    /**
+     * Creates new directory or overwrites existing one.
+     *
+     * @param path
+     *        path to the directory.
+     * @throws IOException
+     *         thrown on filesystem error.
+     */
+    public static void createOverwriteDirectory(Path path)
+            throws IOException {
+        if (Files.exists(path)) {
+            delete(path);
+        }
+        Files.createDirectory(path);
+    }
+
+    /**
+     * Safely copies files and directories with its content.
+     *
+     * @param source
+     *        path to the existing file.
+     * @param destination
+     *        path to the desired location.
+     * @throws IllegalArgumentException
+     *         thrown on failure to resolve filename conflict.
+     * @throws IOException
+     *         thrown on filesystem error.
+     */
+    public static void copy(Path source, Path destination)
+            throws IllegalArgumentException,
+            IOException {
+        if (Files.isDirectory(source)) {
+            if (Files.exists(destination)) {
+                if (!Files.isDirectory(destination)) {
+                    throw new IllegalArgumentException(String.format(
+                            "fail to copy %s to %s "
+                                    + "because former is not a directory",
+                            source.toString(),
+                            destination.toString()));
+                }
+            }
+            else {
+                Files.createDirectory(destination);
+            }
+            DirectoryStream<Path> subPaths = Files.newDirectoryStream(source);
+            for (Path path : subPaths) {
+                final Path relativePath = source.relativize(path);
+                copy(path, destination.resolve(relativePath));
+            }
+            subPaths.close();
+
+        }
+        else {
+            Files.copy(source, destination);
+        }
+    }
+
+    /**
+     * Safely copies file, creates destination folder if needed.
+     *
+     * @param source
+     *        path to the file
+     * @param destination
+     *        path to file's destination.
+     * @throws IOException
+     *         thrown on filesystem error.
+     */
+    public static void copyFile(Path source, Path destination)
+            throws IOException {
+        Path destFolders = destination.getParent();
+        if (Files.notExists(destFolders)) {
+            Files.createDirectories(destFolders);
+        }
+        Files.copy(source, destination);
+    }
+
+    /**
+     * Exports a resource embedded into a Jar file to the local file path.
+     *
+     * @param resourceName
+     *        ie.: "/SmartLibrary.dll".
+     * @param destination
+     *        the desired path of the resource.
+     * @throws IOException
+     *         thrown on filesystem error.
+     */
+    public static void exportResource(String resourceName,
+            Path destination) throws IOException {
+        try (InputStream in = FilesystemUtils.class
+                .getResourceAsStream(resourceName);
+                OutputStream out = Files.newOutputStream(destination)) {
+            int readBytes;
+            byte[] buffer = new byte[BUFFER_SIZE];
+            while ((readBytes = in.read(buffer)) > 0) {
+                out.write(buffer, 0, BUFFER_SIZE);
+            }
+        }
+    }
+
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
@@ -1,0 +1,317 @@
+package com.github.checkstyle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import javax.xml.stream.XMLStreamException;
+
+import com.github.checkstyle.parser.ParsedContent;
+import com.github.checkstyle.parser.StatisticsHolder;
+import com.github.checkstyle.parser.StaxParserProcessor;
+import com.github.checkstyle.site.SiteGenerator;
+import com.github.checkstyle.site.XrefGenerator;
+
+/**
+ * Utility class, contains main function and
+ * its auxiliary routines.
+ *
+ * @author atta_troll
+ *
+ */
+public final class Main {
+
+    /**
+     * Link to the help html.
+     */
+    public static final String HELP_HTML_PATH = "help.html";
+
+    /**
+     * Name for the site file.
+     */
+    public static final Path SITEPATH = Paths.get("site.html");
+
+    /**
+     * Messages for errors.
+     */
+    public static final String MSG_WRONG_NUMBER_OF_ARGS =
+            "Not enough command line args, "
+            + "need at least 2 and no more than 4.";
+    public static final String MSG_BAD_PATH =
+            "Failed to resolve input paths.";
+    private static final String MSG_EXISTS =
+            "Unknown regular file exists with this name: ";
+    public static final String MSG_NOT_EXISTS =
+            "XML file doesn't exist: ";
+
+    public static final String MSG_BAD_SITE =
+            "Failed to locate essentual files: ";
+    public static final String MSG_IDENTICAL_INPUT =
+            "Both input XML files have the same path.";
+
+    public static final String MSG_PREPARATION_FAILURE =
+            "Failed to pass initial integrity checks.";
+    public static final String MSG_PARSE_FAILURE =
+            "Failed to create parse XML files.";
+    public static final String MSG_SITE_FAILURE =
+            "Failed to create html site";
+
+    /**
+     * Stage success messages.
+     */
+    public static final String MSG_PREPARATION_SUCCESS =
+            "Successfull preparation stage.";
+    public static final String MSG_PARSE_SUCCESS =
+            "XML files successfully parsed.";
+    public static final String MSG_SITE_SUCCESS =
+            "Creation of an html site succeed.";
+
+    /**
+     * Help message.
+     */
+    public static final String MSG_HELP =
+            "This program creates symmetric difference "
+            + "from two checkstyle-result.xml reports\n"
+            + "generated for checkstyle build.\n"
+            + "It has from 2 to 4 command line arguments:\n"
+            + "First two are the links to directories, each containing "
+            + "checkstyle-result.xml, these are obligatory arguments,\n"
+            + "Third argument is a link to the folder with the code "
+            + "under testing, it is fucultative, it will be used to "
+            + "relativize xdoc file structure, but it can be skipped and "
+            + "absolute paths will be used.\n"
+            + "Forth argument is a destination folder for the result site, "
+            + "it is facultative, if skipped, you will find the result site "
+            + "in your home directory, if this folder already exists, "
+            + "ITS CONTENT WILL BE PURGED.\n";
+
+    /**
+     * Minimal number of the cli arguments.
+     */
+    public static final int MIN_ARGS_NUMBER = 2;
+
+    /**
+     * Maximal number of the cli arguments.
+     */
+    public static final int MAX_ARGS_NUMBER = 4;
+
+    /**
+     * Minimal number of arguments when first obligatory argument is present.
+     */
+    public static final int ARGS_NUMBER_FIRST_OBLIGATORY = 0;
+
+    /**
+     * Minimal number of arguments when second obligatory argument is present.
+     */
+    public static final int ARGS_NUMBER_SECOND_OBLIGATORY = 1;
+
+    /**
+     * Minimal number of arguments when first facultative argument is present.
+     */
+    public static final int ARGS_NUMBER_FIRST_FACULTATIVE = 2;
+
+    /**
+     * Minimal number of arguments when second facultative argument is present.
+     */
+    public static final int ARGS_NUMBER_SECOND_FACULTATIVE = 3;
+
+    /**
+     * Number of "file" xml tags parsed at one iteration of parser.
+     */
+    public static final int XML_PARSE_PORTION_SIZE = 50;
+
+    /**
+     * Name for standart checkstyle xml report.
+     */
+    private static final Path XML_FILEPATH =
+            Paths.get("checkstyle-result.xml");
+
+    /**
+     * Name for the CSS files folder.
+     */
+    private static final Path CSS_FILEPATH = Paths.get("css");
+
+    /**
+     * Name for the CSS files folder.
+     */
+    private static final Path XREF_FILEPATH = Paths.get("xref");
+
+    /**
+     * Utility class ctor.
+     */
+    private Main() {
+
+    }
+
+    /**
+     * Parses CLI arguments,
+     * then passes control to executeStages.
+     *
+     * @param args
+     *        cli arguments.
+     */
+    public static void main(final String... args) {
+        if (args.length >= MIN_ARGS_NUMBER && args.length <= MAX_ARGS_NUMBER) {
+            try {
+                final Path pathDir1 = Paths
+                        .get(args[ARGS_NUMBER_FIRST_OBLIGATORY]);
+                final Path pathDir2 = Paths
+                        .get(args[ARGS_NUMBER_SECOND_OBLIGATORY]);
+                final Path pathTestData;
+                if (args.length > ARGS_NUMBER_FIRST_FACULTATIVE) {
+                    pathTestData = Paths
+                            .get(args[ARGS_NUMBER_FIRST_FACULTATIVE]);
+                }
+                else {
+                    pathTestData = null;
+                }
+                final Path pathResult;
+                if (args.length > ARGS_NUMBER_SECOND_FACULTATIVE) {
+                    pathResult = Paths
+                            .get(args[ARGS_NUMBER_SECOND_FACULTATIVE]);
+                }
+                else {
+                    pathResult = Paths.get(System.getProperty("user.home"))
+                            .resolve("XMLDiffGen_report_"
+                                    + new SimpleDateFormat(
+                                    "yyyy.MM.dd_HH:mm:ss")
+                                    .format(Calendar.getInstance().getTime()));
+                }
+                final Path pathXml1 = pathDir1.resolve(XML_FILEPATH);
+                final Path pathXml2 = pathDir2.resolve(XML_FILEPATH);
+                executeStages(pathResult, pathXml1, pathXml2, pathTestData);
+            }
+            catch (InvalidPathException e) {
+                e.printStackTrace();
+                System.out.print(MSG_HELP);
+                System.out.println(MSG_BAD_PATH);
+            }
+        }
+        else {
+            System.out.print(MSG_HELP);
+            System.out.println(MSG_WRONG_NUMBER_OF_ARGS);
+        }
+    }
+
+    /**
+     * Executes all three stages of this utility process.
+     *
+     * @param resultPath
+     *        path to folder with result site.
+     * @param pathXml1
+     *        path to first checkstyle-result.xml.
+     * @param pathXml2
+     *        path to second checkstyle-result.xml.
+     * @param pathTestData
+     *        path to checkstyle subject data.
+     */
+    private static void executeStages(Path pathResult, Path pathXml1,
+            Path pathXml2, Path pathTestData) {
+        //stage 1
+        try {
+            preparationStage(pathResult, pathXml1, pathXml2, pathTestData);
+            System.out.println(MSG_PREPARATION_SUCCESS);
+            try {
+                //stage 2
+                ParsedContent content = new ParsedContent();
+                StatisticsHolder holder = new StatisticsHolder();
+                StaxParserProcessor.parse(content, pathXml1,
+                        pathXml2, XML_PARSE_PORTION_SIZE, holder);
+                System.out.println(MSG_PARSE_SUCCESS);
+                //stage 3
+                XrefGenerator generator =
+                        new XrefGenerator(pathTestData, pathResult
+                                .resolve(XREF_FILEPATH), pathResult);
+                content.getStatistics(holder);
+                if (SiteGenerator.writeParsedContentToHtml(content,
+                            pathResult.resolve(SITEPATH), holder,
+                            generator)
+                        && SiteGenerator.writeHtmlHelp(
+                                pathResult
+                                .resolve(HELP_HTML_PATH))) {
+                    System.out.println(MSG_SITE_SUCCESS);
+                }
+                else {
+                    System.out.println(MSG_SITE_FAILURE);
+                }
+            }
+            catch (IOException | XMLStreamException e) {
+                e.printStackTrace();
+                System.out.println(MSG_PARSE_FAILURE);
+            }
+        }
+        catch (IllegalArgumentException | IOException e1) {
+            e1.printStackTrace();
+            System.out.print(MSG_HELP);
+            System.out.println(MSG_PREPARATION_FAILURE);
+        }
+
+    }
+
+    /**
+     * Perform preliminary file existence checks,
+     * also exports to disc necessary static resources.
+     *
+     * @param resultPath
+     *        path to folder with result site.
+     * @param pathXml1
+     *        path to first checkstyle-result.xml.
+     * @param pathXml2
+     *        path to second checkstyle-result.xml.
+     * @param pathTestData
+     *        path to checkstyle subject data.
+     * @throws IOException
+     *        thrown on failure to perform checks.
+     */
+    private static void preparationStage(Path resultPath, Path pathXml1,
+            Path pathXml2, Path pathTestData) throws IOException {
+        initialVerification(resultPath, pathXml1, pathXml2, pathTestData);
+        FilesystemUtils.createOverwriteDirectory(resultPath);
+        FilesystemUtils.createOverwriteDirectory(resultPath
+                .resolve(CSS_FILEPATH));
+        FilesystemUtils.createOverwriteDirectory(resultPath
+                .resolve(XREF_FILEPATH));
+        FilesystemUtils.exportResource("/maven-theme.css",
+                resultPath.resolve(CSS_FILEPATH).resolve("maven-theme.css"));
+        FilesystemUtils.exportResource("/maven-base.css",
+                resultPath.resolve(CSS_FILEPATH).resolve("maven-base.css"));
+    }
+
+    /**
+     * Performs file existence checks.
+     *
+     * @param resultPath
+     *        path to folder with result site.
+     * @param pathXml1
+     *        path to first checkstyle-result.xml.
+     * @param pathXml2
+     *        path to second checkstyle-result.xml.
+     * @param pathTestData
+     *        path to checkstyle subject data.
+     * @throws IllegalArgumentException
+     *         on failure of any check.
+     */
+    private static void initialVerification(Path resultPath,
+            Path pathXml1, Path pathXml2, Path pathTestData)
+                    throws IllegalArgumentException {
+        if (!Files.isRegularFile(pathXml1)) {
+            throw new IllegalArgumentException(MSG_NOT_EXISTS + pathXml1);
+        }
+        if (!Files.isRegularFile(pathXml2)) {
+            throw new IllegalArgumentException(MSG_NOT_EXISTS + pathXml2);
+        }
+        if (pathXml1.equals(pathXml2)) {
+            throw new IllegalArgumentException(MSG_IDENTICAL_INPUT);
+        }
+        if (Files.isRegularFile(resultPath)) {
+            throw new IllegalArgumentException(MSG_EXISTS + resultPath);
+        }
+        if (pathTestData != null && !Files.isDirectory(pathTestData)) {
+            throw new IllegalArgumentException(MSG_NOT_EXISTS + pathTestData);
+        }
+    }
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleRecord.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleRecord.java
@@ -1,0 +1,87 @@
+package com.github.checkstyle.parser;
+
+/**
+ * POJO, maps into single "error" tag of the XML.
+ *
+ * @author atta_troll
+ *
+ */
+public class CheckstyleRecord {
+    private boolean belongsToFirst;
+    private int line;
+    private int column;
+    private Severity severity;
+    private String source;
+    private String message;
+
+    /**
+     * POJO ctor.
+     *
+     * @param belongsToFirst1
+     *        flag of belonging to first XML report.
+     * @param line1
+     *        line number.
+     * @param column1
+     *        column number.
+     * @param severity1
+     *        record severity level.
+     * @param source1
+     *        name of check that generated record.
+     * @param message1
+     *        error message.
+     */
+    public CheckstyleRecord(boolean belongsToFirst1, int line1, int column1,
+            Severity severity1, String source1, String message1) {
+        this.belongsToFirst = belongsToFirst1;
+        this.line = line1;
+        this.column = column1;
+        this.severity = severity1;
+        this.source = source1;
+        this.message = message1;
+    }
+
+    /**
+     * Below are multiple getters.
+     *
+     * @return true if belongs to the first report.
+     */
+    public final boolean belongsToFirstReport() {
+        return belongsToFirst;
+    }
+
+    public final int getLine() {
+        return line;
+    }
+
+    public final int getColumn() {
+        return column;
+    }
+
+    public final String getSource() {
+        return source;
+    }
+
+    public final String getMessage() {
+        return message;
+    }
+
+    public final Severity getSeverity() {
+        return severity;
+    }
+
+    /**
+     * Compares CheckstyleRecord instances by their content.
+     * It is used in a single controlled occasion in the code.
+     *
+     * @param other
+     *        another ChechstyleRecord instance under comparison
+     *        with this instance.
+     * @return true if instances are equal.
+     */
+    public final boolean specificEquals(final CheckstyleRecord other) {
+        return this.line == other.line && this.column == other.column
+                && this.source.equals(other.source)
+                && this.message.equals(other.message);
+    }
+
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/ParsedContent.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/ParsedContent.java
@@ -1,0 +1,163 @@
+package com.github.checkstyle.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Container for all parsed data, expunges all abundant information
+ * immediately when there is an opportunity to do so,
+ * thus keeping memory usage as minimal as possible.
+ *
+ * @author atta_troll
+ *
+ */
+public final class ParsedContent {
+    /**
+     * Comparator used to sort lists of CheckstyleRecord objects
+     * by their position in code.
+     *
+     * @author atta_troll
+     *
+     */
+    private static class PositionOrderComparator
+        implements Comparator<CheckstyleRecord> {
+
+        @Override
+        public int compare(final CheckstyleRecord arg0,
+                final CheckstyleRecord arg1) {
+            final int difference = arg0.getLine() - arg1.getLine();
+            if (difference == 0) {
+                return arg0.getColumn() - arg1.getColumn();
+            }
+            else {
+                return difference;
+            }
+        }
+    }
+
+    /**
+     * Container for parsed data,
+     * note it is a TreeMap for memory keeping purposes.
+     */
+    private Map<String, List<CheckstyleRecord>> records =
+            new TreeMap<>();
+
+    /**
+     * Utility ctor.
+     */
+    public ParsedContent() {
+
+    }
+
+    /**
+     * Getter for data container.
+     *
+     * @return map containing parsed data.
+     */
+    public Map<String, List<CheckstyleRecord>> getRecords() {
+        return records;
+    }
+
+    /**
+     * Adds new records to the container,
+     * when there are records with this filename, comparison
+     * between them and new record is performed and only difference is saved.
+     *
+     * @param filename
+     *        name of a file which is a cause of records generation.
+     * @param newRecords
+     *        a new records list.
+     */
+    public void addRecords(String filename,
+            List<CheckstyleRecord> newRecords) {
+        List<CheckstyleRecord> popped = records.put(filename, newRecords);
+        if (popped != null) {
+            List<CheckstyleRecord> diff = produceDiff(popped, newRecords);
+            if (diff.isEmpty()) {
+                records.remove(filename);
+            }
+            else {
+                Collections.sort(diff, new PositionOrderComparator());
+                records.put(filename, diff);
+            }
+        }
+    }
+
+    /**
+     * Creates difference between 2 lists of records.
+     *
+     * @param list1
+     *        the first list.
+     * @param list2
+     *        the second list.
+     * @return the difference list.
+     */
+    private static List<CheckstyleRecord> produceDiff(
+            List<CheckstyleRecord> list1, List<CheckstyleRecord> list2) {
+        List<CheckstyleRecord> diff = new ArrayList<>();
+        for (CheckstyleRecord rec1 : list1) {
+            if (!isInList(rec1, list2)) {
+                diff.add(rec1);
+            }
+        }
+        for (CheckstyleRecord rec2 : list2) {
+            if (!isInList(rec2, list1)) {
+                diff.add(rec2);
+            }
+        }
+        return diff;
+    }
+
+    /**
+     * Compares the record against list of records.
+     *
+     * @param testedRecord
+     *        the record.
+     * @param list
+     *        of records.
+     * @return true, if has its copy in a list.
+     */
+    private static boolean isInList(CheckstyleRecord testedRecord,
+            List<CheckstyleRecord> list) {
+        boolean belongsToList = false;
+        for (CheckstyleRecord record : list) {
+            if (testedRecord.specificEquals(record)) {
+                belongsToList = true;
+                break;
+            }
+        }
+        return belongsToList;
+    }
+
+    /**
+     * Generates statistical information and puts in in the holder.
+     *
+     * @param holder a StatisticsHolder instance.
+     */
+    public void getStatistics(StatisticsHolder holder) {
+        holder.setFileNumDiff(records.size());
+        for (Map.Entry<String, List<CheckstyleRecord>> entry
+                : records.entrySet()) {
+            final List<CheckstyleRecord> list = entry.getValue();
+            for (CheckstyleRecord rec : list) {
+                holder.incrementTotalNumDiff();
+                switch (rec.getSeverity()) {
+                case ERROR:
+                    holder.incrementErrorNumDiff();
+                    break;
+                case WARNING:
+                    holder.incrementWarningNumDiff();
+                    break;
+                default:
+                    holder.incrementInfoNumDiff();
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/Severity.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/Severity.java
@@ -1,0 +1,24 @@
+package com.github.checkstyle.parser;
+
+/**
+ * Represents different states of severity of the checkstyle messages.
+ *
+ * @author atta_troll
+ *
+ */
+public enum Severity {
+    /**
+     * Represents error level.
+     */
+    ERROR,
+
+    /**
+     * Represents warning level.
+     */
+    WARNING,
+
+    /**
+     * Represents informational level.
+     */
+    INFORMATIONAL;
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/StatisticsHolder.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/StatisticsHolder.java
@@ -1,0 +1,151 @@
+package com.github.checkstyle.parser;
+
+/**
+ * POJO holding all statistics gathered during parsing stage.
+ * @author atta_troll
+ */
+public class StatisticsHolder {
+
+    private int errorNumDiff = 0;
+    private int warningNumDiff = 0;
+    private int infoNumDiff = 0;
+    private int totalNumDiff = 0;
+    private int fileNumDiff = 0;
+
+    private int errorNum1 = 0;
+    private int errorNum2 = 0;
+    private int warningNum1 = 0;
+    private int warningNum2 = 0;
+    private int infoNum1 = 0;
+    private int infoNum2 = 0;
+    private int totalNum1 = 0;
+    private int totalNum2 = 0;
+
+    private int fileNum1 = 0;
+    private int fileNum2 = 0;
+
+    public StatisticsHolder() {
+
+    }
+
+    public final int getErrorNumDiff() {
+        return errorNumDiff;
+    }
+
+    public final void incrementErrorNumDiff() {
+        this.errorNumDiff++;
+    }
+
+    public final int getWarningNumDiff() {
+        return warningNumDiff;
+    }
+
+    public final void incrementWarningNumDiff() {
+        this.warningNumDiff++;
+    }
+
+    public final int getInfoNumDiff() {
+        return infoNumDiff;
+    }
+
+    public final void incrementInfoNumDiff() {
+        this.infoNumDiff++;
+    }
+
+    public final int getTotalNumDiff() {
+        return totalNumDiff;
+    }
+
+    public final void incrementTotalNumDiff() {
+        this.totalNumDiff++;
+    }
+
+    public final int getFileNumDiff() {
+        return fileNumDiff;
+    }
+
+    public final void setFileNumDiff(final int fileNumDiff1) {
+        this.fileNumDiff = fileNumDiff1;
+    }
+
+    public final int getErrorNum1() {
+        return errorNum1;
+    }
+
+    public final void incrementErrorNum1() {
+        this.errorNum1++;
+    }
+
+    public final int getErrorNum2() {
+        return errorNum2;
+    }
+
+    public final void incrementErrorNum2() {
+        this.errorNum2++;
+    }
+
+    public final int getWarningNum1() {
+        return warningNum1;
+    }
+
+    public final void incrementWarningNum1() {
+        this.warningNum1++;
+    }
+
+    public final int getWarningNum2() {
+        return warningNum2;
+    }
+
+    public final void incrementWarningNum2() {
+        this.warningNum2++;
+    }
+
+    public final int getInfoNum1() {
+        return infoNum1;
+    }
+
+    public final void incrementInfoNum1() {
+        this.infoNum1++;
+    }
+
+    public final int getInfoNum2() {
+        return infoNum2;
+    }
+
+    public final void incrementInfoNum2() {
+        this.infoNum2++;
+    }
+
+    public final int getTotalNum1() {
+        return totalNum1;
+    }
+
+    public final void incrementTotalNum1() {
+        this.totalNum1++;
+    }
+
+    public final int getTotalNum2() {
+        return totalNum2;
+    }
+
+    public final void incrementTotalNum2() {
+        this.totalNum2++;
+    }
+
+    public final int getFileNum1() {
+        return fileNum1;
+    }
+
+    public final void incrementFileNum1() {
+        this.fileNum1++;
+    }
+
+    public final int getFileNum2() {
+        return fileNum2;
+    }
+
+    public final void incrementFileNum2() {
+        this.fileNum2++;
+    }
+
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/StaxParserProcessor.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/StaxParserProcessor.java
@@ -1,0 +1,261 @@
+package com.github.checkstyle.parser;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+/**
+ * Contains logics of the StaX parser for the checkstyle xml reports.
+ * If its scheme changed, this class should be the first one to fix.
+ *
+ * @author atta_troll
+ */
+public final class StaxParserProcessor {
+    /**
+     * XML tags values.
+     */
+    private static final String FILE_TAG = "file";
+    private static final String ERROR_TAG = "error";
+    private static final String FILENAME_ATTR = "name";
+    private static final String LINE_ATTR = "line";
+    private static final String COLUMN_ATTR = "column";
+    private static final String SEVERITY_ATTR = "severity";
+    private static final String MESSAGE_ATTR = "message";
+    private static final String SOURCE_ATTR = "source";
+
+    /**
+     * Severity attribute values.
+     */
+    private static final String SEVERITY_WARNING = "warning";
+    private static final String SEVERITY_ERROR = "error";
+
+    /**
+     * Utility ctor.
+     */
+    private StaxParserProcessor() {
+
+    }
+
+    /**
+     * Parses input XML files: creates 2 parsers
+     * which process their XML files in rotation and try
+     * to write their results to the ParsedContent class
+     * inner map, where they are eagerly compared.
+     * @param content
+     *        container for parsed data.
+     * @param xml1
+     *        path to first XML file.
+     * @param xml2
+     *        path to second XML file.
+     * @param portionSize
+     *        single portion of XML file processed at once by any parser.
+     * @param holder
+     *        StatisticsHolder instance.
+     * @throws FileNotFoundException
+     *         thrown if files not found.
+     * @throws XMLStreamException
+     *         thrown on internal parser error.
+     */
+    public static void parse(ParsedContent content, Path xml1,
+            Path xml2, int portionSize, StatisticsHolder holder)
+                    throws FileNotFoundException, XMLStreamException {
+        XMLEventReader reader1 = prepareParsing(xml1);
+        XMLEventReader reader2 = prepareParsing(xml2);
+        while (reader1.hasNext() || reader2.hasNext()) {
+            parseXMLPortion(content, reader1, portionSize, true, holder);
+            parseXMLPortion(content, reader2, portionSize, false, holder);
+        }
+    }
+
+    /**
+     * Creates parser linked to the existing XML file.
+     *
+     * @param xmlFilename
+     *        name of an XML report file.
+     * @return StAX parser interface.
+     * @throws FileNotFoundException
+     *         on wrong filename.
+     * @throws XMLStreamException
+     *         on internal factory failure.
+     */
+    private static XMLEventReader prepareParsing(Path xmlFilename)
+            throws FileNotFoundException, XMLStreamException {
+        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+        // Setup a new eventReader
+        InputStream in = new FileInputStream(xmlFilename.toFile());
+        return inputFactory.createXMLEventReader(in);
+    }
+
+    /**
+     * Parses portion of the XML report.
+     *
+     * @param content
+     *        container for parsed data.
+     * @param reader
+     *        pStAX parser interface.
+     * @param numOfFilenames
+     *        number of "file" tags to parse.
+     * @param first
+     *        flag of parsing the first report.
+     * @param holder
+     *        StatisticsHolder instance.
+     * @throws XMLStreamException
+     *         thrown on internal parser error.
+     */
+    private static void parseXMLPortion(ParsedContent content,
+            XMLEventReader reader, int numOfFilenames, boolean first,
+            StatisticsHolder holder)
+                    throws XMLStreamException {
+        int counter = numOfFilenames;
+        String filename = null;
+        List<CheckstyleRecord> records = null;
+        while (reader.hasNext() && counter > 0) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isStartElement()) {
+                final StartElement startElement = event.asStartElement();
+                final String startElementName = startElement.getName()
+                        .getLocalPart();
+                //file tag encounter
+                if (startElementName.equals(FILE_TAG)) {
+                    counter--;
+                    if (first) {
+                        holder.incrementFileNum1();
+                    }
+                    else {
+                        holder.incrementFileNum2();
+                    }
+                    Iterator<Attribute> attributes = startElement
+                            .getAttributes();
+                    while (attributes.hasNext()) {
+                        Attribute attribute = attributes.next();
+                        if (attribute.getName().toString()
+                                .equals(FILENAME_ATTR)) {
+                            filename = attribute.getValue();
+                        }
+                    }
+                    records = new ArrayList<>();
+                }
+                //error tag encounter
+                else if (startElementName.equals(ERROR_TAG)) {
+                    records.add(parseErrorTag(startElement, holder, first));
+                }
+            }
+            if (event.isEndElement()) {
+                final EndElement endElement = event.asEndElement();
+                if (endElement.getName().getLocalPart().equals(FILE_TAG)) {
+                    content.addRecords(filename, records);
+                }
+            }
+        }
+    }
+
+    /**
+     * Parses "error" XML tag.
+     *
+     * @param startElement
+     *        cursor of StAX parser pointed on the tag.
+     * @param holder
+     *        StatisticsHolder instance.
+     * @param first
+     *        flag of parsing the first report.
+     * @return parsed data as CheckstyleRecord instance.
+     */
+    private static CheckstyleRecord parseErrorTag(StartElement startElement,
+            StatisticsHolder holder, boolean first) {
+        int line = -1;
+        int column = -1;
+        Severity severity = Severity.INFORMATIONAL;
+        String source = null;
+        String message = null;
+
+        Iterator<Attribute> attributes = startElement
+                .getAttributes();
+        while (attributes.hasNext()) {
+            Attribute attribute = attributes.next();
+            final String attrName = attribute.getName().toString();
+            if (attrName.equals(LINE_ATTR)) {
+                line = Integer.parseInt(attribute.getValue());
+            }
+            else if (attrName.equals(COLUMN_ATTR)) {
+                column = Integer.parseInt(attribute.getValue());
+            }
+            else if (attrName.equals(SEVERITY_ATTR)) {
+                final String attrValue = attribute.getValue();
+                if (attrValue.equals(SEVERITY_ERROR)) {
+                    severity = Severity.ERROR;
+                }
+                else if (attrValue.equals(SEVERITY_WARNING)) {
+                    severity = Severity.WARNING;
+                }
+                incrementStatistics(severity, holder, first);
+            }
+            else if (attrName.equals(MESSAGE_ATTR)) {
+                message = attribute.getValue();
+            }
+            else if (attrName.equals(SOURCE_ATTR)) {
+                source = attribute.getValue();
+            }
+        }
+        return new CheckstyleRecord(first,
+                line, column, severity, source, message);
+
+    }
+
+    /**
+     * Adds statistics from single "error" tag to the StatisticsHolder POJO.
+     *
+     * @param severity
+     *        severity level of "error" tag.
+     * @param holder
+     *        StatisticsHolder instance.
+     * @param first
+     *        flag of parsing the first report.
+     */
+    private static void incrementStatistics(Severity severity,
+            StatisticsHolder holder, boolean first) {
+        switch (severity) {
+        case ERROR:
+            if (first) {
+                holder.incrementErrorNum1();
+            }
+            else {
+                holder.incrementErrorNum2();
+            }
+            break;
+        case WARNING:
+            if (first) {
+                holder.incrementWarningNum1();
+            }
+            else {
+                holder.incrementWarningNum2();
+            }
+            break;
+        default:
+            if (first) {
+                holder.incrementInfoNum1();
+            }
+            else {
+                holder.incrementInfoNum2();
+            }
+            break;
+        }
+        if (first) {
+            holder.incrementTotalNum1();
+        }
+        else {
+            holder.incrementTotalNum2();
+        }
+    }
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/JxrDummyLog.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/JxrDummyLog.java
@@ -1,0 +1,35 @@
+package com.github.checkstyle.site;
+
+import org.apache.maven.jxr.log.Log;
+
+/**
+ * Dummy log used by maven-jxr PackageManager.
+ *
+ * @author atta_troll
+ *
+ */
+public class JxrDummyLog implements Log {
+
+    @Override
+    public void debug(String arg0) {
+
+    }
+
+    @Override
+    public void error(String arg0) {
+        System.out.println(arg0);
+
+    }
+
+    @Override
+    public void info(String arg0) {
+
+    }
+
+    @Override
+    public void warn(String arg0) {
+        System.out.println(arg0);
+
+    }
+
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -1,0 +1,410 @@
+package com.github.checkstyle.site;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.github.checkstyle.parser.CheckstyleRecord;
+import com.github.checkstyle.parser.ParsedContent;
+import com.github.checkstyle.parser.StatisticsHolder;
+
+import static com.github.checkstyle.Main.HELP_HTML_PATH;
+import static com.github.checkstyle.Main.SITEPATH;
+
+/**
+ * Site generator from parsed data.
+ *
+ * @author atta_troll
+ *
+ */
+public final class SiteGenerator {
+    /**
+     * CSS style codes.
+     */
+    public static final char FIRST_REPORT_CSS_STYLE = 'a';
+    public static final char SECOND_REPORT_CSS_STYLE = 'b';
+
+    /**
+     * Abbreviations used in site tables.
+     */
+    public static final char SEVERITY_WARNING_CHAR = 'W';
+    public static final char SEVERITY_INFO_CHAR = 'I';
+    public static final char SEVERITY_ERROR_CHAR = 'E';
+
+    /**
+     * Conventional names of the initial XML files.
+     */
+    public static final String FIRST_REPORT_NAME = "first";
+    public static final String SECOND_REPORT_NAME = "second";
+
+    /**
+     * Delimiter used in full names of checks.
+     */
+    private static final char CHECK_NAME_DELIMITER = '.';
+
+    /**
+     * Counter used in anchor links generation.
+     */
+    private static long anchorCounter = 0;
+
+    /**
+     * Site head tag content.
+     */
+    private static final String HTML_HEAD =
+            "<title>checkstyle xml difference report</title>\n"
+            + "<style type=\"text/css\" media=\"all\">"
+            + "@import url(\"./css/maven-base.css\");"
+            + "@import url(\"./css/maven-theme.css\"); );"
+            + "</style>\n"
+            + "<http-equiv http-equiv=\"Content-Language\" content=\"en\">"
+            + "</http-equiv>";
+
+    /**
+     * Site title.
+     */
+    private static final String SITE_TITLE =
+            "<div class=\"section\">\n"
+            + "<h2 a=\"Checkstyle XML difference report\">"
+            + "Checkstyle XML difference report</h2>\n"
+            + "<a href=\"" + HELP_HTML_PATH + "\">"
+            + "<h4>explanation</h4></a>\n</div>\n";
+
+    /**
+     * Statistics section title.
+     */
+    private static final String STATISTICS_TITLE =
+            "<h2 a=\"Summary:\">Summary:</h2>\n";
+
+    /**
+     * Statistics table header.
+     */
+    private static final String STATISTICS_TABLE_HEADER =
+            "<div class=\"section\">\n"
+            + "<table border=\"0\" class=\"bodyTable\">\n"
+            + "<tr class=\"a\">\n"
+            + "<th>Report index</th>\n"
+            + "<th>Files</th>\n"
+            + "<th>Unique rows</th>\n"
+            + "<th>Info</th>\n"
+            + "<th>Warnings</th>\n"
+            + "<th>Errors</th>\n"
+            + "</tr>\n";
+
+    /**
+     * Statistics table row template.
+     */
+    private static final String STATISTICS_TABLE_ROW =
+            "<tr class=\"%c\">\n"
+            + "<td>%s</td>\n"
+            + "<td>%d</td>\n"
+            + "<td>%d</td>\n"
+            + "<td>%d</td>\n"
+            + "<td>%d</td>\n"
+            + "<td>%d</td>\n"
+            + "<tr>\n";
+
+    /**
+     * Title for the content section.
+     */
+    private static final String CONTENT_TITLE =
+            "<div class=\"section\">\n"
+            + "<h2 a=\"Unique rows:\">Unique rows:</h2>\n";
+
+    /**
+     * Header for every content section table.
+     */
+    private static final String TABLE_HEADER =
+            "<div class=\"section\"><h3 id=\"%s\">%s</h3>\n<tr class=\"b\">\n"
+            + "<table border=\"0\" class=\"bodyTable\">"
+            + "<th>Anchor</th>\n"
+            + "<th>Severity</th>\n"
+            + "<th>Rule</th>\n"
+            + "<th>Message</th>\n"
+            + "<th>Line</th>\n"
+            + "<th>Column</th>\n"
+            + "<th>Report</th>\n"
+            + "</tr>\n";
+
+    /**
+     * Content section table row template.
+     */
+    private static final String TABLE_ROW = "<tr class=\"%c\">\n"
+            + "<td><a name=\"%s\" href=\"#%s\">%s</a></td>\n"
+            + "<td>%c</td>\n"
+            + "<td>%s</td>\n"
+            + "<td>%s</td>\n"
+            + "<td><a href=\"%s#L%d\">%d</a></td>\n"
+            + "<td>%d</td>\n"
+            + "<td>%s</td>\n"
+            + "<tr>\n";
+
+    /**
+     * Content for help file.
+     */
+    private static final String HELP_FILE_CONTENT = "<div id=\"contentBox\">\n"
+            + "<div class=\"section\">\n <h2 a=\"Explanation:\">Explanation:"
+            + "</h2>This is symmetric difference generated "
+            + "from two checkstyle-result.xml reports.\n"
+            + "<br>All matching records from each XML file are deleted, "
+            + "then remaining records are merged into single report.\n"
+            + "<br>\n"
+            + "<br>\n"
+            + "<a href=\"https://github.com/checkstyle/contribution/"
+            + "tree/master/patch-diff-report-tool\">"
+            + "Utility that generated this report.</a>\n"
+            + "<h3><a href=\"" + SITEPATH + "\">back to report</a></h3>\n"
+            + "</div>\n"
+            + "</div>\n";
+
+    /**
+     * Utility class ctor.
+     */
+    private SiteGenerator() {
+
+    }
+
+    /**
+     * Generates site from ParsedContent and StatisticsHolder
+     * and writes it on disk.
+     *
+     * @param content
+     *        container for parsed data.
+     * @param path
+     *        of the result site.
+     * @param holder
+     *        StatisticsHolder instance.
+     * @param generator
+     *        XrefGenerator instance.
+     * @return true if overall success.
+     */
+    public static boolean writeParsedContentToHtml(ParsedContent content,
+            Path path, StatisticsHolder holder, XrefGenerator generator) {
+        boolean success = true;
+        try {
+            Files.createFile(path);
+            try (BufferedWriter writer =
+                    new BufferedWriter(new FileWriter(path.toFile()))) {
+                writer.write("<html>\n");
+                writeHead(writer);
+                writeBody(content, writer, holder, generator);
+                writer.write("</html>\n");
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+                success = false;
+            }
+        }
+        catch (IOException e1) {
+            e1.printStackTrace();
+            success = false;
+
+        }
+
+        return success;
+    }
+
+    /**
+     * Writes to disk html help.
+     *
+     * @param path
+     *        path to the help file.
+     * @return true on success.
+     */
+    public static boolean writeHtmlHelp(Path path) {
+        boolean success = true;
+        try {
+            Files.createFile(path);
+            try (BufferedWriter writer =
+                    new BufferedWriter(new FileWriter(path.toFile()))) {
+                writer.write("<html>\n");
+                writeHead(writer);
+                writer.write("<body class=\"composite\">\n");
+                writer.write(HELP_FILE_CONTENT);
+                writer.write("</body>\n");
+                writer.write("</html>\n");
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+                success = false;
+            }
+        }
+        catch (IOException e1) {
+            e1.printStackTrace();
+            success = false;
+
+        }
+
+        return success;
+    }
+
+    /**
+     * Writes out HTML head.
+     *
+     * @param writer
+     *        BufferedWriter used to write HTML to file on disk.
+     * @throws IOException
+     *         thrown on writer failure.
+     */
+    private static void writeHead(BufferedWriter writer)
+            throws IOException {
+        writer.write("<head>\n");
+        writer.write(HTML_HEAD);
+        writer.write("</head>\n");
+    }
+
+    /**
+     * Writes out html body.
+     *
+     * @param content
+     *        container for parsed data.
+     * @param writer
+     *        BufferedWriter used to write HTML to file on disk.
+     * @param holder
+     *        StatisticsHolder instance.
+     * @param generator
+     *        XrefGenerator instance.
+     * @throws IOException
+     *         thrown on writer failure.
+     */
+    private static void writeBody(ParsedContent content, BufferedWriter writer,
+            StatisticsHolder holder, XrefGenerator generator)
+                    throws IOException {
+        writer.write("<body class=\"composite\">\n");
+        writer.write("<div id=\"contentBox\">\n");
+        writer.write(SITE_TITLE);
+        writeStatistics(writer, holder);
+        writeContent(content, writer, generator);
+        writer.write("</div>\n");
+        writer.write("</body>\n");
+    }
+
+    /**
+     * Writes statistics section to the file.
+     *
+     * @param writer
+     *        BufferedWriter used to write HTML to file on disk.
+     * @param holder
+     *        StatisticsHolder instance
+     * @throws IOException
+     *         thrown on writer failure.
+     */
+    private static void writeStatistics(BufferedWriter writer,
+            StatisticsHolder holder) throws IOException {
+        writer.write("<div class=\"section\">\n");
+        writer.write(STATISTICS_TITLE);
+        writer.write(STATISTICS_TABLE_HEADER);
+        writer.write(String.format(STATISTICS_TABLE_ROW, 'a', "first",
+                holder.getFileNum1(),
+                holder.getTotalNum1(),
+                holder.getInfoNum1(),
+                holder.getWarningNum1(),
+                holder.getErrorNum1()));
+        writer.write(String.format(STATISTICS_TABLE_ROW, 'b', "second",
+                holder.getFileNum2(),
+                holder.getTotalNum2(),
+                holder.getInfoNum2(),
+                holder.getWarningNum2(),
+                holder.getErrorNum2()));
+        writer.write(String.format(STATISTICS_TABLE_ROW, 'a', "difference",
+                holder.getFileNumDiff(),
+                holder.getTotalNumDiff(),
+                holder.getInfoNumDiff(),
+                holder.getWarningNumDiff(),
+                holder.getErrorNumDiff()));
+        writer.write("</table>\n</div>\n");
+        writer.write("</div>\n");
+    }
+
+    /**
+     * Writes content section to the file.
+     *
+     * @param content
+     *        container for parsed data.
+     * @param writer
+     *        BufferedWriter used to write HTML to file on disk.
+     * @param generator
+     *        XrefGenerator instance.
+     * @throws IOException
+     *         thrown on writer failure.
+     */
+    private static void writeContent(ParsedContent content,
+            BufferedWriter writer, XrefGenerator generator)
+                    throws IOException {
+        writer.write(CONTENT_TITLE);
+        Iterator<Map.Entry<String, List<CheckstyleRecord>>> it =
+                content.getRecords()
+                .entrySet()
+                .iterator();
+        while (it.hasNext()) {
+            final Map.Entry<String, List<CheckstyleRecord>> entry = it.next();
+            final String filename = entry.getKey();
+            final String xreference = generator.generateXref(filename);
+            writer.write(String.format(TABLE_HEADER, filename, filename));
+            final List<CheckstyleRecord> records = entry.getValue();
+            for (CheckstyleRecord record : records) {
+                writeTableRow(record, writer, xreference);
+            }
+            writer.write("</table>\n</div>\n");
+        }
+        writer.write("</div>\n");
+    }
+
+    /**
+     * Writes single CheckstyleRecord as a row of content section table
+     * to the file.
+     *
+     * @param record
+     *        CheckstyleRecord instance
+     * @param writer
+     *        BufferedWriter used to write HTML to file on disk.
+     * @param xreference
+     *        link to the XDOC file.
+     * @throws IOException
+     *         thrown on writer failure.
+     */
+    private static void writeTableRow(CheckstyleRecord record,
+            BufferedWriter writer, String xreference)
+                    throws IOException {
+        final char styleChar = record.belongsToFirstReport()
+                ? FIRST_REPORT_CSS_STYLE : SECOND_REPORT_CSS_STYLE;
+        final String reportName = record.belongsToFirstReport()
+                ? FIRST_REPORT_NAME : SECOND_REPORT_NAME;
+        final String anchor = generateAnchor();
+        final char severityChar;
+        switch (record.getSeverity()) {
+        case INFORMATIONAL:
+            severityChar = SEVERITY_INFO_CHAR;
+            break;
+        case WARNING:
+            severityChar = SEVERITY_WARNING_CHAR;
+            break;
+        default:
+            severityChar = SEVERITY_ERROR_CHAR;
+        }
+        final int lineNum = record.getLine();
+        final int columnNum = record.getColumn();
+        final String fullCheckName = record.getSource();
+        final String shortCheckName = fullCheckName
+                .substring(fullCheckName
+                        .lastIndexOf(CHECK_NAME_DELIMITER) + 1);
+        writer.write(String.format(TABLE_ROW, styleChar, anchor, anchor,
+                anchor, severityChar, shortCheckName, record.getMessage(),
+                xreference, lineNum, lineNum, columnNum, reportName));
+
+    }
+
+    /**
+     * Generates unique string value to be used as anchor link names.
+     *
+     * @return unique string.
+     */
+    private static String generateAnchor() {
+        anchorCounter++;
+        return String.format("A%d", anchorCounter);
+    }
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
@@ -1,0 +1,114 @@
+package com.github.checkstyle.site;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import org.apache.maven.jxr.JavaCodeTransform;
+import org.apache.maven.jxr.pacman.FileManager;
+import org.apache.maven.jxr.pacman.PackageManager;
+
+/**
+ * Constructor for cross reference HTMLs
+ * from java source files. Wrapper around
+ * maven-jxr functional.
+ *
+ * @author atta_troll
+ *
+ */
+public class XrefGenerator {
+
+    /**
+     * Encoding used for input and output files.
+     */
+    public static final String ENCODING = "ISO-8859-1";
+
+    /**
+     * maven-jxr package manager.
+     */
+    private static PackageManager pacman;
+
+    /**
+     * maven-jxr XREF file generator.
+     */
+    private static JavaCodeTransform codeTransform;
+    static {
+        pacman = new PackageManager(new JxrDummyLog(),
+                new FileManager());
+        codeTransform = new JavaCodeTransform(pacman);
+    }
+
+    /**
+     * Path to the sources, used to shorten paths.
+     */
+    private Path relativizationPath;
+
+    /**
+     * Destination folder for XREF files.
+     */
+    private Path destinationPath;
+
+    /**
+     * Path to the site.
+     */
+    private Path sitePath;
+
+    /**
+     * The only constructor.
+     *
+     * @param relativizationPath1
+     *        path to the sources, used to shorten paths.
+     * @param destinationPath1
+     *        destination folder for XREF files.
+     * @param sitePath1
+     *        path to the site.
+     */
+    public XrefGenerator(Path relativizationPath1,
+            Path destinationPath1, Path sitePath1) {
+        this.relativizationPath = relativizationPath1;
+        this.destinationPath = destinationPath1;
+        this.sitePath = sitePath1;
+    }
+
+    /**
+     * Generates XREF file from source file.
+     *
+     * @param name
+     *        path to the source file.
+     * @return relative path to the resulting file.
+     * @throws IOException
+     *         on maven-jxr internal failure.
+     */
+    public final String generateXref(String name) throws IOException {
+      File sourceFile = new File(name);
+      Path dest = getDestinationPath(name);
+      codeTransform.transform(sourceFile.getAbsolutePath(),
+              dest.toString(), Locale.ENGLISH,
+              ENCODING, ENCODING, "", "", "");
+      return sitePath.relativize(dest).toString();
+    }
+
+    /**
+     * Generates full path to the destination of XREF file.
+     *
+     * @param name
+     *        java source file path.
+     * @return full path to the destination of XREF file.
+     */
+    private Path getDestinationPath(String name) {
+        final String newName = name + ".html";
+        final Path sourcePath = Paths.get(newName);
+        final Path destPath;
+        if (relativizationPath == null) {
+            destPath = destinationPath
+            .resolve(sourcePath.subpath(0, sourcePath.getNameCount()));
+        }
+        else {
+            destPath = destinationPath
+            .resolve(relativizationPath.relativize(sourcePath));
+        }
+        return destPath;
+    }
+}

--- a/patch-diff-report-tool/src/main/resources/maven-base.css
+++ b/patch-diff-report-tool/src/main/resources/maven-base.css
@@ -1,0 +1,155 @@
+body {
+  margin: 0px;
+  padding: 0px;
+}
+img {
+  border:none;
+}
+table {
+  padding:0px;
+  width: 100%;
+  margin-left: -2px;
+  margin-right: -2px;
+}
+acronym {
+  cursor: help;
+  border-bottom: 1px dotted #feb;
+}
+table.bodyTable th, table.bodyTable td {
+  padding: 2px 4px 2px 4px;
+  vertical-align: top;
+}
+div.clear{
+  clear:both;
+  visibility: hidden;
+}
+div.clear hr{
+  display: none;
+}
+#bannerLeft, #bannerRight {
+  font-size: xx-large;
+  font-weight: bold;
+}
+#bannerLeft img, #bannerRight img {
+  margin: 0px;
+}
+.xleft, #bannerLeft img {
+  float:left;
+}
+.xright, #bannerRight {
+  float:right;
+}
+#banner {
+  padding: 0px;
+}
+#banner img {
+  border: none;
+}
+#breadcrumbs {
+  padding: 3px 10px 3px 10px;
+}
+#leftColumn {
+ width: 170px;
+ float:left;
+ overflow: auto;
+}
+#bodyColumn {
+  margin-right: 1.5em;
+  margin-left: 197px;
+}
+#legend {
+  padding: 8px 0 8px 0;
+}
+#navcolumn {
+  padding: 8px 4px 0 8px;
+}
+#navcolumn h5 {
+  margin: 0;
+  padding: 0;
+  font-size: small;
+}
+#navcolumn ul {
+  margin: 0;
+  padding: 0;
+  font-size: small;
+}
+#navcolumn li {
+  list-style-type: none;
+  background-image: none;
+  background-repeat: no-repeat;
+  background-position: 0 0.4em;
+  padding-left: 16px;
+  list-style-position: outside;
+  line-height: 1.2em;
+  font-size: smaller;
+}
+#navcolumn li.expanded {
+  background-image: url(../images/expanded.gif);
+}
+#navcolumn li.collapsed {
+  background-image: url(../images/collapsed.gif);
+}
+#navcolumn li.none {
+  text-indent: -1em;
+  margin-left: 1em;
+}
+#poweredBy {
+  text-align: center;
+}
+#navcolumn img {
+  margin-top: 10px;
+  margin-bottom: 3px;
+}
+#poweredBy img {
+  display:block;
+  margin: 20px 0 20px 17px;
+}
+#search img {
+    margin: 0px;
+    display: block;
+}
+#search #q, #search #btnG {
+    border: 1px solid #999;
+    margin-bottom:10px;
+}
+#search form {
+    margin: 0px;
+}
+#lastPublished {
+  font-size: x-small;
+}
+.navSection {
+  margin-bottom: 2px;
+  padding: 8px;
+}
+.navSectionHead {
+  font-weight: bold;
+  font-size: x-small;
+}
+.section {
+  padding: 4px;
+}
+#footer {
+  padding: 3px 10px 3px 10px;
+  font-size: x-small;
+}
+#breadcrumbs {
+  font-size: x-small;
+  margin: 0pt;
+}
+.source {
+  padding: 12px;
+  margin: 1em 7px 1em 7px;
+}
+.source pre {
+  margin: 0px;
+  padding: 0px;
+}
+#navcolumn img.imageLink, .imageLink {
+  padding-left: 0px;
+  padding-bottom: 0px;
+  padding-top: 0px;
+  padding-right: 2px;
+  border: 0px;
+  margin: 0px;
+}

--- a/patch-diff-report-tool/src/main/resources/maven-theme.css
+++ b/patch-diff-report-tool/src/main/resources/maven-theme.css
@@ -1,0 +1,137 @@
+body {
+  padding: 0px 0px 10px 0px;
+}
+body, td, select, input, li{
+  font-family: Verdana, Helvetica, Arial, sans-serif;
+  font-size: 13px;
+}
+code{
+  font-family: Courier, monospace;
+  font-size: 13px;
+}
+a {
+  text-decoration: none;
+}
+a:link {
+  color:#36a;
+}
+a:visited  {
+  color:#47a;
+}
+a:active, a:hover {
+  color:#69c;
+}
+#legend li.externalLink {
+  background: url(../images/external.png) left top no-repeat;
+  padding-left: 18px;
+}
+a.externalLink, a.externalLink:link, a.externalLink:visited, a.externalLink:active, a.externalLink:hover {
+  background: url(../images/external.png) right center no-repeat;
+  padding-right: 18px;
+}
+#legend li.newWindow {
+  background: url(../images/newwindow.png) left top no-repeat;
+  padding-left: 18px;
+}
+a.newWindow, a.newWindow:link, a.newWindow:visited, a.newWindow:active, a.newWindow:hover {
+  background: url(../images/newwindow.png) right center no-repeat;
+  padding-right: 18px;
+}
+h2 {
+  padding: 4px 4px 4px 6px;
+  border: 1px solid #999;
+  color: #900;
+  background-color: #ddd;
+  font-weight:900;
+  font-size: x-large;
+}
+h3 {
+  padding: 4px 4px 4px 6px;
+  border: 1px solid #aaa;
+  color: #900;
+  background-color: #eee;
+  font-weight: normal;
+  font-size: large;
+}
+h4 {
+  font-weight: normal;
+  font-size: large;
+}
+h5 {
+  padding: 4px 4px 4px 6px;
+  color: #900;
+  font-size: normal;
+}
+p {
+  line-height: 1.3em;
+  font-size: small;
+}
+#breadcrumbs {
+  border-top: 1px solid #aaa;
+  border-bottom: 1px solid #aaa;
+  background-color: #ccc;
+}
+#leftColumn {
+  margin: 10px 0 0 5px;
+  border: 1px solid #999;
+  background-color: #eee;
+}
+#navcolumn h5 {
+  font-size: smaller;
+  border-bottom: 1px solid #aaaaaa;
+  padding-top: 2px;
+  color: #000;
+}
+
+table.bodyTable th {
+  color: white;
+  background-color: #bbb;
+  text-align: left;
+  font-weight: bold;
+}
+
+table.bodyTable th, table.bodyTable td {
+  font-size: 1em;
+}
+
+table.bodyTable tr.a {
+  background-color: #7f7;
+}
+
+table.bodyTable tr.b {
+  background-color: #fca;
+}
+
+.source {
+  border: 1px solid #999;
+}
+dl {
+  padding: 4px 4px 4px 6px;
+  border: 1px solid #aaa;
+  background-color: #ffc;
+}
+dt {
+  color: #900;
+}
+#organizationLogo img, #projectLogo img, #projectLogo span{
+  margin: 8px;
+}
+#banner {
+  border-bottom: 1px solid #fff;
+}
+.errormark, .warningmark, .donemark, .infomark {
+  background: url(../images/icon_error_sml.gif) no-repeat;
+}
+
+.warningmark {
+  background-image: url(../images/icon_warning_sml.gif);
+}
+
+.donemark {
+  background-image: url(../images/icon_success_sml.gif);
+}
+
+.infomark {
+  background-image: url(../images/icon_info_sml.gif);
+}
+


### PR DESCRIPTION
This is initial implementation of patch-diff-report-tool, it creates difference report from 2 different checkstyle-result.xml files. It satisfies  <a title="Checkstyle XML Diff reports tool " href="https://github.com/checkstyle/contribution/issues/50" class="issue-link js-issue-link" data-id="124509767" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">checkstyle/contribution#50</a>.
Here is <a href="http://attatrol.github.io/diff_tool_example/site.html">an example of the report.</a>

The issues:
1. it still uses modified maven style;
2. generation of xdocs and xrefs is a huge issue, i'll spend next couple of days solving it, happy to get any advice here, i want to know which tool did this for checkstyle site previously.
3. assuming xdoc generation won't be memory consuming, please test it on the same sets of data which caused OOME for ahsm.