### PR TITLE
patch-diff-report-tool: fixed possible overflow issue in resource copy

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/FilesystemUtils.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/FilesystemUtils.java
@@ -165,7 +165,7 @@ public final class FilesystemUtils {
             int readBytes;
             final byte[] buffer = new byte[BUFFER_SIZE];
             while ((readBytes = in.read(buffer)) > 0) {
-                out.write(buffer, 0, BUFFER_SIZE);
+                out.write(buffer, 0, readBytes);
             }
         }
     }


### PR DESCRIPTION
Eclipse reported this as a warning when I imported the project. `readBytes` isn't used in the method.
I didn't confirm this is an actual issue but you should only write what you read. If `readBytes` is less than `BUFFER_SIZE`, `out` will be writing garbage data.