### PR TITLE
Issue #213: checkstyle-tester: support regression on new checks/tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
         - CMD3=" "
         - CMD4=" "
         - CMD5=" && cd ../checkstyle-tester"
-        - CMD6=" && groovy diff.groovy -l projects-for-travis.properties -c my_check.xml -b master -p patch-branch -r ../checkstyle -i"
+        - CMD6=" && groovy diff.groovy -l projects-for-travis.properties -c my_check.xml -b master -p patch-branch -r ../checkstyle"
         - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6
     - jdk: oraclejdk8
       env:
@@ -45,14 +45,24 @@ matrix:
         - CMD3=" "
         - CMD4=" "
         - CMD5=" && cd ../checkstyle-tester"
-        - CMD6=" && groovy diff.groovy -l projects-for-travis.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r ../checkstyle -i"
+        - CMD6=" && groovy diff.groovy -l projects-for-travis.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r ../checkstyle"
+        - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6
+    - jdk: oraclejdk8
+      env:
+        - DESC="checkstyle-tester (diff.groovy) on linux with enabled patchOnly"
+        - CMD1=" git clone https://github.com/checkstyle/checkstyle && cd checkstyle "
+        - CMD2=" && git checkout -b patch-branch"
+        - CMD3=" "
+        - CMD4=" "
+        - CMD5=" && cd ../checkstyle-tester"
+        - CMD6=" && groovy diff.groovy -l projects-for-travis.properties -pc my_check.xml -p patch-branch -r ../checkstyle -m single"
         - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6
     - jdk: oraclejdk8
       env:
         - DESC="codenarc validation for groovy files"
         - CMD1=" cd checkstyle-tester "
-        - CMD2=" && ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=21; p3=133)' diff.log"
-        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=23; p3=113)' launch.log"
+        - CMD2=" && ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=15; p3=64)' diff.log"
+        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=23; p3=35)' launch.log"
         - CMD4=" "
         - CMD=$CMD1$CMD2$CMD3$CMD4
     # disable as for now java8 is not supoorted jdk for travis MacOS

