### PR TITLE
Issue #223: changed launch to try cloning multiple times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
         - DESC="codenarc validation for groovy files"
         - CMD1=" cd checkstyle-tester "
         - CMD2=" && ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=21; p3=133)' diff.log"
-        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=23; p3=109)' launch.log"
+        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=23; p3=113)' launch.log"
         - CMD4=" "
         - CMD=$CMD1$CMD2$CMD3$CMD4
     # disable as for now java8 is not supoorted jdk for travis MacOS


### PR DESCRIPTION
Issue #223

Tested locally on a bad URL.

````
$ groovy ./launch.groovy --listOfProjects fail.properties --config checks-nonjavadoc-error.xml
Testing Checkstyle started
Cloning git repository 'BAD' to repositories/BAD folder ...
Cloning into 'repositories/BAD'...
fatal: unable to access 'https://BADCANTRESOLVETHIS.com/google/guava/': Failed to connect to BADCANTRESOLVETHIS.com port 443: Connection timed out
Cloning into 'repositories/BAD'...
fatal: unable to access 'https://BADCANTRESOLVETHIS.com/google/guava/': Failed to connect to BADCANTRESOLVETHIS.com port 443: Connection timed out
Cloning into 'repositories/BAD'...
fatal: unable to access 'https://BADCANTRESOLVETHIS.com/google/guava/': Failed to connect to BADCANTRESOLVETHIS.com port 443: Connection timed out
Cloning into 'repositories/BAD'...
fatal: unable to access 'https://BADCANTRESOLVETHIS.com/google/guava/': Failed to connect to BADCANTRESOLVETHIS.com port 443: Connection refused
Cloning into 'repositories/BAD'...
fatal: unable to access 'https://BADCANTRESOLVETHIS.com/google/guava/': Failed to connect to BADCANTRESOLVETHIS.com port 443: Connection refused
Caught: groovy.lang.GroovyRuntimeException: Error: !
groovy.lang.GroovyRuntimeException: Error: !
	at launch.executeCmdWithRetry(launch.groovy:308)
	at launch.executeCmdWithRetry(launch.groovy:298)
	at launch$executeCmdWithRetry$4.callCurrent(Unknown Source)
	at launch.cloneRepository(launch.groovy:116)
	at launch$_generateCheckstyleReport_closure2.doCall(launch.groovy:82)
	at launch.generateCheckstyleReport(launch.groovy:64)
	at launch$generateCheckstyleReport$1.callCurrent(Unknown Source)
	at launch.run(launch.groovy:10)
$ 
````

groovy doesn't support `do..while` hence why I use `while (true)`.