### PR TITLE
minor: fixed bug that tripled base file number

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/Statistics.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/Statistics.java
@@ -167,7 +167,6 @@ public class Statistics {
      * @param index index of the source.
      */
     public final void incrementFileCount(int index) {
-        this.fileNumBase++;
         if (index == CheckstyleReportsParser.BASE_REPORT_INDEX) {
             this.fileNumBase++;
         }


### PR DESCRIPTION
Every diff run was showing base files as exactly 3x as patch files. Running `diff` on both directories showed they were the same, so bug was in the code.
Why 3x: Utility runs once against base, which increased doubled the count. When utility runs against patch, it increases the count one more time. Thus this results in 3x.