### PR TITLE
minor: turn off failsOnError for regression

### DIFF
--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -56,7 +56,7 @@
 					 but will not take effect on the execution of "mvn checkstyle:checkstyle"  -->
 				<configuration>
 					<enableFilesSummary>false</enableFilesSummary>
-                    <failsOnError>true</failsOnError>
+                    <failsOnError>false</failsOnError>
 				</configuration>
 			</plugin>
           <plugin>


### PR DESCRIPTION
This is a fix for the issue described in https://github.com/checkstyle/checkstyle/issues/3704 .

Even with `haltOnException` turned off, checkstyle still prints "exception violations" as errors and causes `maven-checkstyle-plugin` to fail and `jxr` to stop the build and produce no reports during regression. There is no way to override the severity of "exception violations" through checkstyle at the moment to change them to non-errors, as the above issue won't be approved. The whole reason of adding `haltOnException` was so exceptions in regression won't trigger a stopping of regression and reporting, and so we can include exceptions in our difference reporting.

There is a fix for `maven-checkstyle-plugin` which is what this PR does. It stops `maven-checkstyle-plugin` from failing on any errors produced by checkstyle and allows `jxr` to continue producing reports through errors.