--- a/checkstyle-tester/LAUNCH_GROOVY_README.md
+++ b/checkstyle-tester/LAUNCH_GROOVY_README.md
@@ -1,0 +1,88 @@
+## [launch.groovy] Checkstyle report generation
+
+**launch.groovy** is a script which allows you to generate Checkstyle report over target projects. It invokes Maven Checkstyle plugin. In order to use the script you should run the following command in your command line:
+
+```
+groovy launch.groovy --listOfProjects projects-to-test-on.properties --config my_check.xml
+```
+
+or with short command line arguments names:
+
+```
+groovy launch.groovy -l projects-to-test-on.properties -c my_check.xml
+```
+
+If you want to force Maven Checkstyle Plugin to ignore exceptions:
+
+```
+groovy launch.groovy --listOfProjects projects-to-test-on.properties --config my_check.xml --ignoreExceptions
+```
+
+or with short command line arguments names:
+
+```
+groovy launch.groovy -l projects-to-test-on.properties -c my_check.xml -i
+```
+
+The script receives the following command line arguments:
+
+**listOfProjects** (l) - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation (required);
+
+**config** (c) - path to the file with Checkstyle configuration (required). The default config should be changed in order to be appropriate for your use purposes;
+
+**ignoreExceptions** (i) - whether Checkstyle Maven Plugin should ignore exceptions (optional, default is false).
+
+**ignoreExcludes** (g) - whether to ignore excludes specified in the list of projects (optional, default is false).
+
+When the script finishes its work the following directory structure will be created in the root of cehckstyle-tester directory:
+
+*/repositories* - directory with downloaded projects sources which are specified in projects-to-test-on.properties;
+
+*/reports* - directory with Checkstyle reports. 
+
+*reports/{repository_name}/site* - directory with Checkstyle report generated for the specific project (repository);
+
+You will find *index.html* file in /reports/{repository_name}/site directory. The file represents the main page of the report.
+
+**First run** should be executed with all rules enabled to make sure that new check does not fail. 
+You may see failure of `TreeWalker` but as long as it is applied for no-compilable sources (test, resources) you don't need to worry about it.  **Second run** shall be done to prove that check is working correctly and for this one select the most accurate repositories.
+
+Please use `-Dcheckstyle.consoleOutput=true` option if you need to see all Checkstyle errors in console, but expect it to print very and very much lines of terminal logs in this case. Launch command in this case will be:
+
+```
+groovy launch.groovy projects-to-test-on.properties my_check.xml -Dcheckstyle.consoleOutput=true
+```
+
+**Attention:** this project by default uses the latest SNAPSHOT version of [Checkstyle](https://github.com/checkstyle/contribution/search?utf8=%E2%9C%93&q=path%3Acheckstyle-tester+filename%3Apom.xml+%22checkstyle.version%22&type=) and the latest released version of [sevntu.checkstyle](https://github.com/checkstyle/contribution/search?utf8=%E2%9C%93&q=path%3Acheckstyle-tester+filename%3Apom.xml+%22sevntu.checkstyle.version%22&type=).
+If you you need to use custom (snapshot) versions please update pom.xml to reference that versions ([checkstyle version](https://github.com/checkstyle/contribution/blob/35d35dfcc48e2022403231e41aac8bf96126acc9/checkstyle-tester/pom.xml#L15), [sevntu.checkstyle version](https://github.com/checkstyle/contribution/blob/35d35dfcc48e2022403231e41aac8bf96126acc9/checkstyle-tester/pom.xml#L16)), and please make sure that custom(newly generated) versions are located in your local maven repo 
+
+```
+ls  ~/.m2/repository/com/puppycrawl/tools/checkstyle/
+ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
+```
+
+To build SNAPSHOT version of `checkstyle` please run in its folder (local git repository):
+
+```
+mvn clean install -DskipTests -Dcobertura.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
+```
+
+**Attention:** 
+Make sure that the versions of Checkstyle and SevNTU Checkstyle artifacts, which are located in your local Maven repository, corresponds to the versions specified in pom.xml,
+1) otherwise there will be the exception, because maven-checkstyle-plugin will not find the required artifact in the local Maven repository;
+2) you will not see any new/different violations from your changes, especially if you make changes to version X with changed logic and pom.xml specifies version Y. 
+You will not get an exception message and unless you are expecting a specific difference, you may just assume your report is correct when it really isn't.
+launch.groovy has no way to protect against this as branch with change isn't specified.
+
+If you want to validate new check from `sevntu.checkstyle`(https://github.com/sevntu-checkstyle/sevntu.checkstyle) project, 
+before you use "launch.groovy" you need to clone it and deploy to your local maven repo by following command
+
+```
+./deploy.sh --maven
+```
+
+WINDOWS USERS:
+
+*./deploy.sh* can be luanched on Windows OS by usage [https://www.cygwin.com/](Cygwin).
+Preinstall default commands - http://www.appveyor.com/updates/2015/05/30 search for "Installation command used:"
+Follow example how we do this in Windows CI server - https://github.com/checkstyle/checkstyle/blob/master/appveyor.yml#L71 search for matrix item "checkstyle-tester on guava"

--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -1,109 +1,16 @@
 # CHECKSTYLE-TESTER
 
 checkstyle-tester is a tool for Checkstyle report generation over very [basic set of java projects](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/projects-to-test-on.properties).
-It consists of two Groovy scripts: launch.groovy and diff.groovy. Thus, in order to use the tool make sure you have the Groovy runtime installed on your developer machine (min required version is 2.4.8).
+It consists of one Groovy script: diff.groovy. Thus, in order to use the tool make sure you have the Groovy runtime installed on your developer machine (min required version is 2.4.8).
 
 Content:
 
-- [Checkstyle report generation](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/README.md#launchgroovy-checkstyle-report-generation)
 - [Diff report generation](https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#diffgroovy-diff-report-generation)
 - [Deploy Report](https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#deploy-report)
 
-
-## [launch.groovy] Checkstyle report generation
-
-**launch.groovy** is a script which allows you to generate Checkstyle report over target projects. It invokes Maven Checkstyle plugin. In order to use the script you should run the following command in your command line:
-
-```
-groovy launch.groovy --listOfProjects projects-to-test-on.properties --config my_check.xml
-```
-
-or with short command line arguments names:
-
-```
-groovy launch.groovy -l projects-to-test-on.properties -c my_check.xml
-```
-
-If you want to force Maven Checkstyle Plugin to ignore exceptions:
-
-```
-groovy launch.groovy --listOfProjects projects-to-test-on.properties --config my_check.xml --ignoreExceptions
-```
-
-or with short command line arguments names:
-
-```
-groovy launch.groovy -l projects-to-test-on.properties -c my_check.xml -i
-```
-
-The script receives the following command line arguments:
-
-**listOfProjects** (l) - path to the file which contains the projects which sources will be analyzed by Checkstyle during report generation (required);
-
-**config** (c) - path to the file with Checkstyle configuration (required). The default config should be changed in order to be appropriate for your use purposes;
-
-**ignoreExceptions** (i) - whether Checkstyle Maven Plugin should ignore exceptions (optional, default is false).
-
-**ignoreExcludes** (g) - whether to ignore excludes specified in the list of projects (optional, default is false).
-
-When the script finishes its work the following directory structure will be created in the root of cehckstyle-tester directory:
-
-*/repositories* - directory with downloaded projects sources which are specified in projects-to-test-on.properties;
-
-*/reports* - directory with Checkstyle reports. 
-
-*reports/{repository_name}/site* - directory with Checkstyle report generated for the specific project (repository);
-
-You will find *index.html* file in /reports/{repository_name}/site directory. The file represents the main page of the report.
-
-**First run** should be executed with all rules enabled to make sure that new check does not fail. 
-You may see failure of `TreeWalker` but as long as it is applied for no-compilable sources (test, resources) you don't need to worry about it.  **Second run** shall be done to prove that check is working correctly and for this one select the most accurate repositories.
-
-Please use `-Dcheckstyle.consoleOutput=true` option if you need to see all Checkstyle errors in console, but expect it to print very and very much lines of terminal logs in this case. Launch command in this case will be:
-
-```
-groovy launch.groovy projects-to-test-on.properties my_check.xml -Dcheckstyle.consoleOutput=true
-```
-
-**Attention:** this project by default uses the latest SNAPSHOT version of [Checkstyle](https://github.com/checkstyle/contribution/search?utf8=%E2%9C%93&q=path%3Acheckstyle-tester+filename%3Apom.xml+%22checkstyle.version%22&type=) and the latest released version of [sevntu.checkstyle](https://github.com/checkstyle/contribution/search?utf8=%E2%9C%93&q=path%3Acheckstyle-tester+filename%3Apom.xml+%22sevntu.checkstyle.version%22&type=).
-If you you need to use custom (snapshot) versions please update pom.xml to reference that versions ([checkstyle version](https://github.com/checkstyle/contribution/blob/35d35dfcc48e2022403231e41aac8bf96126acc9/checkstyle-tester/pom.xml#L15), [sevntu.checkstyle version](https://github.com/checkstyle/contribution/blob/35d35dfcc48e2022403231e41aac8bf96126acc9/checkstyle-tester/pom.xml#L16)), and please make sure that custom(newly generated) versions are located in your local maven repo 
-
-```
-ls  ~/.m2/repository/com/puppycrawl/tools/checkstyle/
-ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
-```
-
-To build SNAPSHOT version of `checkstyle` please run in its folder (local git repository):
-
-```
-mvn clean install -DskipTests -Dcobertura.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
-```
-
-**Attention:** 
-Make sure that the versions of Checkstyle and SevNTU Checkstyle artifacts, which are located in your local Maven repository, corresponds to the versions specified in pom.xml,
-1) otherwise there will be the exception, because maven-checkstyle-plugin will not find the required artifact in the local Maven repository;
-2) you will not see any new/different violations from your changes, especially if you make changes to version X with changed logic and pom.xml specifies version Y. 
-You will not get an exception message and unless you are expecting a specific difference, you may just assume your report is correct when it really isn't.
-launch.groovy has no way to protect against this as branch with change isn't specified.
-
-If you want to validate new check from `sevntu.checkstyle`(https://github.com/sevntu-checkstyle/sevntu.checkstyle) project, 
-before you use "launch.groovy" you need to clone it and deploy to your local maven repo by following command
-
-```
-./deploy.sh --maven
-```
-
-WINDOWS USERS:
-
-*./deploy.sh* can be luanched on Windows OS by usage [https://www.cygwin.com/](Cygwin).
-Preinstall default commands - http://www.appveyor.com/updates/2015/05/30 search for "Installation command used:"
-Follow example how we do this in Windows CI server - https://github.com/checkstyle/checkstyle/blob/master/appveyor.yml#L71 search for matrix item "checkstyle-tester on guava"
-
-=============================================
-
 ## [diff.groovy] Diff report generation
 
-In order to generate a compact diff report before and after your changes you can use diff.groovy script which performs all required work automatically. Note, diff.groovy ignores excludes specified in the list of projects file.
+In order to generate a compact diff report before and/or after your changes you can use diff.groovy script which performs all required work automatically. Note, diff.groovy ignores excludes specified in the list of projects file.
 Please execute the following command in your command line to run diff.groovy:
 
 ```
@@ -128,11 +35,27 @@ or with short command line arguments names:
 groovy diff.groovy -r /home/johndoe/projects/checkstyle -b master -p i111-my-fix -bc base_config.xml -pc patch_config.xml -l projects-to-test-on.properties
 ```
 
+To generate the report only for the patch branch which contains your changes, use the following command:
+
+```
+groovy diff.groovy --localGitRepo /home/johndoe/projects/checkstyle --patchBranch i111-my-fix --patchConfig patch_config.xml --listOfProjects projects-to-test-on.properties --mode single
+```
+
+or with short command line arguments names:
+
+```
+groovy diff.groovy -r /home/johndoe/projects/checkstyle -p i111-my-fix -pc patch_config.xml -l projects-to-test-on.properties -m single
+```
+
 The script receives the following set of command line arguments:
 
 **localGitRepo** (r) - path to the local Checkstyle repository (required);
 
-**baseBranch** (b) - name of the base branch in local Checkstyle repository (optional, default is master branch);
+**baseBranch** (b) - name of the base branch in local Checkstyle repository (optional, if asent, then the tool will use only patchBranch in case the tool mode is 'single', otherwise baseBrach will be set to 'master');
+
+**mode** (m) - the mode of the tool: 'single' or 'diff' (optional, default is 'diff'. Set this option to 'single' if your patch branch contains changes for any option that can't work on master/base branch. 
+For example, for new properties, new tokens, or new modules. For all other changes, 'diff' mode should be the preferred mode used. Note, that if the mode is 'single', then 'baseBranch', 'baseConfig', and 'config' should not be specified as the tool will finish the execution with the error.
+You must specify 'patchBranch' and 'patchConfig' if the mode is 'single', and 'baseBranch', 'baseConfig', 'patchBranch', and 'patchConfig' if the mode is 'diff');
 
 **patchBranch** (p) - name of the branch with your changes (required);
 
@@ -152,7 +75,7 @@ When the script finishes its work the following directory structure will be crea
 
 */reports/diff* - directory with diff reports;
 
-*reports/baseBranch* - directory with Checkstyle reports which are generated with Checkstyle base version (based on specified base branch);
+*reports/baseBranch* - directory with Checkstyle reports which are generated with Checkstyle base version (based on specified base branch. If the mode is 'single', then the directory will not be created.);
 
 *reports/patchBranch* - directory with Checkstyle reports which are generated with Checkstyle version that contains your changes (based on specified patch branch).
 

--- a/checkstyle-tester/StarterRuleSet-AllRulesByCategory.groovy.txt
+++ b/checkstyle-tester/StarterRuleSet-AllRulesByCategory.groovy.txt
@@ -92,7 +92,11 @@ ruleset {
     IfStatementCouldBeTernary
     InvertedIfElse
     LongLiteralWithLowerCaseL
-    NoDef
+
+    // def is commonly used in Groovy, as it provides greater flexibility and readability.
+    // The keywoard removes boilerplate explicit type declaration.
+    // NoDef
+
     NoTabCharacter
     ParameterReassignment
     TernaryCouldBeElvis
@@ -220,7 +224,11 @@ ruleset {
     ExplicitCallToAndMethod
     ExplicitCallToCompareToMethod
     ExplicitCallToDivMethod
-    ExplicitCallToEqualsMethod
+
+    // Groovy's `==` operator which is equivalent to 'equals' method from Java makes code weird to
+    // Java contributors. It is better to use direct call of 'equals' method to compare objects.
+    // ExplicitCallToEqualsMethod
+
     ExplicitCallToGetAtMethod
     ExplicitCallToLeftShiftMethod
     ExplicitCallToMinusMethod


### PR DESCRIPTION
issue #213 

1) Added ability to generate Checkstyle reports for patch branch only with diff.groovy
2) Extended README.md
3) diff.groovy does not have ```-i``` command line option (only launch groovy has), so it was removed from Travis CI yml.

Further refactoring and performance optimization of diff.groovy will be performed in the scope of https://github.com/checkstyle/contribution/issues/182.

diff.groovy should be renamed to reports.groovy or something similar in separate issue.

@rnveach
Maybe we need to have the manual for launch.groovy in a separate file. Do contributors need to know about it from the main REAMDE.md of checkstyle-tester?
