### PR TITLE
Issue #152: Add property 'ignoreExceptios' for launch.groovy

### DIFF
--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -8,14 +8,34 @@ It consists of two Groovy scripts: launch.groovy and diff.groovy. Thus, in order
 **launch.groovy** is a script which allows you to generate Checkstyle report over target projects. It invokes Maven Checkstyle plugin. In order to use the script you should run the following command in your command line:
 
 ```
-groovy launch.groovy projects-to-test-on.properties my_check.xml
+groovy launch.groovy --listOfProjects projects-to-test-on.properties --checkstyleCfg my_check.xml
 ```
 
-The script receives two command line arguments:
+or with short command line arguments names:
 
-1) **projects-to-test-on.properties** - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation;
+```
+groovy launch.groovy -l projects-to-test-on.properties -c my_check.xml
+```
 
-2) **my_check.xml** - path to the file with Checkstyle configuration.
+If you want to force Maven Checkstyle Plugin to ignore exceptions:
+
+```
+groovy launch.groovy --listOfProjects projects-to-test-on.properties --checkstyleCfg my_check.xml --ignoreExceptions
+```
+
+or with short command line arguments names:
+
+```
+groovy launch.groovy -l projects-to-test-on.properties -c my_check.xml -i
+```
+
+The script receives the following command line arguments:
+
+**listOfProjects** (l) - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation (required);
+
+**checkstyleCfg** (c) - path to the file with Checkstyle configuration (required);
+
+**ignoreExceptions** (i) - whether Checkstyle Maven Plugin should ignore exceptions (optional, default is false).
 
 When the script finishes its work the following directory structure will be created in the root of cehckstyle-tester directory:
 
@@ -67,7 +87,7 @@ Follow example how we do this in Windows CI server - https://github.com/checksty
 In order to generate a compact diff report before and after your changes you can use diff.groovy script which performs all required work automatically. Please run the following command in your command line:
 
 ```
-groovy diff.groovy --localGitRepo /home/johndoe/projects/checkstyle --baseBranch master --patchBranch i111-my-fix --checkstyleCfg my_check.xml --projectsToTestOn projects-to-test-on.properties
+groovy diff.groovy --localGitRepo /home/johndoe/projects/checkstyle --baseBranch master --patchBranch i111-my-fix --checkstyleCfg my_check.xml --listOfProjects projects-to-test-on.properties
 ```
 
 or with short command line arguments names:
@@ -86,7 +106,7 @@ The script receives the following set of command line arguments:
 
 **checkstyleCfg** (c) - path to the file with Checkstyle configuration;
 
-**projectsToTestOn** (l) - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation.
+**listOfProjects** (l) - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation.
 
 When the script finishes its work the following directory structure will be created in the root of cehckstyle-tester directory:
 

--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -9,7 +9,7 @@ static void main(String[] args) {
         b(longOpt: 'baseBranch', args: 1, argName: 'baseBranch', 'Base branch name. Default is master')
         p(longOpt: 'patchBranch', args: 1, argName: 'patchBranch', 'Name of the patch branch in local git repository')
         c(longOpt: 'checkstyleCfg', args: 1, argName: 'checkstyleCfg', 'Path to checkstyle config file')
-        l(longOpt: 'projectsToTestOn', args: 1, argName: 'projectsToTestOn', 'Path to file which contains projects to test on')
+        l(longOpt: 'listOfProjects', args: 1, argName: 'listOfProjects', 'Path to file which contains projects to test on')
     }
     def options = cli.parse(args)
 
@@ -25,7 +25,7 @@ static void main(String[] args) {
         }
 
         def patchBranch = options.patchBranch
-        def projectsToTestOn = options.projectsToTestOn
+        def listOfProjects = options.listOfProjects
         def checkstyleCfg = options.checkstyleCfg
 
         def reportsDir = 'reports'
@@ -46,8 +46,8 @@ static void main(String[] args) {
             deleteDir(tmpReportsDir)
         }
 
