### PR TITLE
checkstyle-tester: added apache apex project

### DIFF
--- a/checkstyle-tester/launch.sh
+++ b/checkstyle-tester/launch.sh
@@ -78,7 +78,11 @@ mvn --batch-mode clean
 #export MAVEN_OPTS="-Xmx3000m"
 
 echo "Running Checkstyle on $SOURCES_DIR ... with excludes $EXCLUDES_ACCUM"
-mvn -e --batch-mode site -Dcheckstyle.excludes=$EXCLUDES_ACCUM "$@"
+if [ "$EXCLUDES" == "" ]; then
+	mvn -e --batch-mode site -Dcheckstyle.excludes=$EXCLUDES_ACCUM "$@"
+else
+	mvn -e --batch-mode site -Dcheckstyle.excludes=$EXCLUDES_ACCUM -Djxr-plugin.exclude=$EXCLUDES "$@"
+fi
 if [ "$?" != "0" ]
 then
 	echo "Checkstyle is failed on $SOURCES_DIR"

--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -15,6 +15,7 @@
 		<checkstyle.version>6.18-SNAPSHOT</checkstyle.version>
 		<sevntu-checkstyle.version>1.20.0</sevntu-checkstyle.version>
 		<jxr-plugin.version>2.5</jxr-plugin.version>
+		<jxr-plugin.exclude>EXCLUDEDOESNTEXIST</jxr-plugin.exclude>
 		<checkstyle.config.location>https://raw.githubusercontent.com/checkstyle/checkstyle/master/src/main/resources/google_checks.xml</checkstyle.config.location>
 	</properties>
 
@@ -63,6 +64,11 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jxr-plugin</artifactId>
             <version>${jxr-plugin.version}</version>
+            <configuration>
+              <excludes>
+                <exclude>${jxr-plugin.exclude}</exclude>
+              </excludes>
+            </configuration>
           </plugin>
 
 		</plugins>

--- a/checkstyle-tester/projects-for-travis.properties
+++ b/checkstyle-tester/projects-for-travis.properties
@@ -23,7 +23,7 @@ guava|git|http://github.com/google/guava|v18.0
 #MaterialDesignLibrary|git|http://github.com/navasmdc/MaterialDesignLibrary|1.3
 #RxJava|git|http://github.com/ReactiveX/RxJava|v1.0.9
 #Hbase|git|http://github.com/apache/hbase|1.1.0.1
-
+#apacheapex|github|apache/incubator-apex-core|master|**/src/main/resources/**
 
 # Those projects are quite old and have lot of legacy code
 #apache-ant|git|http://github.com/apache/ant|ANT_194|**apache-ant/src/tests/**/*,apache-ant/src/etc/testcases/

--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -23,6 +23,7 @@ guava|github|google/guava|v18.0
 #MaterialDesignLibrary|github|navasmdc/MaterialDesignLibrary|1.3
 #Hbase|github|apache/hbase|1.1.0.1
 #Orekit|github|CS-SI/Orekit|bc527a1
+#apacheapex|github|apache/incubator-apex-core|master|**/src/main/resources/**
 
 # Those projects are quite old and have lot of legacy code
 #apache-ant|github|apache/ant|ANT_194|**apache-ant/src/tests/**/*,apache-ant/src/etc/testcases/


### PR DESCRIPTION
Added apache apex to the list of projects to run regression on.

Added optional parameter to pom so could exclude files that can't be parsed by JXR, otherwise it throws an exception and stops the regression.
http://stackoverflow.com/questions/31207529/is-it-possible-to-pass-optional-parameter-testincludes-or-testexcludes-to-maven

Had to modify launch as this parameter can't be nothing, otherwise it will throw an exception too.
