### PR TITLE
checkstyle-tester: Add Apache Struts into projects-to-test-on.properties

### DIFF
--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -28,6 +28,7 @@ guava|github|google/guava|v18.0
 #apache-ant|github|apache/ant|ANT_194|**apache-ant/src/tests/**/*,apache-ant/src/etc/testcases/
 #apache-jsecurity|github|apache/jsecurity|c2ac5b90a467aedb04b52ae50a99e83207d847b3
 #android-launcher|github|android/platform_packages_apps_launcher|android-2.1_r2.1p2
+#apache-struts|git|https://github.com/apache/struts.git|master|**/resources/**/*
 
 # Projects which contain a lot of labmda expressions
 #infinispan|github|infinispan/infinispan|7.2.5.Final


### PR DESCRIPTION
Apache Struts 2 web framework is a free open-source solution for creating Java web applications. Apache team no longer supports Struts 1, but Apache Struts 2 contains a lot of legacy code. The code is also packed with annotations (Injections, ets) and will be good choice for testing Checkstyle's annotation checks.

https://github.com/apache/struts