### PR TITLE
Issue #88: added base/patch unique message counts

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffReport.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffReport.java
@@ -147,6 +147,7 @@ public final class DiffReport {
             for (CheckstyleRecord rec : list) {
                 statistics.addSeverityRecord(rec.getSeverity(),
                         CheckstyleReportsParser.DIFF_REPORT_INDEX);
+                statistics.incrementUniqueMessageCount(rec.getIndex());
             }
         }
     }

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/Statistics.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/Statistics.java
@@ -54,6 +54,11 @@ public class Statistics {
     private int fileNumBase;
 
     /**
+     * Number of unique messages in the base source.
+     */
+    private int uniqueMessagesBase;
+
+    /**
      * Map storing severity numbers for patch source.
      */
     private Map<String, Integer> severityNumPatch = new HashMap<>();
@@ -62,6 +67,11 @@ public class Statistics {
      * Number of files in the patch source.
      */
     private int fileNumPatch;
+
+    /**
+     * Number of unique messages in the patch source.
+     */
+    private int uniqueMessagesPatch;
 
     public final Map<String, Integer> getSeverityNumDiff() {
         return severityNumDiff;
@@ -109,6 +119,10 @@ public class Statistics {
         return fileNumBase;
     }
 
+    public final int getUniqueMessagesBase() {
+        return uniqueMessagesBase;
+    }
+
     /**
      * Getter for total number of severity records for patch source.
      *
@@ -124,6 +138,10 @@ public class Statistics {
 
     public final int getFileNumPatch() {
         return fileNumPatch;
+    }
+
+    public final int getUniqueMessagesPatch() {
+        return uniqueMessagesPatch;
     }
 
     /**
@@ -188,4 +206,17 @@ public class Statistics {
         return names;
     }
 
+    /**
+     * Registers unique message from numbered source.
+     *
+     * @param index index of the source.
+     */
+    public void incrementUniqueMessageCount(int index) {
+        if (index == CheckstyleReportsParser.BASE_REPORT_INDEX) {
+            this.uniqueMessagesBase++;
+        }
+        else if (index == CheckstyleReportsParser.PATCH_REPORT_INDEX) {
+            this.uniqueMessagesPatch++;
+        }
+    }
 }

--- a/patch-diff-report-tool/src/main/resources/header.template
+++ b/patch-diff-report-tool/src/main/resources/header.template
@@ -111,6 +111,10 @@
 							</th:block>
 						<tr>
 					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase" th:text=${statistics.uniqueMessagesBase}>uniqueMessagesBase</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch" th:text=${statistics.uniqueMessagesPatch}>uniqueMessagesPatch</span><br />
 				</div>
 			</div>
 

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html
@@ -230,6 +230,10 @@
 							
 						<tr>
 					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase">6</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">6</span><br />
 				</div>
 			</div>
 

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesRefFiles.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesRefFiles.html
@@ -230,6 +230,10 @@
 							
 						<tr>
 					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase">6</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">6</span><br />
 				</div>
 			</div>
 

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesShortFilePaths.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesShortFilePaths.html
@@ -230,6 +230,10 @@
 							
 						<tr>
 					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase">6</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">6</span><br />
 				</div>
 			</div>
 

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportEmpty.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportEmpty.html
@@ -44,6 +44,10 @@
 							
 						<tr>
 					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase">0</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">0</span><br />
 				</div>
 			</div>
 

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportEmptyWithConfig.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportEmptyWithConfig.html
@@ -222,6 +222,10 @@
 							
 						<tr>
 					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase">0</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">0</span><br />
 				</div>
 			</div>
 

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportSeverities.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportSeverities.html
@@ -76,6 +76,10 @@
 							
 						<tr>
 					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase">0</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">4</span><br />
 				</div>
 			</div>
 


### PR DESCRIPTION
Issue #88

Fields and IDs were named uniqueMessagesBase and uniqueMessagesPatch.
Let me know if there is a better name.

This section will only show counts of messages in reports.
Example: 
[Normal way says 7](https://github.com/rnveach/contribution/blob/945f2734c2ced12d6458214563b4146cd205e9e8/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html#L213), which is all violations in file.
[True count in report is 6](https://github.com/rnveach/contribution/blob/945f2734c2ced12d6458214563b4146cd205e9e8/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html#L235).