### PR TITLE
Issue #204: Fix xdoc_thymeleaf.template to avoid spaces in issues links

### DIFF
--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_thymeleaf.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_thymeleaf.template
@@ -3,36 +3,44 @@
       <p>Breaking backward compatibility:</p>
         <ul>
           <li th:each="message : ${breakingMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
-            th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
+            [[${message.title}]]. Author: [[${message.author}]]
+            <th:block th:if="${message.issueNo} != -1">
+                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            </th:block>
           </li>
         </ul></th:block><th:block
       th:if="${not #lists.isEmpty(newMessages)}">
       <p>New:</p>
         <ul>
           <li th:each="message : ${newMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
-            th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
+            [[${message.title}]]. Author: [[${message.author}]]
+            <th:block th:if="${message.issueNo} != -1">
+                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            </th:block>
           </li>
         </ul></th:block><th:block
       th:if="${not #lists.isEmpty(bugMessages)}">
       <p>Bug fixes:</p>
         <ul>
           <li th:each="message : ${bugMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
-            th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
+            [[${message.title}]]. Author: [[${message.author}]]
+            <th:block th:if="${message.issueNo} != -1">
+                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            </th:block>
           </li>
         </ul></th:block><th:block
       th:if="${not #lists.isEmpty(notesMessages)}">
       <p>Notes:</p>
         <ul>
           <li th:each="message : ${notesMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]<a th:if="${message.issueNo} != -1"
-            th:href="'https://github.com/checkstyle/checkstyle/issues/'
-            + ${message.issueNo}"> #[[${message.issueNo}]]</a>
+            [[${message.title}]]. Author: [[${message.author}]]
+            <th:block th:if="${message.issueNo} != -1">
+                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a>
+            </th:block>
           </li>
         </ul></th:block>
     </section>


### PR DESCRIPTION
#205 

Release notes after fix:
[xdoc.xml](http://mezk.github.io/i204-fix-xdoc-template/xdoc.xml)
[xdoc.html](http://mezk.github.io/i204-fix-xdoc-template/xdoc.html)

Due to usage of ```<th: block>``` there are blank lines in release notes: (xdoc.xml)
```
<li>
    Revert &quot;Pull #3162: Update version of commons-collections to 3.2.2 to fix security vulnerability CVE-2015-6420&quot;. Author: Roman Ivanov

</li>
```

and I cannot find workaround for these issues. There was [the request](https://github.com/thymeleaf/thymeleaf/issues/108) to implement the functionality to remove blank lines, however it was declined.

@romani 
Please, recheck. This is the cli args that I used to generate reports:
```-localRepoPath /checkstyle -startRef 2b90c7db5b6e64c7e667d112b982f865e5e9aa40 -githubAuthToken ************************* -endRef 11e1eb3ddd07df6a8859430bb6794b418c6a08b7 -releaseNumber 8 -generateXdoc```

Note, that previous fix was done in the scope of #117. 
So we need to avoid spaces at the end of the lines if there is no issue number in xdoc.xml.