### PR TITLE
Issue #243: Fix thymeleaf template to avoid incorrect placement of '\n'

### DIFF
--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -25,6 +25,7 @@
         <tools.jar.version>${java.version}.0</tools.jar.version>
         <tools.jar.path>${java.home}/../lib/tools.jar</tools.jar.path>
         <checkstyle.version>7.8.1</checkstyle.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
@@ -77,6 +78,12 @@
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
             <version>${maven.plugin.javax.mail.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_thymeleaf.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_thymeleaf.template
@@ -3,44 +3,32 @@
       <p>Breaking backward compatibility:</p>
         <ul>
           <li th:each="message : ${breakingMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]
-            <th:block th:if="${message.issueNo} != -1">
-                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
-                + ${message.issueNo}">#[[${message.issueNo}]]</a>
-            </th:block>
+            [[${message.title}]]. Author: [[${message.author}]]<th:block th:if="${message.issueNo} != -1"> <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a></th:block>
           </li>
         </ul></th:block><th:block
       th:if="${not #lists.isEmpty(newMessages)}">
       <p>New:</p>
         <ul>
           <li th:each="message : ${newMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]
-            <th:block th:if="${message.issueNo} != -1">
-                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
-                + ${message.issueNo}">#[[${message.issueNo}]]</a>
-            </th:block>
+            [[${message.title}]]. Author: [[${message.author}]]<th:block th:if="${message.issueNo} != -1"> <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a></th:block>
           </li>
         </ul></th:block><th:block
       th:if="${not #lists.isEmpty(bugMessages)}">
       <p>Bug fixes:</p>
         <ul>
           <li th:each="message : ${bugMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]
-            <th:block th:if="${message.issueNo} != -1">
-                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
-                + ${message.issueNo}">#[[${message.issueNo}]]</a>
-            </th:block>
+            [[${message.title}]]. Author: [[${message.author}]]<th:block th:if="${message.issueNo} != -1"> <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a></th:block>
           </li>
         </ul></th:block><th:block
       th:if="${not #lists.isEmpty(notesMessages)}">
       <p>Notes:</p>
         <ul>
           <li th:each="message : ${notesMessages}" th:inline="text">
-            [[${message.title}]]. Author: [[${message.author}]]
-            <th:block th:if="${message.issueNo} != -1">
-                <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
-                + ${message.issueNo}">#[[${message.issueNo}]]</a>
-            </th:block>
+            [[${message.title}]]. Author: [[${message.author}]]<th:block th:if="${message.issueNo} != -1"> <a th:href="'https://github.com/checkstyle/checkstyle/issues/'
+                + ${message.issueNo}">#[[${message.issueNo}]]</a></th:block>
           </li>
         </ul></th:block>
     </section>

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/TemplateProcessorTest.java
@@ -1,0 +1,181 @@
+package com.github.checkstyle;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.kohsuke.github.GHIssue;
+
+public class TemplateProcessorTest {
+
+    private static TemporaryFolder tmpDir;
+
+    private static final String THYMELEAF_XDOC_TEMPLATE_FILE = "xdoc_thymeleaf.template";
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        tmpDir = new TemporaryFolder();
+        tmpDir.create();
+    }
+
+    @Test
+    public void testGenerateWithThymeleafOnlyBreakingCompatibilitySection() throws Exception{
+        final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("releaseNo", "1.0.0");
+        templateVariables.put("breakingMessages", getMockReleasenotesMessages());
+
+        final File actualNotes = tmpDir.newFile("xdoc1.txt");
+        TemplateProcessor.generateWithThymeleaf(templateVariables, actualNotes.getAbsolutePath(),
+            THYMELEAF_XDOC_TEMPLATE_FILE);
+
+        final String expectedXdoc =
+            getFileContents(getPath("correct_breaking_compatibility_section.txt").toFile());
+        final String actualXdoc = getFileContents(actualNotes);
+
+        assertEquals(expectedXdoc, actualXdoc);
+    }
+
+    @Test
+    public void testGenerateWithThymeleafOnlyNewSection() throws Exception{
+        final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("releaseNo", "1.0.0");
+        templateVariables.put("newMessages", getMockReleasenotesMessages());
+
+        final File actualNotes = tmpDir.newFile("xdoc2.txt");
+        TemplateProcessor.generateWithThymeleaf(templateVariables, actualNotes.getAbsolutePath(),
+            THYMELEAF_XDOC_TEMPLATE_FILE);
+
+        final String expectedXdoc = getFileContents(getPath("correct_new_section.txt").toFile());
+        final String actualXdoc = getFileContents(actualNotes);
+
+        assertEquals(expectedXdoc, actualXdoc);
+    }
+
+    @Test
+    public void testGenerateWithThymeleafOnlyBugSection() throws Exception{
+        final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("releaseNo", "1.0.0");
+        templateVariables.put("bugMessages", getMockReleasenotesMessages());
+
+        final File actualNotes = tmpDir.newFile("xdoc3.txt");
+        TemplateProcessor.generateWithThymeleaf(templateVariables, actualNotes.getAbsolutePath(),
+            THYMELEAF_XDOC_TEMPLATE_FILE);
+
+        final String expectedXdoc = getFileContents(getPath("correct_bug_section.txt").toFile());
+        final String actualXdoc = getFileContents(actualNotes);
+
+        assertEquals(expectedXdoc, actualXdoc);
+    }
+
+    @Test
+    public void testGenerateWithThymeleafOnlyNotesSection() throws Exception{
+        final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("releaseNo", "1.0.0");
+        templateVariables.put("notesMessages", getMockReleasenotesMessages());
+
+        final File actualNotes = tmpDir.newFile("xdoc4.txt");
+        TemplateProcessor.generateWithThymeleaf(templateVariables, actualNotes.getAbsolutePath(),
+            THYMELEAF_XDOC_TEMPLATE_FILE);
+
+        final String expectedXdoc = getFileContents(getPath("correct_notes_section.txt").toFile());
+        final String actualXdoc = getFileContents(actualNotes);
+
+        assertEquals(expectedXdoc, actualXdoc);
+    }
+
+    @Test
+    public void testGenerateWithThymeleafAllSections() throws Exception{
+        final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("releaseNo", "1.0.0");
+        templateVariables.put("breakingMessages", getMockReleasenotesMessages());
+        templateVariables.put("newMessages", getMockReleasenotesMessages());
+        templateVariables.put("bugMessages", getMockReleasenotesMessages());
+        templateVariables.put("notesMessages", getMockReleasenotesMessages());
+
+        final File actualNotes = tmpDir.newFile("xdoc5.txt");
+        TemplateProcessor.generateWithThymeleaf(templateVariables, actualNotes.getAbsolutePath(),
+            THYMELEAF_XDOC_TEMPLATE_FILE);
+
+        final String expectedXdoc = getFileContents(getPath("correct_all_sections.txt").toFile());
+        final String actualXdoc = getFileContents(actualNotes);
+
+        assertEquals(expectedXdoc, actualXdoc);
+    }
+
+    private static List<ReleaseNotesMessage> getMockReleasenotesMessages()
+            throws NoSuchFieldException, IllegalAccessException {
+        final List<ReleaseNotesMessage> messages = new ArrayList<>();
+
+        final ReleaseNotesMessage msgWithoutIssueNo =
+            new ReleaseNotesMessage("Mock issue title 1", "Author 1");
+        messages.add(msgWithoutIssueNo);
+
+        final ReleaseNotesMessage msgWithoutIssueNoWithMultipleAuthors =
+            new ReleaseNotesMessage("Mock issue title 2", "Author 3, Author 4");
+        messages.add(msgWithoutIssueNoWithMultipleAuthors);
+
+        final GHIssue issue1 = getMockGithubIssue(123, "Mock issue title 3");
+        final ReleaseNotesMessage msgWithIssueNo = new ReleaseNotesMessage(issue1, "Author 5");
+        messages.add(msgWithIssueNo);
+
+        final GHIssue issue2 = getMockGithubIssue(123, "Mock issue title 4");
+        final ReleaseNotesMessage msgWithIssueNoWithMultipleAuthors =
+            new ReleaseNotesMessage(issue2, "Author 6, Author 7");
+        messages.add(msgWithIssueNoWithMultipleAuthors);
+
+        return messages;
+    }
+
+    private static GHIssue getMockGithubIssue(int issueNo, String issueTitle)
+        throws IllegalAccessException, NoSuchFieldException {
+        final GHIssue issue = new GHIssue();
+
+        final Field title = issue.getClass().getDeclaredField("title");
+        title.setAccessible(true);
+        title.set(issue, issueTitle);
+
+        final Field number = issue.getClass().getDeclaredField("number");
+        number.setAccessible(true);
+        number.set(issue, issueNo);
+
+        return issue;
+    }
+
+    private static String getFileContents(File file) throws IOException {
+        final StringBuilder result = new StringBuilder();
+
+        try (BufferedReader br = Files.newBufferedReader(file.toPath())) {
+            do {
+                final String line = br.readLine();
+
+                if (line == null) {
+                    break;
+                }
+
+                result.append(line);
+                result.append('\n');
+            } while (true);
+        }
+
+        return result.toString();
+    }
+
+    private static Path getPath(String fileName) {
+        return Paths.get("src/test/resources/com/github/checkstyle/" + fileName)
+            .toAbsolutePath();
+    }
+
+}

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_all_sections.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_all_sections.txt
@@ -1,0 +1,62 @@
+    <section name="Release 1.0.0">
+      <p>Breaking backward compatibility:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+      <p>New:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+      <p>Bug fixes:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+      <p>Notes:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+    </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_breaking_compatibility_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_breaking_compatibility_section.txt
@@ -1,0 +1,17 @@
+    <section name="Release 1.0.0">
+      <p>Breaking backward compatibility:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+    </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_bug_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_bug_section.txt
@@ -1,0 +1,17 @@
+    <section name="Release 1.0.0">
+      <p>Bug fixes:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+    </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_new_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_new_section.txt
@@ -1,0 +1,17 @@
+    <section name="Release 1.0.0">
+      <p>New:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+    </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_notes_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_notes_section.txt
@@ -1,0 +1,17 @@
+    <section name="Release 1.0.0">
+      <p>Notes:</p>
+        <ul>
+          <li>
+            Mock issue title 1. Author: Author 1
+          </li>
+          <li>
+            Mock issue title 2. Author: Author 3, Author 4
+          </li>
+          <li>
+            Mock issue title 3. Author: Author 5 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+          <li>
+            Mock issue title 4. Author: Author 6, Author 7 <a href="https://github.com/checkstyle/checkstyle/issues/123">#123</a>
+          </li>
+        </ul>
+    </section>


### PR DESCRIPTION
issue #243 

Fixed thymeleaft template to have it formatted correct in case freemarker has problems. I'll switch the tool to freemarker in the next PR.

Template looks wired, but works. 