### PR TITLE
Issue #193: Fix FileAlreadyExistsException in launch.groovy

### DIFF
--- a/checkstyle-tester/launch.groovy
+++ b/checkstyle-tester/launch.groovy
@@ -90,7 +90,7 @@ def generateCheckstyleReport(cliOptions) {
     }
 
     // restore empty_file to make src directory tracked by git
-    Files.createFile(Paths.get("$srcDir/empty_file"))
+    new File("$srcDir/empty_file").createNewFile()
 }
 
 def createWorkDirsIfNotExist(srcDirPath, repoDirPath, reportsDirPath) {


### PR DESCRIPTION
#193 

[createNewFile](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#createNewFile--) method creates new file only if the file does not exist.