### PR TITLE
Issue #82: added option 'shortFilePaths' to patch-diff-report-tool

### DIFF
--- a/patch-diff-report-tool/README.md
+++ b/patch-diff-report-tool/README.md
@@ -21,6 +21,7 @@ You have 2 different checkstyle repos, original (base) and forked (patch), for e
 `--output` - path to store the resulting diff report (optional argument, default: ~/XMLDiffGen_report_yyyy.mm.dd_hh_mm_ss)<br/>
 `--baseConfig` - path to the base checkstyle configuration xml file (optional argument);<br/>
 `--patchConfig` - path to the patch checkstyle configuration xml file (optional argument);<br/>
+`--shortFilePaths` - Option to save report file paths as a shorter version to prevent long paths. This option is useful for Windows users where they are restricted to maximum directory depth.<br />
 `-h` - shows help message.<br/>
 
 

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
@@ -115,6 +115,12 @@ public final class Main {
     private static final String OPTION_PATCH_CONFIG_PATH = "patchConfig";
 
     /**
+     * Name for command line option to save report file paths as a shorter
+     * version to prevent long paths.
+     */
+    private static final String OPTION_SHORT_PATHS = "shortFilePaths";
+
+    /**
      * Name for command line option that shows help message.
      */
     private static final String OPTION_HELP = "h";
@@ -244,6 +250,8 @@ public final class Main {
                 "Path to the checkstyle configuration xml of the base report.");
         options.addOption(null, OPTION_PATCH_CONFIG_PATH, true,
                 "Path to the checkstyle configuration xml of the patch report.");
+        options.addOption(null, OPTION_SHORT_PATHS, false,
+                "Option to save report file paths as a shorter version to prevent long paths.");
         options.addOption(OPTION_HELP, false, "Shows help message, nothing else.");
         return options;
     }
@@ -268,8 +276,9 @@ public final class Main {
         final Path outputPath = getPath(OPTION_OUTPUT_PATH, commandLine, defaultResultPath);
         final Path configBasePath = getPath(OPTION_BASE_CONFIG_PATH, commandLine, null);
         final Path configPatchPath = getPath(OPTION_PATCH_CONFIG_PATH, commandLine, null);
+        final boolean shortFilePaths = commandLine.hasOption(OPTION_SHORT_PATHS);
         return new CliPaths(xmlBasePath, xmlPatchPath, refFilesPath, outputPath, configBasePath,
-                configPatchPath);
+                configPatchPath, shortFilePaths);
     }
 
     /**

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliPaths.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliPaths.java
@@ -57,6 +57,11 @@ public final class CliPaths {
     private final Path patchConfigPath;
 
     /**
+     * Switch specifying if only short file names should be used with no path.
+     */
+    private final boolean shortFilePaths;
+
+    /**
      * POJO ctor.
      *
      * @param baseReportPath
@@ -71,15 +76,19 @@ public final class CliPaths {
      *        path to the configuration of the base report.
      * @param baseConfigPath
      *        path to the configuration of the patch report.
+     * @param shortFilePaths
+     *           {@code true} if only short file names should be used with no paths.
      */
     public CliPaths(Path baseReportPath, Path patchReportPath,
-            Path refFilesPath, Path outputPath, Path baseConfigPath, Path patchConfigPath) {
+            Path refFilesPath, Path outputPath, Path baseConfigPath, Path patchConfigPath,
+            boolean shortFilePaths) {
         this.baseReportPath = baseReportPath;
         this.patchReportPath = patchReportPath;
         this.refFilesPath = refFilesPath;
         this.outputPath = outputPath;
         this.baseConfigPath = baseConfigPath;
         this.patchConfigPath = patchConfigPath;
+        this.shortFilePaths = shortFilePaths;
     }
 
     public Path getBaseReportPath() {
@@ -104,6 +113,10 @@ public final class CliPaths {
 
     public Path getPatchConfigPath() {
         return patchConfigPath;
+    }
+
+    public boolean isShortFilePaths() {
+        return shortFilePaths;
     }
 
     /**

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -180,7 +180,8 @@ public final class SiteGenerator {
         for (Map.Entry<String, List<CheckstyleRecord>> entry : diffReport.getRecords().entrySet()) {
             final List<CheckstyleRecord> records = entry.getValue();
             String filename = entry.getKey();
-            final String xreference = xrefGenerator.generateXref(filename);
+            final String xreference = xrefGenerator.generateXref(filename,
+                    paths.isShortFilePaths());
             if (refFilesPath != null) {
                 filename = refFilesPath.relativize(Paths.get(filename)).toString();
             }

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
@@ -45,6 +45,17 @@ class XrefGenerator {
     public static final String ENCODING = "UTF-8";
 
     /**
+     * File extension used for reports.
+     */
+    private static final String FILE_EXTENSION = ".html";
+
+    /**
+     * File counter only to be used with {@code shortFileNames} option in
+     * {@link #getDestinationPath(String, boolean)}.
+     */
+    private static int simpleFileNameCounter;
+
+    /**
      * Maven-jxr package manager.
      */
     private static PackageManager pacman;
@@ -97,13 +108,15 @@ class XrefGenerator {
      *
      * @param name
      *        path to the source file.
+     * @param shortFilePaths
+     *           {@code true} if only short file names should be used with no path.
      * @return relative path to the resulting file.
      * @throws IOException
      *         on maven-jxr internal failure.
      */
-    public final String generateXref(String name) throws IOException {
+    public final String generateXref(String name, boolean shortFilePaths) throws IOException {
         final File sourceFile = new File(name);
-        final Path dest = getDestinationPath(name);
+        final Path dest = getDestinationPath(name, shortFilePaths);
         codeTransform.transform(sourceFile.getAbsolutePath(),
                 dest.toString(), Locale.ENGLISH,
                 ENCODING, ENCODING, "", "", "");
@@ -115,19 +128,29 @@ class XrefGenerator {
      *
      * @param name
      *        java source file path.
+     * @param shortFilePaths
+     *           {@code true} if only short file names should be used with no path.
      * @return full path to the destination of XREF file.
      */
-    private Path getDestinationPath(String name) {
-        final String newName = name + ".html";
-        final Path sourcePath = Paths.get(newName);
+    private Path getDestinationPath(String name, boolean shortFilePaths) {
         final Path destPath;
-        if (relativizationPath == null) {
-            destPath = destinationPath
-            .resolve(sourcePath.subpath(0, sourcePath.getNameCount()));
+
+        if (shortFilePaths) {
+            simpleFileNameCounter++;
+            destPath = Paths
+                    .get(destinationPath + "/File" + simpleFileNameCounter + FILE_EXTENSION);
         }
         else {
-            destPath = destinationPath
-            .resolve(relativizationPath.relativize(sourcePath));
+            final String newName = name + FILE_EXTENSION;
+            final Path sourcePath = Paths.get(newName);
+            if (relativizationPath == null) {
+                destPath = destinationPath
+                    .resolve(sourcePath.subpath(0, sourcePath.getNameCount()));
+            }
+            else {
+                destPath = destinationPath
+                    .resolve(relativizationPath.relativize(sourcePath));
+            }
         }
         return destPath;
     }


### PR DESCRIPTION
Issue #82

added option `shortFilePaths`.
Utilities that call patch-diff-report still need to be updated.