### PR TITLE
minor: removed large file from regression to prevent slowdown

### DIFF
--- a/checkstyle-tester/projects-for-wercker.properties
+++ b/checkstyle-tester/projects-for-wercker.properties
@@ -5,7 +5,8 @@
 #apache-struts|git|https://github.com/apache/struts.git|master|**/apache-struts/**/resources/**/*
 
 # Few projects that delivers set of unusual Java constructions that shall be correctly handled by AST visitor
-#checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/checkstyle/src/test/resources-noncompilable/**/*
+# 'InputAllEscapedUnicodeCharacters' must be skipped because it is too big and slows down JXR
+#checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/checkstyle/src/test/resources-noncompilable/**/*,**/InputAllEscapedUnicodeCharacters.java
 #sevntu-checkstyle|git|http://github.com/sevntu-checkstyle/sevntu.checkstyle|master||
 
 guava|git|http://github.com/google/guava|v18.0||

--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -3,7 +3,8 @@
 # Please note that bash comments works in this file
 
 # Few projects that delivers set of unusual Java constructions that shall be correctly handled by AST visitor
-#checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/checkstyle/src/test/resources-noncompilable/**/*
+# 'InputAllEscapedUnicodeCharacters' must be skipped because it is too big and slows down JXR
+#checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/checkstyle/src/test/resources-noncompilable/**/*,**/InputAllEscapedUnicodeCharacters.java
 #sevntu-checkstyle|git|http://github.com/sevntu-checkstyle/sevntu.checkstyle|master||
 
 #openjdk7|hg|http://hg.openjdk.java.net/jdk7/jdk7/jdk/|||


### PR DESCRIPTION
When testing locally, run on checkstyle took 7 minutes.
When I removed `test/resources` it only took 30 seconds.
I found this slowdown to be `InputAllEscapedUnicodeCharacters` which we just recently added. I assume JXR has some issue with it because of it's size.