### PR TITLE
Issue #222: renamed rows to violations in patch-diff-report-tool

### DIFF
--- a/patch-diff-report-tool/src/main/resources/header.template
+++ b/patch-diff-report-tool/src/main/resources/header.template
@@ -81,7 +81,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							<th:block th:each="name : ${statistics.severityNames}">
 								<th th:text="Severity- + ${name}"> infoNumBase </th>
 							</th:block>
@@ -119,4 +119,4 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferences.html
@@ -200,7 +200,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 								<th>Severity-warning</th>
 							
@@ -238,7 +238,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 				<div class="section">
 					<h3>src/test/resources/run/BaseOnly1.java</h3>
 					<tr class="b">

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesRefFiles.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesRefFiles.html
@@ -200,7 +200,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 								<th>Severity-warning</th>
 							
@@ -238,7 +238,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 				<div class="section">
 					<h3>BaseOnly1.java</h3>
 					<tr class="b">

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesShortFilePaths.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportDifferencesShortFilePaths.html
@@ -200,7 +200,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 								<th>Severity-warning</th>
 							
@@ -238,7 +238,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 				<div class="section">
 					<h3>src/test/resources/run/BaseOnly1.java</h3>
 					<tr class="b">

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportEmpty.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportEmpty.html
@@ -22,7 +22,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 						</tr>
 						<tr class="b">
@@ -52,7 +52,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 			</div>
 		</div>
 	</body>

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportEmptyWithConfig.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportEmptyWithConfig.html
@@ -200,7 +200,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 						</tr>
 						<tr class="b">
@@ -230,7 +230,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 			</div>
 		</div>
 	</body>

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportNonCompilable.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportNonCompilable.html
@@ -22,7 +22,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 								<th>Severity-warning</th>
 							
@@ -60,7 +60,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 				<div class="section">
 					<h3>src/test/resources/run/NonCompilable.java</h3>
 					<tr class="b">

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportPatchOnly.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportPatchOnly.html
@@ -156,7 +156,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 								<th>Severity-warning</th>
 							
@@ -194,7 +194,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 				<div class="section">
 					<h3>src/test/resources/run/Change1.java</h3>
 					<tr class="b">

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportSeverities.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportSeverities.html
@@ -22,7 +22,7 @@
 						<tr class="a">
 							<th>Report id</th>
 							<th>Files</th>
-							<th>Unique rows</th>
+							<th>Violations</th>
 							
 								<th>Severity-test</th>
 							
@@ -84,7 +84,7 @@
 			</div>
 
 			<div class="section">
-				<h2 a="Unique rows:">Unique rows:</h2>
+				<h2 a="Violations:">Violations:</h2>
 				<div class="section">
 					<h3>src/test/resources/run/PatchOnly1.java</h3>
 					<tr class="b">


### PR DESCRIPTION
Issue #222

Renamed all `Unique Rows` to `Violations`.