### PR TITLE
minor: [releasenotes-builder] fix wrong reference in lambda expression

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
@@ -183,7 +183,7 @@ public final class NotesBuilder {
                     commitMessage.substring(lastSpaceIndex + 1, lastPeriodIndex);
 
                 final Optional<RevCommit> revertedCommit = commitsForRelease.stream()
-                    .filter(revCommit -> revertedCommitReference.equals(commit.getName()))
+                    .filter(revCommit -> revertedCommitReference.equals(revCommit.getName()))
                     .findFirst();
 
                 if (revertedCommit.isPresent()) {


### PR DESCRIPTION
@romani 

Lambda parameter 'revCommit' should be used in a condition to find the value in a stream using filter.