### PR TITLE
Issue #206: Fix incorrect filter condition for binary search

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
@@ -306,7 +306,7 @@ public final class NotesBuilder {
     private static String getIssueLabelFrom(GHIssue issue) throws IOException {
         final Collection<GHLabel> issueLabels = issue.getLabels();
         final Optional<GHLabel> label = issueLabels.stream()
-            .filter(input -> Arrays.binarySearch(Constants.ISSUE_LABELS, input.getName()) != -1)
+            .filter(input -> Arrays.binarySearch(Constants.ISSUE_LABELS, input.getName()) >= 0)
             .findFirst();
         return label.map(GHLabel::getName).orElse("");
     }


### PR DESCRIPTION
#208 

@romani 
> This looks like the issue. Binary search returns >= 0 if it exists in array and < 0 on where it should be inserted into array if it doesn't exist. It doesn't guarantee a result of -1 all the time.
Condition should be checking >= 0 instead of != -1.

Yes, that was the problem.

> issue checkstyle/checkstyle#3437
one more : checkstyle/checkstyle#3892
has label "new feature" but it is not present in releasenotes after 7.6, that forced me to create 7.6.1 release instead of 7.7 .
TODO: investigate a reason of missed "new feature" group in release notes of 7.6.1 - checkstyle.sourceforge.net/releasenotes.html#Release_7.6.1

Fixed.

> one more problem - checkstyle/checkstyle#3329 does not have label and build is not failed

Fixed.

> link to all closed "new feature" issues - https://github.com/checkstyle/checkstyle/issues?q=is%3Aissue+label%3A%22new+feature%22+is%3Aclosed+sort%3Aupdated-desc

Here is the [xdoc.xml](https://github.com/checkstyle/contribution/files/880123/xdoc.txt) which was generated starting from tag ```checkstyle-6.12```. As you can see there are 48 issues in ```New``` group.

Program args to check:
```-localRepoPath /checkstyle -startRef checkstyle-6.12 -githubAuthToken *********************************** -releaseNumber 8 -generateXdoc```

I do not know why TeamCity is not happy this time.