-        generateCheckstyleReport(localGitRepo, baseBranch, checkstyleCfg, projectsToTestOn, tmpMasterReportsDir)
-        generateCheckstyleReport(localGitRepo, patchBranch, checkstyleCfg, projectsToTestOn, tmpPatchReportsDir)
+        generateCheckstyleReport(localGitRepo, baseBranch, checkstyleCfg, listOfProjects, tmpMasterReportsDir)
+        generateCheckstyleReport(localGitRepo, patchBranch, checkstyleCfg, listOfProjects, tmpPatchReportsDir)
         deleteDir(reportsDir)
         moveDir(tmpReportsDir, reportsDir)
         generateDiffReport(reportsDir, masterReportsDir, patchReportsDir, checkstyleCfg)
@@ -67,7 +67,7 @@ def areValidCliArgs(options) {
         if (options.checkstyleCfg
                 && options.localGitRepo
                 && options.patchBranch
-                && options.projectsToTestOn) {
+                && options.listOfProjects) {
             def localGitRepo = new File(options.localGitRepo)
             def patchBranch = options.patchBranch
             def baseBranch = options.baseBranch
@@ -140,7 +140,7 @@ def getCheckstyleVersionFromPomXml(pathToPomXml, xmlTagName) {
     return checkstyleVersion
 }
 
-def generateCheckstyleReport(localGitRepo, branch, checkstyleCfg, projectsToTestOn, destDir) {
+def generateCheckstyleReport(localGitRepo, branch, checkstyleCfg, listOfProjects, destDir) {
     println "Installing Checkstyle artifact ($branch) into local Maven repository ..."
     executeCmd("git checkout $branch", localGitRepo)
 
@@ -151,7 +151,7 @@ def generateCheckstyleReport(localGitRepo, branch, checkstyleCfg, projectsToTest
     }
 
     executeCmd("mvn -Pno-validations clean install", localGitRepo)
-    executeCmd("groovy launch.groovy $projectsToTestOn $checkstyleCfg")
+    executeCmd("groovy launch.groovy --listOfProjects $listOfProjects --checkstyleCfg $checkstyleCfg --ignoreExceptions")
     println "Moving Checkstyle report into $destDir ..."
     moveDir("reports", destDir)
 }

--- a/patch-diff-report-tool/README.md
+++ b/patch-diff-report-tool/README.md
@@ -10,7 +10,7 @@ You have 2 different checkstyle repos, original (base) and forked (patch), for e
 
 4) go to repo folder and execute in console `mvn clean install` <br/>
 5) go to `./contribution/checkstyle-tester` directory, uncomment all/required lines in `projects-to-test-on.properties`, edit  `my_check.xml`<br/>
-6) execute `groovy launch.groovy projects-to-test-on.properties my_check.xml`<br/>
+6) execute `groovy launch.groovy --listOfProjects projects-to-test-on.properties --checkstyleCfg my_check.xml --ignoreExceptions`<br/>
 7) copy `checkstyle-result.xml` from `checkstyle-tester/reports/project-name/` to some other location.<br/>
 
 8) Now execute this utility with 6 command line arguments:<br/>


### PR DESCRIPTION
#152 

1) Added property 'failsOnError' for launch.groovy as a cli option. Default value is false as I used CliBuilder from Groovy SDK. 

```
usage: groovy launch.groovy [options]
options:
 -c,--checkstyleCfg <path>      Path to checkstyle config file (required)
 -e,--failsOnError              Turn on 'failsOnError' of Maven Checkstyle Plugin (optional, default is false)
 -l,--projectsToTestOn <path>   Path to file which contains projects to test on (required)
```

2) Performed refactoring of launch.groovy. Deleted odd validations and replaced them with default validations from CliBuilder. Validation error message which will be thrown if 'projectsToTestOn' is not specified :

```
error: Missing required option: l
usage: groovy launch.groovy [options]
options:
 -c,--checkstyleCfg <path>      Path to checkstyle config file (required)
 -e,--failsOnError              Turn on 'failsOnError' of Maven Checkstyle Plugin (optional, default is false)
 -l,--projectsToTestOn <path>   Path to file which contains projects to test on (required)
Caught: java.lang.IllegalArgumentException: Error: invalid command line arguments!
java.lang.IllegalArgumentException: Error: invalid command line arguments!
	at launch.run(launch.groovy:23)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
```

3) Updated README.md

P.S.
All CIs configs need to be changed. All invocations of launch.groovy (no exception tests) need to set 'failsOnError'.