### PR TITLE
minor: removed javadoc link from patch-diff-report xref

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/XrefGenerator.java
@@ -118,7 +118,7 @@ class XrefGenerator {
         try {
             codeTransform.transform(sourceFile.getAbsolutePath(),
                 dest.toString(), Locale.ENGLISH,
-                ENCODING, ENCODING, "", "", "");
+                ENCODING, ENCODING, null, "", "");
             result = sitePath.relativize(dest).toString();
         }
         // -@cs[IllegalCatch] We need to catch all exception from JXR


### PR DESCRIPTION
Removes `View Javadoc` that is always found at the top of the xref view, as it is an invalid link and it never works.

Example:
http://rveach.no-ip.org/checkstyle/regression/reports/30/checkstyle/xref/checkstyle/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/InputVariableDeclarationUsageDistanceCheck.java.html

http://rveach.no-ip.org/checkstyle/regression/reports/30/checkstyle/xref/checkstyle/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/InputVariableDeclarationUsageDistanceCheck.html