### PR TITLE
checkstyle-web-tester: added first release

### DIFF
--- a/checkstyle-web-tester/README.md
+++ b/checkstyle-web-tester/README.md
@@ -1,0 +1,34 @@
+About
+=====
+
+CheckStyle Web Tester is a web utility for regression and testing simple scenarios using checkstyle utility.
+You can share code, configurations, and output from any version of checkstyle, including releases and nightlies.
+There is even an option to create a report for submitting issues and problems with checkstyle.
+
+Requirements
+============
+
+* PHP runtime environment
+* `shell_exec` must be enabled for PHP to call the checkstyle utility
+* Linux for running automated terminal shell scripts
+* `git` and `maven` are required for the nightly script
+
+Configuration
+=============
+
+You only need to modify `checkstyle.php` for where you will store the user supplied code and create the `jars` and `files` folder in that location.
+
+Scripts
+=======
+
+All scripts should be placed inside the `jars` folder.
+
+download-release.sh
+-------------------
+
+Only requires the full version of the release as the first parameter. Will download the checkstyle all jar from `sourceforge.net`.
+
+download-nightly.sh
+-------------------
+
+No parameters required. Downloads checkstyle's repository and packages the jar from the master branch.

--- a/checkstyle-web-tester/checkstyle.php
+++ b/checkstyle-web-tester/checkstyle.php
@@ -1,0 +1,247 @@
+<?php
+// Configuration
+
+$basedir = "/tmp/checkstyle";
+$jarDir = $basedir . "/jars/";
+$saveDir = $basedir . "/files/";
+
+?>
+
+<html>
+<head>
+	<title>CheckStyle Web Tester</title>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
+	<script src="jquery-linedtextarea.js"></script>
+	<script src="checkstyle_report.js"></script>
+	<link href="jquery-linedtextarea.css" type="text/css" rel="stylesheet" />
+</head>
+<center><h1>CheckStyle Web Tester</h1></center>
+
+<?php
+
+ini_set('display_errors', 1);
+ini_set('log_errors', 1);
+ini_set('error_log', dirname(__FILE__) . '/error_log.txt');
+error_reporting(E_ALL);
+
+date_default_timezone_set('US/Eastern');
+
+$action = getParameter("action");
+$checkstyle = getParameter("checkstyle");
+$config = getParameter("config");
+$code = getParameter("code");
+
+if (!isset($checkstyle)) {
+	$checkstyle = "checkstyle-6.17-all.jar";
+}
+
+if (!isset($action)) {
+	if (!isset($config)) {
+		$config = "<?xml version=\"1.0\"?>\n<!DOCTYPE module PUBLIC\n          \"-//Puppy Crawl//DTD Check Configuration 1.3//EN\"\n          \"http://www.puppycrawl.com/dtds/configuration_1_3.dtd\">\n\n<module name=\"Checker\">\n    <property name=\"charset\" value=\"UTF-8\"/>\n\n    <module name=\"TreeWalker\">\n    </module>\n</module>";
+	}
+	if (!isset($code)) {
+		$code = "public class TestClass {\n    void method() {\n    }\n}";
+	}
+
+	showForm($checkstyle, $config, $code);
+} else if ($action == "save") {
+	if (!isset($config) || !isset($code)) {
+		echo "Some fields are missing for a save.";
+	// Size Limitations
+	} else if (strlen($config) > 5120) { // 5kb
+		echo "Size Security: Configuration is larger than 5kb";
+	} else if (strlen($code) > 5120) { // 5kb
+		echo "Size Security: Code is larger than 5kb";
+	// Vulnerabilities
+	// http://stackoverflow.com/questions/1906927/xml-vulnerabilities/1907500#1907500
+	} else if (stripos($config, "<!ENTITY") !== false) {
+		echo "XML Security: '<!ENTITY' is not allowed";
+	} else if (stripos($config, "<!ELEMENT") !== false) {
+		echo "XML Security: '<!ELEMENT' is not allowed";
+	//
+	} else {
+		$config = fix_post_text($config);
+		$configMD = hash("md5", $config);
+		$configFile = $saveDir . $configMD;
+		$code = fix_post_text($code);
+		$codeMD = hash("md5", $code);
+		$codeFile = $saveDir . $codeMD . ".java";
+
+		if (!file_exists($configFile)) {
+			$fhandle = @fopen($configFile, "w");
+			if ($fhandle != FALSE) {
+				if (fwrite($fhandle, $config) == FALSE) {
+					die("Failed to save configuration to " . $configMD);
+				} else {
+					echo "Configuration file saved.<br />";
+				}
+			} else {
+				die("Failed to save configuration to " . $configMD);
+			}
+		}
+
+		if (!file_exists($codeFile)) {
+			$fhandle = @fopen($codeFile, "w");
+			if ($fhandle != FALSE) {
+				if (fwrite($fhandle, $code) == FALSE) {
+					die("Failed to save code to " . $codeMD);
+				} else {
+					echo "Code file saved.<br />";
+				}
+			} else {
+				die("Failed to save code to " . $codeMD);
+			}
+		}
+
+		$action = "view";
+		$config = $configMD;
+		$code = $codeMD;
+
+		echo "<br />";
+	}
+}
+
+if ($action == "view") {
+	if (preg_match("/[^a-z0-9.-]/i", $checkstyle)) {
+		die("Improper checkstyle '" . $checkstyle . "' was supplied.");
+	}
+	if (preg_match("/[^a-fA-F0-9]/i", $config)) {
+		die("Improper configuration '" . $config . "' was supplied.");
+	}
+	if (preg_match("/[^a-fA-F0-9]/i", $code)) {
+		die("Improper code '" . $code . "' was supplied.");
+	}
+
+	$checkstyleFile = $jarDir . $checkstyle;
+	$configFile = $saveDir . $config;
+	$codeFile = $saveDir . $code . ".java";
+
+	if (!file_exists($checkstyleFile)) {
+		die("Can't find checkstyle file '" . $checkstyle . "'");
+	}
+	if (!file_exists($configFile)) {
+		die("Can't find configuration file '" . $config . "'");
+	}
+	if (!file_exists($codeFile)) {
+		die("Can't find code file '" . $code . "'");
+	}
+
+	$configContents = @file_get_contents($configFile);
+	$codeContents = @file_get_contents($codeFile);
+
+	echo "Results:<br />";
+	echo "<div style='border: 1px solid black;' id='cs_results'>";
+
+	$output = shell_exec("java -jar " . $checkstyleFile . " -c " . $configFile . " " . $codeFile . " 2>&1");
+
+	// pretty display
+	echo str_replace("\n", "<br />", str_replace("  ", "&nbsp; ", str_replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;", str_replace($saveDir, "", str_replace($code, "TestClass", str_replace($config, "TestConfig.xml", _sanitizeText($output)))))));
+
+	echo "</div>";
+
+	$link = $_SERVER['SCRIPT_NAME'] . "?action=view&config=" . $config . "&code=" . $code . "&checkstyle=" . $checkstyle;
+	$lpos = strrpos($link, "/");
+	if ($lpos >= 0) {
+		$link = substr($link, $lpos + 1);
+	}
+
+	echo "<br />Share Link: <a href='" . $link . "'>" . $link . "</a>";
+	//echo "<br />GitHub Link Text: [CheckStyle Example in Web Tester](" . $link . ")";
+	echo "<br /><br /><input type=\"submit\" value=\"Create GitHub CLI Report\" id=\"reportCreate\" onclick=\"report();\">";
+	echo "<br /><br /><hr /><br />";
+
+	showForm($checkstyle, $configContents, $codeContents);
+}
+
+function showForm($checkstyle, $config, $code) {
+	global $jarDir;
+
+	echo "<form action=\"" . $_SERVER['SCRIPT_NAME'] . "\" method=\"POST\">";
+	echo "<input type='hidden' name='action' value='save'>";
+	echo "Checkstyle:<br />";
+	echo "<select name='checkstyle' id='cs_jar' onchange='report_on_change();'>";
+
+	foreach (getCheckStyles() as $key => $value) {
+		echo '<option value="' . $value . '" ' . ($value == $checkstyle ? "selected='selected'" : "") . '>' . $value . '</option>';
+	}
+
+	echo "</select>";
+	echo "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"submit\" value=\"Submit\"><br /><br />";
+	echo "Configuration:<br />";
+	echo "<textarea name='config' rows='12' wrap='off' style='width: 100%' id='cs_config' onchange='report_on_change();' onkeyup='report_on_change();'>";
+	echo _sanitizeText($config);
+	echo "</textarea><br /><br />";
+	echo "Java Code:<br />";
+	echo "<textarea name='code' rows='12' wrap='off' style='width: 100%' id='cs_code' onchange='report_on_change();' onkeyup='report_on_change();'>";
+	echo _sanitizeText($code);
+	echo "</textarea><br /><br />";
+	echo "<input type=\"submit\" value=\"Submit\">";
+	echo "</form>";
+	echo "<script>$(function() { $(\"#cs_config\").linedtextarea(); $(\"#cs_code\").linedtextarea(); });</script>";
+}
+
+function getCheckStyles() {
+	global $jarDir;
+	$result = array();
+
+	$dhandle = @opendir($jarDir);
+	if ($dhandle != FALSE) {
+		while (($name = @readdir($dhandle)) !== false) {
+			if (($name == ".") || ($name == "..")) continue;
+
+			if ((@filetype($jarDir . $name) != "dir") && (str_endswith($name, ".jar")))
+				$result[] = $name;
+		}
+
+		closedir($dhandle);
+	}
+
+	sort($result);
+	return $result;
+}
+
+function str_endswith($string, $test) {
+	$strlen = strlen($string);
+	$testlen = strlen($test);
+	if ($testlen > $strlen) return false;
+	return substr_compare($string, $test, $strlen - $testlen, $testlen) === 0;
+}
+
+function getParameter($param) {
+	return (isset($_POST[$param]) ? $_POST[$param] : (isset($_GET[$param]) ? $_GET[$param] : null));
+}
+
+function fix_post_text($in, $r_sq = "'", $r_dq = "\\\"", $r_ds = "\\\\") {
+	$in = str_replace(
+		array("\r",	$r_sq),
+		array("",	"'"),
+		$in);
+
+	if (!ini_get('safe_mode')) {
+		$in = str_replace(
+			array($r_dq,	$r_ds),
+			array("\"",	"\\"),
+			$in);
+	}
+
+	return $in;
+}
+
+function _sanitizeText($in) {
+	$in = str_replace(
+		array(chr(38) . "",	"<",		">",		"'"),
+		array(chr(38) . "amp;",	chr(38) . "lt;",chr(38) . "gt;","'"),
+		$in);
+
+	if (ini_get('safe_mode')) {
+		$in = str_replace(
+			array("\\\"",	"\\\\"),
+			array("\"",	"\\"),
+			$in);
+	}
+
+	return $in;
+}
+
+?>
+</body></html>

--- a/checkstyle-web-tester/checkstyle_report.js
+++ b/checkstyle-web-tester/checkstyle_report.js
@@ -1,0 +1,38 @@
+function report() {
+	var report = "";
+
+	report += "````<br />";
+	report += "$ cat TestClass.java<br />";
+	report += sanitize_text(document.getElementById("cs_code").innerHTML);
+	report += "<br /><br />";
+
+
+	report += "$ cat TestConfig.xml<br />";
+	report += sanitize_text(document.getElementById("cs_config").innerHTML);
+	report += "<br /><br />";
+
+
+	var select = document.getElementById("cs_jar");
+	report += "$ java -jar " + sanitize_text(select.options[select.selectedIndex].text) + " -c TestConfig.xml TestClass.java<br />";
+	report += document.getElementById("cs_results").innerHTML;
+	report += "````<br />";
+
+	var win = window.open("", "_blank", "toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=500,height=400");
+	win.document.title = "CheckStyle Report";
+	win.document.write(report);
+}
+
+function sanitize_text(s) {
+	return replace_all(replace_all(s, " ", "&nbsp;"), "\n", "<br />");
+}
+
+function replace_all(s, f, r) {
+	return s.replace(new RegExp(f, 'g'), r);
+}
+
+function report_on_change() {
+	var element = document.getElementById("reportCreate");
+
+	if (element != null)
+		element.style.display = 'none';
+}

--- a/checkstyle-web-tester/download-nightly.sh
+++ b/checkstyle-web-tester/download-nightly.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+CS_DIR="/tmp/checkstyle-nightly"
+
+#############################################
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DATE=`date +%Y-%m-%d`
+FILE="checkstyle-nightly-$DATE-all.jar"
+
+#############################################
+
+if [ ! -d $CS_DIR ]; then
+	mkdir $CS_DIR
+fi
+
+cd $CS_DIR
+
+if [ ! -d "$CS_DIR/checkstyle/.git" ]; then
+	git clone https://github.com/checkstyle/checkstyle.git
+
+	cd checkstyle
+else
+	cd checkstyle
+
+	git checkout master
+	git fetch origin
+
+	if [ $(git rev-parse HEAD) == $(git rev-parse @{u}) ]; then
+		echo "No changes in checkstyle since last run."
+		exit 1
+	fi
+
+	git reset --hard HEAD
+	git pull
+fi
+
+mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Dcobertura.skip=true
+
+sudo -u www-data cp target/checkstyle-*-SNAPSHOT-all.jar $DIR/$FILE

--- a/checkstyle-web-tester/download-release.sh
+++ b/checkstyle-web-tester/download-release.sh
@@ -1,0 +1,1 @@
+sudo -u www-data wget http://downloads.sourceforge.net/project/checkstyle/checkstyle/$1/checkstyle-$1-all.jar

--- a/checkstyle-web-tester/jquery-linedtextarea.css
+++ b/checkstyle-web-tester/jquery-linedtextarea.css
@@ -1,0 +1,68 @@
+/**
+ * jQuery Lined Textarea Plugin
+ *   http://alan.blog-city.com/jquerylinedtextarea.htm
+ *
+ * Copyright (c) 2010 Alan Williamson
+ *
+ * Released under the MIT License:
+ * http://www.opensource.org/licenses/mit-license.php
+ * 
+ * Usage:
+ *   Displays a line number count column to the left of the textarea
+ *   
+ *   Class up your textarea with a given class, or target it directly
+ *   with JQuery Selectors
+ *   
+ *   $(".lined").linedtextarea({
+ *   	selectedLine: 10,
+ *    selectedClass: 'lineselect'
+ *   });
+ *
+ */
+
+.linedwrap {
+	border: 1px solid #c0c0c0;
+	padding: 3px;
+}
+
+.linedtextarea {
+	padding: 0px;
+	margin: 0px;
+}
+
+.linedtextarea textarea, .linedwrap .codelines .lineno {
+	font-size: 10pt;
+	font-family: monospace;
+	line-height: normal !important;
+}
+
+.linedtextarea textarea {
+	padding-right:0.3em;
+	padding-top:0.3em;
+	border: 0;
+}
+
+.linedwrap .lines {
+	margin-top: 0px;
+	width: 50px;
+	float: left;
+	overflow: hidden;
+	border-right: 1px solid #c0c0c0;
+	margin-right: 10px;
+}
+
+.linedwrap .codelines {
+	padding-top: 5px;
+}
+
+.linedwrap .codelines .lineno {
+	color:#AAAAAA;
+	padding-right: 0.5em;
+	padding-top: 0.0em;
+	text-align: right;
+	white-space: nowrap;
+}
+
+.linedwrap .codelines .lineselect {
+	color: red;
+}

--- a/checkstyle-web-tester/jquery-linedtextarea.js
+++ b/checkstyle-web-tester/jquery-linedtextarea.js
@@ -1,0 +1,126 @@
+/**
+ * jQuery Lined Textarea Plugin 
+ *   http://alan.blog-city.com/jquerylinedtextarea.htm
+ *
+ * Copyright (c) 2010 Alan Williamson
+ * 
+ * Version: 
+ *    $Id: jquery-linedtextarea.js 464 2010-01-08 10:36:33Z alan $
+ *
+ * Released under the MIT License:
+ *    http://www.opensource.org/licenses/mit-license.php
+ * 
+ * Usage:
+ *   Displays a line number count column to the left of the textarea
+ *   
+ *   Class up your textarea with a given class, or target it directly
+ *   with JQuery Selectors
+ *   
+ *   $(".lined").linedtextarea({
+ *   	selectedLine: 10,
+ *    selectedClass: 'lineselect'
+ *   });
+ *
+ * History:
+ *   - 2010.01.08: Fixed a Google Chrome layout problem
+ *   - 2010.01.07: Refactored code for speed/readability; Fixed horizontal sizing
+ *   - 2010.01.06: Initial Release
+ *
+ */
+(function($) {
+
+	$.fn.linedtextarea = function(options) {
+		
+		// Get the Options
+		var opts = $.extend({}, $.fn.linedtextarea.defaults, options);
+		
+		
+		/*
+		 * Helper function to make sure the line numbers are always
+		 * kept up to the current system
+		 */
+		var fillOutLines = function(codeLines, h, lineNo){
+			while ( (codeLines.height() - h ) <= 0 ){
+				if ( lineNo == opts.selectedLine )
+					codeLines.append("<div class='lineno lineselect'>" + lineNo + "</div>");
+				else
+					codeLines.append("<div class='lineno'>" + lineNo + "</div>");
+				
+				lineNo++;
+			}
+			return lineNo;
+		};
+		
+		
+		/*
+		 * Iterate through each of the elements are to be applied to
+		 */
+		return this.each(function() {
+			var lineNo = 1;
+			var textarea = $(this);
+			
+			/* Turn off the wrapping of as we don't want to screw up the line numbers */
+			textarea.attr("wrap", "off");
+			textarea.css({resize:'none'});
+			var originalTextAreaWidth	= textarea.outerWidth();
+
+			/* Wrap the text area in the elements we need */
+			textarea.wrap("<div class='linedtextarea'></div>");
+			var linedTextAreaDiv	= textarea.parent().wrap("<div class='linedwrap' style='width:" + originalTextAreaWidth + "px'></div>");
+			var linedWrapDiv 			= linedTextAreaDiv.parent();
+			
+			linedWrapDiv.prepend("<div class='lines' style='width:50px'></div>");
+			
+			var linesDiv	= linedWrapDiv.find(".lines");
+			linesDiv.height( textarea.height() + 6 );
+			
+			
+			/* Draw the number bar; filling it out where necessary */
+			linesDiv.append( "<div class='codelines'></div>" );
+			var codeLinesDiv	= linesDiv.find(".codelines");
+			lineNo = fillOutLines( codeLinesDiv, linesDiv.height(), 1 );
+
+			/* Move the textarea to the selected line */ 
+			if ( opts.selectedLine != -1 && !isNaN(opts.selectedLine) ){
+				var fontSize = parseInt( textarea.height() / (lineNo-2) );
+				var position = parseInt( fontSize * opts.selectedLine ) - (textarea.height()/2);
+				textarea[0].scrollTop = position;
+			}
+
+			
+			/* Set the width */
+			var sidebarWidth					= linesDiv.outerWidth();
+			var paddingHorizontal 		= parseInt( linedWrapDiv.css("border-left-width") ) + parseInt( linedWrapDiv.css("border-right-width") ) + parseInt( linedWrapDiv.css("padding-left") ) + parseInt( linedWrapDiv.css("padding-right") );
+			var linedWrapDivNewWidth 	= originalTextAreaWidth - paddingHorizontal;
+			var textareaNewWidth			= originalTextAreaWidth - sidebarWidth - paddingHorizontal - 20;
+
+			textarea.width( textareaNewWidth );
+			linedWrapDiv.width( linedWrapDivNewWidth );
+			
+
+			
+			/* React to the scroll event */
+			textarea.scroll( function(tn){
+				var domTextArea		= $(this)[0];
+				var scrollTop 		= domTextArea.scrollTop;
+				var clientHeight 	= domTextArea.clientHeight;
+				codeLinesDiv.css( {'margin-top': (-1*scrollTop) + "px"} );
+				lineNo = fillOutLines( codeLinesDiv, scrollTop + clientHeight, lineNo );
+			});
+
+
+			/* Should the textarea get resized outside of our control */
+			textarea.resize( function(tn){
+				var domTextArea	= $(this)[0];
+				linesDiv.height( domTextArea.clientHeight + 6 );
+			});
+
+		});
+	};
+
+  // default options
+  $.fn.linedtextarea.defaults = {
+  	selectedLine: -1,
+  	selectedClass: 'lineselect'
+  };
+})(jQuery);


### PR DESCRIPTION
Not to be confused with `checkstyle-tester` for regression, web tester is just a simple web interface for checkstyle. Users can supply config, code, and CS version and run it. Links are generated for the file and config for easy sharing. You can select any installed CS release for regression.
Textarea fields have line numbers so its easy to see what line violations point to.

**Live version may be found here: http://rveach.no-ip.org/checkstyle/checkstyle.php**

You may use this as you wish, but I can't guarantee uptime or how long files will be saved, if you use that feature. Max 5kb limit for all files.
Releases and nightlies have to be manually installed.