### PR TITLE
Issue #226: fixed NPE from non-compilable file in patch-diff-report-util

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleConfigurationsParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleConfigurationsParser.java
@@ -145,7 +145,7 @@ public final class CheckstyleConfigurationsParser {
                 }
                 //property tag encounter
                 else if (startElementName.equals(PROPERTY_TAG)) {
-                    processPropertyTag(reader, startElement, parent);
+                    processPropertyTag(startElement, parent);
                 }
             }
             if (event.isEndElement()) {
@@ -191,17 +191,13 @@ public final class CheckstyleConfigurationsParser {
     /**
      * Parses single "property" tag.
      *
-     * @param reader
-     *        StAX parser interface.
      * @param startElement
      *        start element of the tag.
      * @param parent
      *        parent module instance.
-     * @throws XMLStreamException
-     *         on internal StAX failure.
      */
-    private static void processPropertyTag(XMLEventReader reader, StartElement startElement,
-            ConfigurationModule parent) throws XMLStreamException {
+    private static void processPropertyTag(StartElement startElement,
+            ConfigurationModule parent) {
         String propertyName = null;
         String propertyValue = null;
         final Iterator<Attribute> attributes = startElement

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -186,12 +186,10 @@ public final class SiteGenerator {
      *        path to xreference file.
      * @param anchorCounter
      *        anchor links provider.
-     * @throws IOException
-     *         on failure to write data on disk or generate xreference file.
      */
     private static void generateContent(TemplateEngine tplEngine, FileWriter writer,
             List<CheckstyleRecord> records, String filename, String xreference,
-            AnchorCounter anchorCounter) throws IOException {
+            AnchorCounter anchorCounter) {
         final Context context = new Context();
         context.setVariable("filename", filename);
         context.setVariable("records", records);

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -150,11 +150,9 @@ public final class SiteGenerator {
      *        CLI paths.
      * @param xrefGenerator
      *        xReference generator.
-     * @throws IOException
-     *         on failure to write data on disk or generate xreference file.
      */
     private static void generateBody(TemplateEngine tplEngine, FileWriter writer,
-            DiffReport diffReport, CliPaths paths, XrefGenerator xrefGenerator) throws IOException {
+            DiffReport diffReport, CliPaths paths, XrefGenerator xrefGenerator) {
         final AnchorCounter anchorCounter = new AnchorCounter();
 
         final Path refFilesPath = paths.getRefFilesPath();

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
@@ -20,7 +20,6 @@
 package com.github.checkstyle.site;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
@@ -111,16 +110,22 @@ class XrefGenerator {
      * @param shortFilePaths
      *           {@code true} if only short file names should be used with no path.
      * @return relative path to the resulting file.
-     * @throws IOException
-     *         on maven-jxr internal failure.
      */
-    public final String generateXref(String name, boolean shortFilePaths) throws IOException {
+    public final String generateXref(String name, boolean shortFilePaths) {
         final File sourceFile = new File(name);
         final Path dest = getDestinationPath(name, shortFilePaths);
-        codeTransform.transform(sourceFile.getAbsolutePath(),
+        String result;
+        try {
+            codeTransform.transform(sourceFile.getAbsolutePath(),
                 dest.toString(), Locale.ENGLISH,
                 ENCODING, ENCODING, "", "", "");
-        return sitePath.relativize(dest).toString();
+            result = sitePath.relativize(dest).toString();
+        }
+        // -@cs[IllegalCatch] We need to catch all exception from JXR
+        catch (Exception ex) {
+            result = null;
+        }
+        return result;
     }
 
     /**

--- a/patch-diff-report-tool/src/main/resources/content.template
+++ b/patch-diff-report-tool/src/main/resources/content.template
@@ -18,7 +18,10 @@
 								<td th:text = ${record.severity}> Severity </td>
 								<td th:text = ${record.simpleCuttedSourceName}> Rule </td>
 								<td th:text = ${record.message}> Message </td>
-								<td><a th:href = "${xref} + @{#L} + ${record.line}" th:text = ${record.line}> Line </a></td>
+								<th:block th:switch="${xref}">
+									<td th:case = "null" th:text = ${record.line}> Line </td>
+									<td th:case = "*"><a th:href = "${xref} + @{#L} + ${record.line}" th:text = ${record.line}> Line </a></td>
+								</th:block>
 								<th:block th:switch="${record.column}">
 									<td th:case = "-1"> </td>
 									<td th:case = "*" th:text=${record.column}> column </td>

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
@@ -175,6 +175,16 @@ public class MainTest extends AbstractTest {
     }
 
     @Test
+    public void testNonCompilableFile() throws Exception {
+        final File outputDirectory = folder.getRoot();
+
+        Main.main("-patchReport", getPath("InputPatchReportNonCompilable.xml"), "-output",
+                outputDirectory.getAbsolutePath());
+
+        assertReportOutput(getPath("ExpectedReportNonCompilable.html"), outputDirectory);
+    }
+
+    @Test
     public void testConstructor() throws Exception {
         assertUtilsClassHasPrivateConstructor(Main.class);
     }

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html
@@ -258,7 +258,10 @@
 								<td>warning</td>
 								<td>MyTest</td>
 								<td>Should appear only in base.</td>
-								<td><a href = "xref\src\test\resources\run\BaseOnly1.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/BaseOnly1.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>
@@ -286,7 +289,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>File should appear only in base.</td>
-								<td><a href = "xref\src\test\resources\run\BaseOnly2.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/BaseOnly2.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>
@@ -314,7 +320,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line same.</td>
-								<td><a href = "xref\src\test\resources\run\Change1.java.html#L8">8</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change1.java.html#L8">8</a></td>
+								
 								
 									
 									<td>2</td>
@@ -328,7 +337,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in patch but be different from base. Line same.</td>
-								<td><a href = "xref\src\test\resources\run\Change1.java.html#L8">8</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change1.java.html#L8">8</a></td>
+								
 								
 									
 									<td>2</td>
@@ -356,7 +368,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line change.</td>
-								<td><a href = "xref\src\test\resources\run\Change2.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change2.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -370,7 +385,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line change.</td>
-								<td><a href = "xref\src\test\resources\run\Change2.java.html#L11">11</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change2.java.html#L11">11</a></td>
+								
 								
 									
 									<td>1</td>
@@ -398,7 +416,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Column change.</td>
-								<td><a href = "xref\src\test\resources\run\Change3.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change3.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -412,7 +433,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Column change.</td>
-								<td><a href = "xref\src\test\resources\run\Change3.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change3.java.html#L10">10</a></td>
+								
 								
 									
 									<td>5</td>
@@ -440,7 +464,10 @@
 								<td>warning</td>
 								<td>Test1</td>
 								<td>Should appear in base and change in patch. Source change.</td>
-								<td><a href = "xref\src\test\resources\run\Change4.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change4.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -454,7 +481,10 @@
 								<td>warning</td>
 								<td>Test2</td>
 								<td>Should appear in base and change in patch. Source change.</td>
-								<td><a href = "xref\src\test\resources\run\Change4.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change4.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -482,7 +512,10 @@
 								<td>warning</td>
 								<td>MyTest</td>
 								<td>Should appear only in patch.</td>
-								<td><a href = "xref\src\test\resources\run\PatchOnly1.java.html#L7">7</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/PatchOnly1.java.html#L7">7</a></td>
+								
 								
 									
 									<td>1</td>
@@ -510,7 +543,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>File should appear only in patch.</td>
-								<td><a href = "xref\src\test\resources\run\PatchOnly2.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/PatchOnly2.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesRefFiles.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesRefFiles.html
@@ -258,7 +258,10 @@
 								<td>warning</td>
 								<td>MyTest</td>
 								<td>Should appear only in base.</td>
-								<td><a href = "xref\BaseOnly1.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/BaseOnly1.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>
@@ -286,7 +289,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>File should appear only in base.</td>
-								<td><a href = "xref\BaseOnly2.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/BaseOnly2.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>
@@ -314,7 +320,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line same.</td>
-								<td><a href = "xref\Change1.java.html#L8">8</a></td>
+								
+									
+									<td><a href = "xref/Change1.java.html#L8">8</a></td>
+								
 								
 									
 									<td>2</td>
@@ -328,7 +337,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in patch but be different from base. Line same.</td>
-								<td><a href = "xref\Change1.java.html#L8">8</a></td>
+								
+									
+									<td><a href = "xref/Change1.java.html#L8">8</a></td>
+								
 								
 									
 									<td>2</td>
@@ -356,7 +368,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line change.</td>
-								<td><a href = "xref\Change2.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/Change2.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -370,7 +385,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line change.</td>
-								<td><a href = "xref\Change2.java.html#L11">11</a></td>
+								
+									
+									<td><a href = "xref/Change2.java.html#L11">11</a></td>
+								
 								
 									
 									<td>1</td>
@@ -398,7 +416,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Column change.</td>
-								<td><a href = "xref\Change3.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/Change3.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -412,7 +433,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Column change.</td>
-								<td><a href = "xref\Change3.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/Change3.java.html#L10">10</a></td>
+								
 								
 									
 									<td>5</td>
@@ -440,7 +464,10 @@
 								<td>warning</td>
 								<td>Test1</td>
 								<td>Should appear in base and change in patch. Source change.</td>
-								<td><a href = "xref\Change4.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/Change4.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -454,7 +481,10 @@
 								<td>warning</td>
 								<td>Test2</td>
 								<td>Should appear in base and change in patch. Source change.</td>
-								<td><a href = "xref\Change4.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/Change4.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -482,7 +512,10 @@
 								<td>warning</td>
 								<td>MyTest</td>
 								<td>Should appear only in patch.</td>
-								<td><a href = "xref\PatchOnly1.java.html#L7">7</a></td>
+								
+									
+									<td><a href = "xref/PatchOnly1.java.html#L7">7</a></td>
+								
 								
 									
 									<td>1</td>
@@ -510,7 +543,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>File should appear only in patch.</td>
-								<td><a href = "xref\PatchOnly2.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/PatchOnly2.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesShortFilePaths.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesShortFilePaths.html
@@ -258,7 +258,10 @@
 								<td>warning</td>
 								<td>MyTest</td>
 								<td>Should appear only in base.</td>
-								<td><a href = "xref\File1.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/File1.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>
@@ -286,7 +289,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>File should appear only in base.</td>
-								<td><a href = "xref\File2.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/File2.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>
@@ -314,7 +320,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line same.</td>
-								<td><a href = "xref\File3.html#L8">8</a></td>
+								
+									
+									<td><a href = "xref/File3.html#L8">8</a></td>
+								
 								
 									
 									<td>2</td>
@@ -328,7 +337,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in patch but be different from base. Line same.</td>
-								<td><a href = "xref\File3.html#L8">8</a></td>
+								
+									
+									<td><a href = "xref/File3.html#L8">8</a></td>
+								
 								
 									
 									<td>2</td>
@@ -356,7 +368,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line change.</td>
-								<td><a href = "xref\File4.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/File4.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -370,7 +385,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line change.</td>
-								<td><a href = "xref\File4.html#L11">11</a></td>
+								
+									
+									<td><a href = "xref/File4.html#L11">11</a></td>
+								
 								
 									
 									<td>1</td>
@@ -398,7 +416,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Column change.</td>
-								<td><a href = "xref\File5.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/File5.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -412,7 +433,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Column change.</td>
-								<td><a href = "xref\File5.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/File5.html#L10">10</a></td>
+								
 								
 									
 									<td>5</td>
@@ -440,7 +464,10 @@
 								<td>warning</td>
 								<td>Test1</td>
 								<td>Should appear in base and change in patch. Source change.</td>
-								<td><a href = "xref\File6.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/File6.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -454,7 +481,10 @@
 								<td>warning</td>
 								<td>Test2</td>
 								<td>Should appear in base and change in patch. Source change.</td>
-								<td><a href = "xref\File6.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/File6.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -482,7 +512,10 @@
 								<td>warning</td>
 								<td>MyTest</td>
 								<td>Should appear only in patch.</td>
-								<td><a href = "xref\File7.html#L7">7</a></td>
+								
+									
+									<td><a href = "xref/File7.html#L7">7</a></td>
+								
 								
 									
 									<td>1</td>
@@ -510,7 +543,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>File should appear only in patch.</td>
-								<td><a href = "xref\File8.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/File8.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportNonCompilable.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportNonCompilable.html
@@ -24,13 +24,7 @@
 							<th>Files</th>
 							<th>Unique rows</th>
 							
-								<th>Severity-test</th>
-							
 								<th>Severity-warning</th>
-							
-								<th>Severity-error</th>
-							
-								<th>Severity-info</th>
 							
 						</tr>
 						<tr class="b">
@@ -38,55 +32,37 @@
 							<td id="filesBase">0</td>
 							<td id="totalBase">0</td>
 							
-								<td id="testSeverityNumBase">0</td>
-							
 								<td id="warningSeverityNumBase">0</td>
-							
-								<td id="errorSeverityNumBase">0</td>
-							
-								<td id="infoSeverityNumBase">0</td>
 							
 						</tr>
 						<tr class="a">
 							<td>patch</td>
 							<td id="filesPatch">1</td>
-							<td id="totalPatch">4</td>
-							
-								<td id="testSeverityNumPatch">1</td>
+							<td id="totalPatch">1</td>
 							
 								<td id="warningSeverityNumPatch">1</td>
-							
-								<td id="errorSeverityNumPatch">1</td>
-							
-								<td id="infoSeverityNumPatch">1</td>
 							
 						</tr>
 						<tr class="d">
 							<td>difference</td>
 							<td id="filesDiff">1</td>
-							<td id="totalDiff">4</td>
-							
-								<td id="testSeverityNumDiff">1</td>
+							<td id="totalDiff">1</td>
 							
 								<td id="warningSeverityNumDiff">1</td>
-							
-								<td id="errorSeverityNumDiff">1</td>
-							
-								<td id="infoSeverityNumDiff">1</td>
 							
 						<tr>
 					</table>
 
 					<br />
 					Number of unique base messages reported below: <span id="uniqueMessagesBase">0</span><br />
-					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">4</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">1</span><br />
 				</div>
 			</div>
 
 			<div class="section">
 				<h2 a="Unique rows:">Unique rows:</h2>
 				<div class="section">
-					<h3>src/test/resources/run/PatchOnly1.java</h3>
+					<h3>src/test/resources/run/NonCompilable.java</h3>
 					<tr class="b">
 					<table border="0" class="bodyTable">
 					        <th></th>
@@ -101,63 +77,12 @@
 								<tr class="a">
 							
 								<td><a name="A1" href = "#A1">#</a></td>
-								<td>info</td>
-								<td>Test</td>
-								<td>Info.</td>
-								
-									
-									<td><a href = "xref/src/test/resources/run/PatchOnly1.java.html#L1">1</a></td>
-								
-								
-									
-									<td>1</td>
-								
-							</tr>
-						
-							
-								<tr class="a">
-							
-								<td><a name="A2" href = "#A2">#</a></td>
 								<td>warning</td>
-								<td>Test</td>
-								<td>Warning.</td>
+								<td>Source</td>
+								<td>Message.</td>
 								
-									
-									<td><a href = "xref/src/test/resources/run/PatchOnly1.java.html#L1">1</a></td>
-								
-								
-									
 									<td>1</td>
-								
-							</tr>
-						
-							
-								<tr class="a">
-							
-								<td><a name="A3" href = "#A3">#</a></td>
-								<td>error</td>
-								<td>Test</td>
-								<td>Error.</td>
-								
 									
-									<td><a href = "xref/src/test/resources/run/PatchOnly1.java.html#L1">1</a></td>
-								
-								
-									
-									<td>1</td>
-								
-							</tr>
-						
-							
-								<tr class="a">
-							
-								<td><a name="A4" href = "#A4">#</a></td>
-								<td>test</td>
-								<td>Test</td>
-								<td>Test.</td>
-								
-									
-									<td><a href = "xref/src/test/resources/run/PatchOnly1.java.html#L1">1</a></td>
 								
 								
 									

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportPatchOnly.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportPatchOnly.html
@@ -228,7 +228,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in patch but be different from base. Line same.</td>
-								<td><a href = "xref/src/test/resources/run/Change1.java.html#L8">8</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change1.java.html#L8">8</a></td>
+								
 								
 									
 									<td>2</td>
@@ -256,7 +259,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Line change.</td>
-								<td><a href = "xref/src/test/resources/run/Change2.java.html#L11">11</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change2.java.html#L11">11</a></td>
+								
 								
 									
 									<td>1</td>
@@ -284,7 +290,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Should appear in base and change in patch. Column change.</td>
-								<td><a href = "xref/src/test/resources/run/Change3.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change3.java.html#L10">10</a></td>
+								
 								
 									
 									<td>5</td>
@@ -312,7 +321,10 @@
 								<td>warning</td>
 								<td>Test2</td>
 								<td>Should appear in base and change in patch. Source change.</td>
-								<td><a href = "xref/src/test/resources/run/Change4.java.html#L10">10</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Change4.java.html#L10">10</a></td>
+								
 								
 									
 									<td>1</td>
@@ -340,7 +352,10 @@
 								<td>warning</td>
 								<td>MyTest</td>
 								<td>Should appear only in patch.</td>
-								<td><a href = "xref/src/test/resources/run/PatchOnly1.java.html#L7">7</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/PatchOnly1.java.html#L7">7</a></td>
+								
 								
 									
 									<td>1</td>
@@ -368,7 +383,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>File should appear only in patch.</td>
-								<td><a href = "xref/src/test/resources/run/PatchOnly2.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/PatchOnly2.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>
@@ -410,7 +428,10 @@
 								<td>warning</td>
 								<td>Test</td>
 								<td>Same violation.</td>
-								<td><a href = "xref/src/test/resources/run/Same2.java.html#L5">5</a></td>
+								
+									
+									<td><a href = "xref/src/test/resources/run/Same2.java.html#L5">5</a></td>
+								
 								
 									
 									<td>1</td>

--- a/patch-diff-report-tool/src/test/resources/InputPatchReportNonCompilable.xml
+++ b/patch-diff-report-tool/src/test/resources/InputPatchReportNonCompilable.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="9.9-SNAPSHOT">
+  <file name="src/test/resources/run/NonCompilable.java">
+    <error line="1" column="1" severity="warning" message="Message."
+      source="Source"/>
+  </file>
+</checkstyle>

--- a/patch-diff-report-tool/src/test/resources/run/NonCompilable.java
+++ b/patch-diff-report-tool/src/test/resources/run/NonCompilable.java
@@ -1,0 +1,9 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+import ${package}.Application;
+
+public class ApplicationTest {
+}


### PR DESCRIPTION
Minor removes unused exceptions and parameters.

Issue #226
Since the file is non-compilable and the HTML file will be garbage, the report now has no link for the file in question.