### PR TITLE
Pull #179: transformed xref windows url to linux

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
@@ -120,7 +120,11 @@ class XrefGenerator {
         codeTransform.transform(sourceFile.getAbsolutePath(),
                 dest.toString(), Locale.ENGLISH,
                 ENCODING, ENCODING, "", "", "");
-        return sitePath.relativize(dest).toString();
+        String result = sitePath.relativize(dest).toString();
+        if (result.indexOf('\\') != -1) {
+            result = result.replace('\\', '/');
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
This is the fix for PR #178 .
File path in the report's href was the only area where it was different depending on the OS being used.

> `ComparisonFailure: expected:<...	<td><a href = "xref[\]File1.html#L5">5</a></td>...> but was:<...	<td><a href = "xref[/]File1.html#L5">5</a></td>`