### PR TITLE
minor: removed empty files with no violations from patch only report

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffReport.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffReport.java
@@ -75,17 +75,19 @@ public final class DiffReport {
      */
     public void addRecords(List<CheckstyleRecord> newRecords,
             String filename) {
-        final List<CheckstyleRecord> popped =
-            records.put(filename, newRecords);
-        if (popped != null) {
-            final List<CheckstyleRecord> diff =
-                produceDiff(popped, newRecords);
-            if (diff.isEmpty()) {
-                records.remove(filename);
-            }
-            else {
-                Collections.sort(diff, new PositionOrderComparator());
-                records.put(filename, diff);
+        if (!newRecords.isEmpty()) {
+            final List<CheckstyleRecord> popped =
+                records.put(filename, newRecords);
+            if (popped != null) {
+                final List<CheckstyleRecord> diff =
+                    produceDiff(popped, newRecords);
+                if (diff.isEmpty()) {
+                    records.remove(filename);
+                }
+                else {
+                    Collections.sort(diff, new PositionOrderComparator());
+                    records.put(filename, diff);
+                }
             }
         }
     }

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportPatchOnly.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportPatchOnly.html
@@ -179,7 +179,7 @@
 						</tr>
 						<tr class="d">
 							<td>difference</td>
-							<td id="filesDiff">9</td>
+							<td id="filesDiff">7</td>
 							<td id="totalDiff">7</td>
 							
 								<td id="warningSeverityNumDiff">7</td>
@@ -195,20 +195,6 @@
 
 			<div class="section">
 				<h2 a="Unique rows:">Unique rows:</h2>
-				<div class="section">
-					<h3>src/test/resources/run/BaseOnly1.java</h3>
-					<tr class="b">
-					<table border="0" class="bodyTable">
-					        <th></th>
-							<th>Severity</th>
-							<th>Rule</th>
-							<th>Message</th>
-							<th>Line</th>
-							<th>Col</th>
-						</tr>
-						
-					</table>
-				</div>
 				<div class="section">
 					<h3>src/test/resources/run/Change1.java</h3>
 					<tr class="b">
@@ -392,20 +378,6 @@
 									<td>1</td>
 								
 							</tr>
-						
-					</table>
-				</div>
-				<div class="section">
-					<h3>src/test/resources/run/Same1.java</h3>
-					<tr class="b">
-					<table border="0" class="bodyTable">
-					        <th></th>
-							<th>Severity</th>
-							<th>Rule</th>
-							<th>Message</th>
-							<th>Line</th>
-							<th>Col</th>
-						</tr>
 						
 					</table>
 				</div>


### PR DESCRIPTION
Fixed issue where empty files were being displayed in patch only report. This polluted the report with too many headers in a real scenario.
See http://rveach.no-ip.org/checkstyle/regression/reports/30/checkstyle/index.html

Fix ignores files with no violations. Test regression shows it only affects patch only report with less numbers and headers. It doesn't affect the overall file number count.

Will rename commit to reference this pull number.