### PR TITLE
Issue #200: Edit default config for checkstyle tester to produce no violations

### DIFF
--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -40,7 +40,7 @@ The script receives the following command line arguments:
 
 **listOfProjects** (l) - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation (required);
 
-**config** (c) - path to the file with Checkstyle configuration (required);
+**config** (c) - path to the file with Checkstyle configuration (required). The default config should be changed in order to be appropriate for your use purposes;
 
 **ignoreExceptions** (i) - whether Checkstyle Maven Plugin should ignore exceptions (optional, default is false).
 
@@ -130,7 +130,7 @@ The script receives the following set of command line arguments:
 
 **patchConfig** (pc) - path to the patch checkstyle config file. It will be applied to patch branch (required if baseConfig is specified);
 
-**config** (c) - path to the checkstyle config file. It will be applied to base and patch branches (required if baseConfig and patchConfig are not secified);
+**config** (c) - path to the checkstyle config file. It will be applied to base and patch branches (required if baseConfig and patchConfig are not secified). The default config should be changed in order to be appropriate for your use purposes;
 
 **listOfProjects** (l) - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation.
 

--- a/checkstyle-tester/my_check.xml
+++ b/checkstyle-tester/my_check.xml
@@ -6,7 +6,7 @@
 
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
-    
+
     <!-- do not change severity to 'error', as that will hide errors caused by exceptions -->
     <property name="severity" value="warning"/>
 
@@ -21,9 +21,11 @@
     <module name="TreeWalker">
          <!-- Example of sevntu.checkstyle Check usage -->
          <!-- <module name="NestedSwitchCheck"/> -->
-         
+
          <!-- Example of checkstyle Check usage -->
-         <module name="AbstractClassName"/>
+         <module name="ThrowsCount">
+             <property name="max" value="20000000"/>
+         </module>
     </module>
 <!--
     <module name="SeverityMatchFilter">


### PR DESCRIPTION
#200

It default config is not changed we will get the following diff report:

![image](https://cloud.githubusercontent.com/assets/7242568/24269071/e98347a0-1020-11e7-9d80-7c20b78ab488.png)

Sorry, but my IDEA continues reformatting blank lines with tabs even if I disable code formatting before a commit.