### PR TITLE
[patch-diff-report-tool] Correct path for windows

### DIFF
--- a/patch-diff-report-tool/README.md
+++ b/patch-diff-report-tool/README.md
@@ -18,7 +18,7 @@ You have 2 different checkstyle repos, original (base) and forked (patch), for e
 `--baseReport` - path to the base checkstyle-result.xml (required argument);<br/>
 `--patchReport` - path to the patch checkstyle-result.xml (required argument);<br/>
 `--refFiles` - path to the source file under check (optional argument);<br/>
-`--output` - path to the resulting site (optional argument, default: ~/XMLDiffGen_report_yyyy.mm.dd_hh:mm:ss)<br/>
+`--output` - path to the resulting site (optional argument, default: ~/XMLDiffGen_report_yyyy.mm.dd_hh_mm_ss)<br/>
 `--baseConfig` - path to the base checkstyle configuration xml file (optional argument);<br/>
 `--patchConfig` - path to the patch checkstyle configuration xml file (optional argument);<br/>
 `-h` - shows help message.<br/>

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
@@ -60,7 +60,7 @@ public final class Main {
             + "structure for cross reference files won't be relativized, "
             + "full paths will be used);\n"
             + "\t--resultPath - path to the resulting site (optional, if absent then default "
-            + "path will be used: ~/XMLDiffGen_report_yyyy.mm.dd_hh:mm:ss), remember, "
+            + "path will be used: ~/XMLDiffGen_report_yyyy.mm.dd_hh_mm_ss), remember, "
             + "if this folder exists its content will be purged;\n"
             + "\t-h - simply shows help message.";
 
@@ -204,7 +204,7 @@ public final class Main {
         final Path xmlPatchPath = getPath(OPTION_PATCH_REPORT_PATH, commandLine, null);
         final Path sourcePath = getPath(OPTION_SOURCE_PATH, commandLine, null);
         final Path defaultResultPath = Paths.get(System.getProperty("user.home"))
-                .resolve("XMLDiffGen_report_" + new SimpleDateFormat("yyyy.MM.dd_HH:mm:ss")
+                .resolve("XMLDiffGen_report_" + new SimpleDateFormat("yyyy.MM.dd_HH_mm_ss")
                         .format(Calendar.getInstance().getTime()));
         final Path resultPath =
                 getPath(OPTION_RESULT_FOLDER_PATH, commandLine, defaultResultPath);


### PR DESCRIPTION
there's a bug at `com.github.checkstyle.Main` L207:
```
.resolve("XMLDiffGen_report_" + new SimpleDateFormat("yyyy.MM.dd_HH:mm:ss")
```
It is illegal to have ':' in windows path.

change it to '_'