### PR TITLE
Issue #239: added support for full text file compare

### DIFF
--- a/patch-diff-report-tool/config/import-control.xml
+++ b/patch-diff-report-tool/config/import-control.xml
@@ -23,5 +23,6 @@
     </subpackage>
     <subpackage name="parser">
         <allow pkg="javax.xml.stream" />
+        <allow pkg="org.eclipse.jgit.diff" />
     </subpackage>
 </import-control>

--- a/patch-diff-report-tool/pom.xml
+++ b/patch-diff-report-tool/pom.xml
@@ -39,6 +39,11 @@
             <version>3.0.0.BETA02</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>4.7.0.201704051617-r</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/CliArgsValidator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/CliArgsValidator.java
@@ -22,6 +22,7 @@ package com.github.checkstyle;
 import java.nio.file.Files;
 
 import com.github.checkstyle.data.CliPaths;
+import com.github.checkstyle.data.CompareMode;
 
 /**
  * Checker for paths validity.
@@ -47,65 +48,81 @@ public final class CliArgsValidator {
      * Performs file existence checks.
      *
      * @param paths
-     *        POJO holding all input paths.
+     *            POJO holding all input paths.
      * @throws IllegalArgumentException
-     *         on failure of any check.
+     *             on failure of any check.
      */
-    public static void checkPaths(CliPaths paths)
-                    throws IllegalArgumentException {
+    public static void checkPaths(CliPaths paths) throws IllegalArgumentException {
         if (paths.getPatchReportPath() == null) {
             throw new IllegalArgumentException("obligatory argument --patchReportPath "
                     + "not present, -h for help");
-        }
-        if (!Files.isRegularFile(paths.getPatchReportPath())) {
-            throw new IllegalArgumentException("Patch XML Report file doesn't exist: "
-                    + paths.getPatchReportPath());
-        }
-        if (Files.isRegularFile(paths.getOutputPath())) {
-            throw new IllegalArgumentException("Output path is not a directory: "
-                    + paths.getOutputPath());
         }
         if (paths.getRefFilesPath() != null && !Files.isDirectory(paths.getRefFilesPath())) {
             throw new IllegalArgumentException("Ref Files path is not a directory: "
                     + paths.getRefFilesPath());
         }
-        if (paths.getPatchConfigPath() != null
-                && !Files.isRegularFile(paths.getPatchConfigPath())) {
-            throw new IllegalArgumentException(
-                    "Patch checkstyle configuration xml file is missing: "
-                            + paths.getPatchConfigPath());
+        if (Files.isRegularFile(paths.getOutputPath())) {
+            throw new IllegalArgumentException("Output path is not a directory: "
+                    + paths.getOutputPath());
         }
 
-        if (paths.getBaseReportPath() == null) {
-            if (paths.getBaseConfigPath() != null) {
-                throw new IllegalArgumentException("Base checkstyle configuration xml path is "
-                        + "missing while base configuration path is present.");
+        if (paths.getCompareMode() == CompareMode.XML) {
+            if (!Files.isRegularFile(paths.getPatchReportPath())) {
+                throw new IllegalArgumentException("Patch XML Report file doesn't exist: "
+                        + paths.getPatchReportPath());
+            }
+            if (paths.getPatchConfigPath() != null
+                    && !Files.isRegularFile(paths.getPatchConfigPath())) {
+                throw new IllegalArgumentException(
+                        "Patch checkstyle configuration xml file is missing: "
+                                + paths.getPatchConfigPath());
+            }
+            if (paths.getBaseReportPath() == null) {
+                if (paths.getBaseConfigPath() != null) {
+                    throw new IllegalArgumentException("Base checkstyle configuration xml path is "
+                            + "missing while base configuration path is present.");
+                }
+            }
+            else {
+                if (!Files.isRegularFile(paths.getBaseReportPath())) {
+                    throw new IllegalArgumentException("Base XML Report file doesn't exist: "
+                            + paths.getBaseReportPath());
+                }
+                if (paths.getPatchReportPath().equals(paths.getBaseReportPath())) {
+                    throw new IllegalArgumentException(
+                            "Both Base and Patch XML report files have the same path.");
+                }
+                if (paths.getBaseConfigPath() != null && paths.getPatchConfigPath() == null) {
+                    throw new IllegalArgumentException(
+                            "Patch checkstyle configuration xml path is missing while base "
+                                    + "configuration path is present");
+                }
+                if (paths.getPatchConfigPath() != null && paths.getBaseConfigPath() == null) {
+                    throw new IllegalArgumentException(
+                            "Base checkstyle configuration xml path is missing while patch "
+                                    + "configuration path is present");
+                }
+                if (paths.getBaseConfigPath() != null
+                        && !Files.isRegularFile(paths.getBaseConfigPath())) {
+                    throw new IllegalArgumentException(
+                            "Base checkstyle configuration xml file is missing: "
+                                    + paths.getBaseConfigPath());
+                }
             }
         }
         else {
-            if (!Files.isRegularFile(paths.getBaseReportPath())) {
-                throw new IllegalArgumentException("Base XML Report file doesn't exist: "
+            if (paths.getBaseConfigPath() != null || paths.getPatchConfigPath() != null) {
+                throw new IllegalArgumentException(
+                        "Checkstyle configuration xml paths do not need to be present for "
+                                + "text mode.");
+            }
+            if (!Files.isDirectory(paths.getPatchReportPath())) {
+                throw new IllegalArgumentException("Patch Report directory doesn't exist: "
+                        + paths.getPatchReportPath());
+            }
+            if (!Files.isDirectory(paths.getBaseReportPath())) {
+                throw new IllegalArgumentException("Base Report directory doesn't exist: "
                         + paths.getBaseReportPath());
-            }
-            if (paths.getPatchReportPath().equals(paths.getBaseReportPath())) {
-                throw new IllegalArgumentException(
-                        "Both Base and Patch XML report files have the same path.");
-            }
-            if ((paths.getBaseConfigPath() != null) && (paths.getPatchConfigPath() == null)) {
-                throw new IllegalArgumentException(
-                        "Patch checkstyle configuration xml path is missing while base "
-                                + "configuration path is present");
-            }
-            if ((paths.getPatchConfigPath() != null) && (paths.getBaseConfigPath() == null)) {
-                throw new IllegalArgumentException(
-                        "Base checkstyle configuration xml path is missing while patch "
-                                + "configuration path is present");
-            }
-            if (paths.getBaseConfigPath() != null
-                    && !Files.isRegularFile(paths.getBaseConfigPath())) {
-                throw new IllegalArgumentException(
-                        "Base checkstyle configuration xml file is missing: "
-                                + paths.getBaseConfigPath());
             }
         }
     }

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CheckstyleRecord.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CheckstyleRecord.java
@@ -74,6 +74,11 @@ public final class CheckstyleRecord {
     private final String message;
 
     /**
+     * The xref.
+     */
+    private String xref;
+
+    /**
      * POJO ctor.
      *
      * @param index
@@ -86,17 +91,20 @@ public final class CheckstyleRecord {
      *        record severity level.
      * @param source
      *        name of check that generated record.
+     * @param xref
+     *        external file reference.
      * @param message
      *        error message.
      */
     public CheckstyleRecord(int index, int line, int column,
-            String severity, String source, String message) {
+            String severity, String source, String message, String xref) {
         this.index = index;
         this.line = line;
         this.column = column;
         this.severity = severity;
         this.source = source;
         this.message = message;
+        this.xref = xref;
     }
 
     /**
@@ -126,6 +134,14 @@ public final class CheckstyleRecord {
 
     public String getMessageHtml() {
         return StringUtils.escapeXml(message).replace("\n", "<br />\n");
+    }
+
+    public String getXref() {
+        return xref;
+    }
+
+    public void setXref(String xref) {
+        this.xref = xref;
     }
 
     public String getSeverity() {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliPaths.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliPaths.java
@@ -27,6 +27,11 @@ import java.nio.file.Path;
  */
 public final class CliPaths {
     /**
+     * Option to control which type of diff comparison to do.
+     */
+    private final CompareMode compareMode;
+
+    /**
      * Path to the first checkstyle-report.xml.
      */
     private final Path baseReportPath;
@@ -64,6 +69,8 @@ public final class CliPaths {
     /**
      * POJO ctor.
      *
+     * @param compareMode
+     *        type of diff comparison to do.
      * @param baseReportPath
      *        path to the base checkstyle-report.xml.
      * @param patchReportPath
@@ -79,9 +86,11 @@ public final class CliPaths {
      * @param shortFilePaths
      *           {@code true} if only short file names should be used with no paths.
      */
-    public CliPaths(Path baseReportPath, Path patchReportPath,
+    // -@cs[ParameterNumber] Helper class to pass all CLI attributes around.
+    public CliPaths(CompareMode compareMode, Path baseReportPath, Path patchReportPath,
             Path refFilesPath, Path outputPath, Path baseConfigPath, Path patchConfigPath,
             boolean shortFilePaths) {
+        this.compareMode = compareMode;
         this.baseReportPath = baseReportPath;
         this.patchReportPath = patchReportPath;
         this.refFilesPath = refFilesPath;
@@ -89,6 +98,10 @@ public final class CliPaths {
         this.baseConfigPath = baseConfigPath;
         this.patchConfigPath = patchConfigPath;
         this.shortFilePaths = shortFilePaths;
+    }
+
+    public CompareMode getCompareMode() {
+        return compareMode;
     }
 
     public Path getBaseReportPath() {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CompareMode.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CompareMode.java
@@ -1,0 +1,35 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.data;
+
+/**
+ * Different modes for comparison in reporting.
+ *
+ * @author Richard Veach
+ */
+public enum CompareMode {
+    /**
+     * Compare mode where violations are read from an XML file and file and violation attributes are
+     * compared against each other.
+     */
+    XML,
+    /** Compare mode where raw files are read and compared against each other. */
+    TEXT;
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleReportsParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleReportsParser.java
@@ -179,7 +179,8 @@ public final class CheckstyleReportsParser {
                 }
                 //error tag encounter
                 else if (startElementName.equals(ERROR_TAG)) {
-                    records.add(parseErrorTag(startElement, diffReport.getStatistics(), index));
+                    records.add(parseErrorTag(startElement, diffReport.getStatistics(), index,
+                            filename));
                 }
             }
             if (event.isEndElement()) {
@@ -203,10 +204,12 @@ public final class CheckstyleReportsParser {
      *        container accumulating statistics.
      * @param index
      *        internal index of the parsed file.
+     * @param filename
+     *        file name.
      * @return parsed data as CheckstyleRecord instance.
      */
     private static CheckstyleRecord parseErrorTag(StartElement startElement,
-            Statistics statistics, int index) {
+            Statistics statistics, int index, String filename) {
         int line = -1;
         int column = -1;
         String source = null;
@@ -239,7 +242,7 @@ public final class CheckstyleReportsParser {
             }
         }
         return new CheckstyleRecord(index,
-                line, column, severity, source, message);
+                line, column, severity, source, message, filename);
 
     }
 

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
@@ -164,15 +164,25 @@ public final class CheckstyleTextParser {
         while (iterator.hasNext()) {
             final JgitDifference diff = iterator.next();
 
+            final String xref;
+
+            if (diff.getIndex() == BASE_REPORT_INDEX) {
+                xref = baseFile.getPath();
+            }
+            else {
+                xref = patchFile.getPath();
+            }
+
             final CheckstyleRecord record = new CheckstyleRecord(diff.getIndex(),
-                    diff.getLineNo() + 1, 1, DEFAULT_SEVERITY, DEFAULT_SOURCE, diff.getLine());
+                    diff.getLineNo() + 1, 1, DEFAULT_SEVERITY, DEFAULT_SOURCE, diff.getLine(),
+                    xref);
 
             statistics.addSeverityRecord(DEFAULT_SEVERITY, diff.getIndex());
 
             records.add(record);
         }
 
-        diffReport.addRecords(records, baseFile.getPath());
+        diffReport.addRecords(records, filePath);
 
         statistics.incrementFileCount(BASE_REPORT_INDEX);
         statistics.incrementFileCount(PATCH_REPORT_INDEX);
@@ -202,17 +212,20 @@ public final class CheckstyleTextParser {
             otherIndex = BASE_REPORT_INDEX;
         }
 
+        final String filePath = reader.next();
+        final String xref = new File(path.toFile(), filePath).getPath();
+
         final Statistics statistics = diffReport.getStatistics();
         final List<CheckstyleRecord> records = new ArrayList<>();
 
         final CheckstyleRecord record = new CheckstyleRecord(otherIndex, 1, 1, DEFAULT_SEVERITY,
-                DEFAULT_SOURCE, "File not found.");
+                DEFAULT_SOURCE, "File not found.", xref);
 
         statistics.addSeverityRecord(DEFAULT_SEVERITY, otherIndex);
 
         records.add(record);
 
-        diffReport.addRecords(records, new File(path.toFile(), reader.next()).getPath());
+        diffReport.addRecords(records, filePath);
 
         statistics.incrementFileCount(index);
     }

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
@@ -1,0 +1,340 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.parser;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import com.github.checkstyle.data.CheckstyleRecord;
+import com.github.checkstyle.data.DiffReport;
+import com.github.checkstyle.data.Statistics;
+import com.github.checkstyle.parser.JgitUtils.JgitDifference;
+
+/**
+ * Contains logics of the parser for the raw files.
+ *
+ * @author Richard Veach
+ */
+public final class CheckstyleTextParser {
+    /**
+     * Internal index of the base report file.
+     */
+    public static final int BASE_REPORT_INDEX = 1;
+
+    /**
+     * Internal index of the patch report file.
+     */
+    public static final int PATCH_REPORT_INDEX = 2;
+
+    /**
+     * Default severity of any differences.
+     */
+    public static final String DEFAULT_SEVERITY = "difference";
+
+    /**
+     * Default source of any differences.
+     */
+    public static final String DEFAULT_SOURCE = "patch-diff-report-tool";
+
+    /**
+     * Private ctor, see parse method.
+     */
+    private CheckstyleTextParser() {
+    }
+
+    /**
+     * Parses input files: creates 2 parsers which process their files in rotation and try to
+     * compare and write their results to the {@link DiffReport} class.
+     *
+     * @param baseReport
+     *            path to base directory.
+     * @param patchReport
+     *            path to patch directory.
+     * @return parsed content.
+     * @throws IOException
+     *             if there is a problem accessing a file.
+     */
+    public static DiffReport parse(Path baseReport, Path patchReport) throws IOException {
+        final DiffReport content = new DiffReport();
+        final StringListIterator baseReader = getFiles(baseReport);
+        final StringListIterator patchReader = getFiles(patchReport);
+        while (true) {
+            final boolean baseNext = baseReader.hasNext();
+            final boolean patchNext = patchReader.hasNext();
+
+            if (baseNext && patchNext) {
+                parseDifference(content, baseReader, baseReport, patchReader, patchReport);
+            }
+            else if (baseNext != patchNext) {
+                if (baseNext) {
+                    parseDifferenceSingle(content, baseReader, baseReport, BASE_REPORT_INDEX);
+                }
+                else {
+                    parseDifferenceSingle(content, patchReader, patchReport, PATCH_REPORT_INDEX);
+                }
+            }
+            else {
+                break;
+            }
+        }
+        content.getDiffStatistics();
+        return content;
+    }
+
+    /**
+     * Compares the next file in {@code baseReader} and {@code patchReader} and the contents of
+     * those files. File contents are only compared if the files have the same name.
+     *
+     * @param diffReport
+     *            container for parsed data.
+     * @param baseReader
+     *            reader for base file list.
+     * @param baseReport
+     *            path for base files.
+     * @param patchReader
+     *            reader for patch file list.
+     * @param patchReport
+     *            path for patch files.
+     * @throws IOException
+     *             if there is a problem accessing a file.
+     */
+    private static void parseDifference(DiffReport diffReport, StringListIterator baseReader,
+            Path baseReport, StringListIterator patchReader, Path patchReport) throws IOException {
+        final int order = baseReader.peek().compareTo(patchReader.peek());
+
+        if (order == 0) {
+            parseDifferenceFile(diffReport, baseReader.next(), baseReport, patchReport);
+
+            patchReader.next();
+        }
+        else if (order < 0) {
+            parseDifferenceSingle(diffReport, baseReader, baseReport, BASE_REPORT_INDEX);
+        }
+        else {
+            parseDifferenceSingle(diffReport, patchReader, patchReport, PATCH_REPORT_INDEX);
+        }
+    }
+
+    /**
+     * Compares the contents of the files located at {@code fielPath} at {@code baseReport} and
+     * {@code patchReport}.
+     *
+     * @param diffReport
+     *            container for parsed data.
+     * @param filePath
+     *            path for files.
+     * @param baseReport
+     *            path for base files.
+     * @param patchReport
+     *            path for patch files.
+     * @throws IOException
+     *             if there is a problem accessing a file.
+     */
+    private static void parseDifferenceFile(DiffReport diffReport, String filePath,
+            Path baseReport, Path patchReport) throws IOException {
+        final File baseFile = new File(baseReport.toFile(), filePath);
+        final File patchFile = new File(patchReport.toFile(), filePath);
+
+        final Statistics statistics = diffReport.getStatistics();
+        final Iterator<JgitDifference> iterator = JgitUtils.getDifferences(baseFile, patchFile);
+        final List<CheckstyleRecord> records = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            final JgitDifference diff = iterator.next();
+
+            final CheckstyleRecord record = new CheckstyleRecord(diff.getIndex(),
+                    diff.getLineNo() + 1, 1, DEFAULT_SEVERITY, DEFAULT_SOURCE, diff.getLine());
+
+            statistics.addSeverityRecord(DEFAULT_SEVERITY, diff.getIndex());
+
+            records.add(record);
+        }
+
+        diffReport.addRecords(records, baseFile.getPath());
+
+        statistics.incrementFileCount(BASE_REPORT_INDEX);
+        statistics.incrementFileCount(PATCH_REPORT_INDEX);
+    }
+
+    /**
+     * Adds the next file in the {@code reader} as a difference as there is no matching file in the
+     * other side.
+     *
+     * @param diffReport
+     *            container for parsed data.
+     * @param reader
+     *            reader for file list.
+     * @param path
+     *            path for files.
+     * @param index
+     *            internal index of the parsed file.
+     */
+    private static void parseDifferenceSingle(DiffReport diffReport, StringListIterator reader,
+            Path path, int index) {
+        final int otherIndex;
+
+        if (index == BASE_REPORT_INDEX) {
+            otherIndex = PATCH_REPORT_INDEX;
+        }
+        else {
+            otherIndex = BASE_REPORT_INDEX;
+        }
+
+        final Statistics statistics = diffReport.getStatistics();
+        final List<CheckstyleRecord> records = new ArrayList<>();
+
+        final CheckstyleRecord record = new CheckstyleRecord(otherIndex, 1, 1, DEFAULT_SEVERITY,
+                DEFAULT_SOURCE, "File not found.");
+
+        statistics.addSeverityRecord(DEFAULT_SEVERITY, otherIndex);
+
+        records.add(record);
+
+        diffReport.addRecords(records, new File(path.toFile(), reader.next()).getPath());
+
+        statistics.incrementFileCount(index);
+    }
+
+    /**
+     * Retrieves the list of files in the {@code base}.
+     *
+     * @param base
+     *            The base directory to scan.
+     * @return The iterator with the list of files found.
+     * @throws IOException
+     *             if a canonical path can't be retrieved.
+     */
+    private static StringListIterator getFiles(Path base) throws IOException {
+        final List<String> result = new ArrayList<>();
+        final File baseFile = base.toFile();
+
+        getFiles(baseFile, baseFile.getCanonicalPath().length() + 1, result);
+
+        return new StringListIterator(result.iterator());
+    }
+
+    /**
+     * Retrieves the list of files in the {@code base}.
+     *
+     * @param directory
+     *            The directory to scan.
+     * @param baseLength
+     *            The amount to cutoff from the file names.
+     * @param result
+     *            The list of files found.
+     * @throws IOException
+     *             if a canonical path can't be retrieved.
+     */
+    private static void getFiles(File directory, int baseLength, List<String> result)
+            throws IOException {
+        final File[] files = directory.listFiles();
+
+        Arrays.sort(files);
+
+        for (File file : files) {
+            if (file.isDirectory()) {
+                getFiles(file, baseLength, result);
+            }
+            else {
+                result.add(file.getCanonicalPath().substring(baseLength));
+            }
+        }
+    }
+
+    /**
+     * A custom iterator for a list of strings with peek functionality.
+     *
+     * @author Richard Veach
+     */
+    private static final class StringListIterator implements Iterator<String> {
+        /** The wrapped Iterator. */
+        private final Iterator<String> iterator;
+        /** The next item in the iterator, or {@code null} if to use {@link #iterator}. */
+        private String next;
+
+        /**
+         * Default constructor.
+         *
+         * @param iterator
+         *            The iterator to get the results from.
+         */
+        private StringListIterator(Iterator<String> iterator) {
+            this.iterator = iterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            final boolean result;
+
+            if (next != null) {
+                result = true;
+            }
+            else {
+                result = iterator.hasNext();
+            }
+
+            return result;
+        }
+
+        @Override
+        public String next() {
+            final String result;
+
+            if (next != null) {
+                result = next;
+                next = null;
+            }
+            else {
+                result = iterator.next();
+            }
+
+            return result;
+        }
+
+        /**
+         * Check the next element without reading it from the iterator. Returns {@code null} if the
+         * iterator is at the end or has no more elements. A call to this method will be equal to
+         * the next return of {@link #next()}.
+         *
+         * @return The next item.
+         */
+        public String peek() {
+            final String result;
+
+            if (next != null) {
+                result = next;
+            }
+            else if (iterator.hasNext()) {
+                next = iterator.next();
+                result = next;
+            }
+            else {
+                result = null;
+            }
+
+            return result;
+        }
+    }
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/JgitUtils.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/JgitUtils.java
@@ -1,0 +1,232 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.parser;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.eclipse.jgit.diff.DiffAlgorithm;
+import org.eclipse.jgit.diff.DiffAlgorithm.SupportedAlgorithm;
+import org.eclipse.jgit.diff.Edit;
+import org.eclipse.jgit.diff.EditList;
+import org.eclipse.jgit.diff.RawText;
+import org.eclipse.jgit.diff.RawTextComparator;
+
+/**
+ * Utility class for JGit routines.
+ *
+ * @author Richard Veach
+ */
+public final class JgitUtils {
+    /** The cached difference algorithm to use for comparisons. */
+    private static DiffAlgorithm diffAlgorithm;
+
+    /** Private ctor. */
+    private JgitUtils() {
+    }
+
+    /**
+     * Generates the differences between the contents of the 2 files.
+     *
+     * @param baseFile
+     *            The base file to examine.
+     * @param patchFile
+     *            The patch file to examine.
+     * @return The iterator containing the differences.
+     * @throws IOException
+     *             if Exceptions occur while reading the file.
+     */
+    public static Iterator<JgitDifference> getDifferences(File baseFile, File patchFile)
+            throws IOException {
+        if (diffAlgorithm == null) {
+            diffAlgorithm = DiffAlgorithm.getAlgorithm(SupportedAlgorithm.HISTOGRAM);
+        }
+
+        final RawText baseFileRaw = new RawText(baseFile);
+        final RawText patchFileRaw = new RawText(patchFile);
+
+        return new JgitDifferenceIterator(diffAlgorithm.diff(RawTextComparator.DEFAULT,
+                baseFileRaw, patchFileRaw), baseFileRaw, patchFileRaw);
+    }
+
+    /**
+     * Custom iterator to loop through all the differences found by JGit.
+     *
+     * @author Richard Veach
+     */
+    private static final class JgitDifferenceIterator implements Iterator<JgitDifference> {
+        /** Initial position used to denote to do no more processing. */
+        private static final int INITIAL_END_LINE = -2;
+
+        /** The list of base and patch line numbers with differences. */
+        private final EditList edits;
+        /** The raw base file. */
+        private final RawText baseFileRaw;
+        /** The raw patch file. */
+        private final RawText patchFileRaw;
+
+        /** The current difference from {@link #edits}. */
+        private Edit currentEdit;
+        /** The next item in the iterator. */
+        private JgitDifference next;
+
+        /** The current index of {@link #edits}. */
+        private int index = -1;
+        /** The current line number for the base file of the {@link #currentEdit}. */
+        private int baseLineNo = index;
+        /** The max line number for the base file of the {@link #currentEdit}. */
+        private int baseEndLineNo = INITIAL_END_LINE;
+        /** The current line number for the patch file of the {@link #currentEdit}. */
+        private int patchLineNo = baseLineNo;
+        /** The max line number for the patch file of the {@link #currentEdit}. */
+        private int patchEndLineNo = baseEndLineNo;
+
+        /**
+         * Default constructor.
+         *
+         * @param edits
+         *            The list of base and patch line numbers with differences.
+         * @param baseFileRaw
+         *            The raw base file.
+         * @param patchFileRaw
+         *            The raw patch file.
+         */
+        private JgitDifferenceIterator(EditList edits, RawText baseFileRaw, RawText patchFileRaw) {
+            this.edits = edits;
+            this.baseFileRaw = baseFileRaw;
+            this.patchFileRaw = patchFileRaw;
+        }
+
+        @Override
+        public boolean hasNext() {
+            populateNext();
+
+            return next != null;
+        }
+
+        @Override
+        public JgitDifference next() {
+            populateNext();
+
+            final JgitDifference result = next;
+
+            next = null;
+
+            return result;
+        }
+
+        /** Populates the value for {@link #next} to be returned. */
+        private void populateNext() {
+            if (next == null) {
+                nextEdit();
+
+                if (currentEdit != null) {
+                    if (baseLineNo < currentEdit.getEndA()) {
+                        next = new JgitDifference(CheckstyleTextParser.BASE_REPORT_INDEX,
+                                baseLineNo, baseFileRaw.getString(baseLineNo));
+
+                        baseLineNo++;
+                    }
+                    else if (patchLineNo < currentEdit.getEndB()) {
+                        next = new JgitDifference(CheckstyleTextParser.PATCH_REPORT_INDEX,
+                                patchLineNo, patchFileRaw.getString(patchLineNo));
+
+                        patchLineNo++;
+                    }
+                }
+            }
+        }
+
+        /** Sets the next edit with differences to be used. */
+        private void nextEdit() {
+            if (baseLineNo >= baseEndLineNo && patchLineNo >= patchEndLineNo) {
+                index++;
+
+                if (index >= edits.size()) {
+                    currentEdit = null;
+                }
+                else {
+                    currentEdit = edits.get(index);
+
+                    baseLineNo = Math.max(0, currentEdit.getBeginA());
+                    patchLineNo = Math.max(0, currentEdit.getBeginB());
+                    baseEndLineNo = Math.min(baseFileRaw.size(), currentEdit.getEndA());
+                    patchEndLineNo = Math.min(patchFileRaw.size(), currentEdit.getEndB());
+                }
+            }
+        }
+    }
+
+    /**
+     * Class that holds the information of JGit's differences.
+     *
+     * @author Richard Veach
+     */
+    public static final class JgitDifference {
+        /**
+         * Index of the source.
+         */
+        private final int index;
+        /**
+         * Line number of the difference.
+         */
+        private final int lineNo;
+        /**
+         * Contents of the difference.
+         */
+        private final String line;
+
+        /**
+         * Default constructor.
+         *
+         * @param index
+         *            internal index of the source.
+         * @param lineNo
+         *            line number.
+         * @param line
+         *            contents of the line.
+         */
+        private JgitDifference(int index, int lineNo, String line) {
+            this.index = index;
+            this.lineNo = lineNo;
+
+            // truncate line for windows
+            String temp = line;
+            if (temp.endsWith("\r")) {
+                temp = temp.substring(0, temp.length() - 1);
+            }
+
+            this.line = temp;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        public int getLineNo() {
+            return lineNo;
+        }
+
+        public String getLine() {
+            return line;
+        }
+    }
+}

--- a/patch-diff-report-tool/src/main/resources/content.template
+++ b/patch-diff-report-tool/src/main/resources/content.template
@@ -18,9 +18,9 @@
 								<td th:text = ${record.severity}> Severity </td>
 								<td th:text = ${record.simpleCuttedSourceName}> Rule </td>
 								<td th:utext = ${record.messageHtml}> Message </td>
-								<th:block th:switch="${xref}">
+								<th:block th:switch="${record.xref}">
 									<td th:case = "null" th:text = ${record.line}> Line </td>
-									<td th:case = "*"><a th:href = "${xref} + @{#L} + ${record.line}" th:text = ${record.line}> Line </a></td>
+									<td th:case = "*"><a th:href = "${record.xref} + @{#L} + ${record.line}" th:text = ${record.line}> Line </a></td>
 								</th:block>
 								<th:block th:switch="${record.column}">
 									<td th:case = "-1"> </td>

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/CliArgsValidatorTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/CliArgsValidatorTest.java
@@ -160,4 +160,49 @@ public class CliArgsValidatorTest extends AbstractTest {
                     ex.getMessage());
         }
     }
+
+    @Test
+    public void testTextBaseConfigGiven() throws Exception {
+        try {
+            Main.main("-compareMode", "text", "-patchReport", VALID_PATCH_REPORT_EMPTY,
+                    "-baseConfig", "test");
+        }
+        catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Checkstyle configuration xml paths do not need to be present for "
+                    + "text mode.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testTextPatchConfigGiven() throws Exception {
+        try {
+            Main.main("-compareMode", "text", "-patchReport", VALID_PATCH_REPORT_EMPTY,
+                    "-patchConfig", "test");
+        }
+        catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Checkstyle configuration xml paths do not need to be present for "
+                    + "text mode.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testTextInvalidPatchReportPath() throws Exception {
+        try {
+            Main.main("-compareMode", "text", "-patchReport", "test");
+        }
+        catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Patch Report directory doesn't exist: test", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testTextInvalidBaseReportPath() throws Exception {
+        try {
+            Main.main("-compareMode", "text", "-baseReport", "test", "-patchReport",
+                    VALID_PATCH_DIR);
+        }
+        catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Base Report directory doesn't exist: test", ex.getMessage());
+        }
+    }
 }

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
@@ -40,8 +40,7 @@ public class MainTest extends AbstractTest {
                 + "Command line arguments:\n"
                 + "\t--baseReportPath - path to the base checkstyle-result.xml (optional, if "
                 + "absent then only configuration and violations for patch will be in the "
-                + "report)\n"
-                + "\t--patchReportPath - path to the patch checkstyle-result.xml,"
+                + "report)\n" + "\t--patchReportPath - path to the patch checkstyle-result.xml,"
                 + " obligatory argument;\n"
                 + "\t--sourcePath - path to the data under check (optional, if absent"
                 + " then file structure for cross reference files won't be relativized,"
@@ -200,6 +199,16 @@ public class MainTest extends AbstractTest {
 
         Assert.assertEquals(getFileContents(new File(getPath("ExpectedXrefNonCompilable.html"))),
                 getFileContents(xrefFile));
+    }
+
+    @Test
+    public void testTextMode() throws Exception {
+        final File outputDirectory = folder.getRoot();
+
+        Main.main("-compareMode", "text", "-baseReport", VALID_BASE_DIR, "-patchReport",
+                VALID_PATCH_DIR, "-output", outputDirectory.getAbsolutePath());
+
+        assertReportOutput(getPath("ExpectedReportTextMode.html"), outputDirectory);
     }
 
     @Test

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/internal/AbstractTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/internal/AbstractTest.java
@@ -39,6 +39,9 @@ public abstract class AbstractTest {
     protected static final String VALID_PATCH_REPORT_EMPTY = getPath("InputPatchReportEmpty.xml");
     protected static final String VALID_BASE_CONFIG = getPath("InputBaseConfig.xml");
 
+    protected static final String VALID_BASE_DIR = getPath("runText/base");
+    protected static final String VALID_PATCH_DIR = getPath("runText/patch");
+
     protected static final ByteArrayOutputStream OUT_CONTENT = new ByteArrayOutputStream();
 
     @Rule
@@ -117,7 +120,7 @@ public abstract class AbstractTest {
 
                 // fix for different OS runs as file path is printed in OS'
                 // format. Windows prints with '\' and unix prints with '/'.
-                if (line.contains("<a href = ")) {
+                if (line.contains("<a href = ") || (line.contains("<h3>"))) {
                     line = line.replace("\\", "/");
                 }
 

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/parser/CheckstyleTextParserTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/parser/CheckstyleTextParserTest.java
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.parser;
+
+import org.junit.Test;
+
+import com.github.checkstyle.internal.AbstractTest;
+
+public class CheckstyleTextParserTest extends AbstractTest {
+    @Test
+    public void testConstructor() throws Exception {
+        assertUtilsClassHasPrivateConstructor(CheckstyleTextParser.class);
+    }
+}

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/parser/JgitUtilsTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/parser/JgitUtilsTest.java
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.parser;
+
+import org.junit.Test;
+
+import com.github.checkstyle.internal.AbstractTest;
+
+public class JgitUtilsTest extends AbstractTest {
+    @Test
+    public void testConstructor() throws Exception {
+        assertUtilsClassHasPrivateConstructor(JgitUtils.class);
+    }
+}

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportTextMode.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportTextMode.html
@@ -62,7 +62,7 @@
 			<div class="section">
 				<h2 a="Violations:">Violations:</h2>
 				<div class="section">
-					<h3>src/test/resources/runText/base/Change1.txt</h3>
+					<h3>Change1.txt</h3>
 					<tr class="b">
 					<table border="0" class="bodyTable">
 					        <th></th>
@@ -99,7 +99,7 @@
 								<td>Line 1 Different (Patch)</td>
 								
 									
-									<td><a href = "xref/src/test/resources/runText/base/Change1.txt.html#L1">1</a></td>
+									<td><a href = "xref/src/test/resources/runText/patch/Change1.txt.html#L1">1</a></td>
 								
 								
 									
@@ -110,7 +110,7 @@
 					</table>
 				</div>
 				<div class="section">
-					<h3>src/test/resources/runText/base/Change2.txt</h3>
+					<h3>Change2.txt</h3>
 					<tr class="b">
 					<table border="0" class="bodyTable">
 					        <th></th>
@@ -147,7 +147,7 @@
 								<td>Line 2 Different (Patch)</td>
 								
 									
-									<td><a href = "xref/src/test/resources/runText/base/Change2.txt.html#L2">2</a></td>
+									<td><a href = "xref/src/test/resources/runText/patch/Change2.txt.html#L2">2</a></td>
 								
 								
 									
@@ -158,7 +158,7 @@
 					</table>
 				</div>
 				<div class="section">
-					<h3>src/test/resources/runText/base/Change3.txt</h3>
+					<h3>Change3.txt</h3>
 					<tr class="b">
 					<table border="0" class="bodyTable">
 					        <th></th>
@@ -178,7 +178,7 @@
 								<td>Line 2a Different (Patch)</td>
 								
 									
-									<td><a href = "xref/src/test/resources/runText/base/Change3.txt.html#L2">2</a></td>
+									<td><a href = "xref/src/test/resources/runText/patch/Change3.txt.html#L2">2</a></td>
 								
 								
 									
@@ -195,7 +195,7 @@
 								<td>Line 2b Different (Patch)</td>
 								
 									
-									<td><a href = "xref/src/test/resources/runText/base/Change3.txt.html#L3">3</a></td>
+									<td><a href = "xref/src/test/resources/runText/patch/Change3.txt.html#L3">3</a></td>
 								
 								
 									
@@ -206,7 +206,7 @@
 					</table>
 				</div>
 				<div class="section">
-					<h3>src/test/resources/runText/base/Change4.txt</h3>
+					<h3>Change4.txt</h3>
 					<tr class="b">
 					<table border="0" class="bodyTable">
 					        <th></th>
@@ -254,38 +254,7 @@
 					</table>
 				</div>
 				<div class="section">
-					<h3>src/test/resources/runText/base/subdirectory/BaseOnly1.txt</h3>
-					<tr class="b">
-					<table border="0" class="bodyTable">
-					        <th></th>
-							<th>Severity</th>
-							<th>Rule</th>
-							<th>Message</th>
-							<th>Line</th>
-							<th>Col</th>
-						</tr>
-						
-							
-								<tr class="a">
-							
-								<td><a name="A9" href = "#A9">#</a></td>
-								<td>difference</td>
-								<td>patch-diff-report-tool</td>
-								<td>File not found.</td>
-								
-									
-									<td><a href = "xref/src/test/resources/runText/base/subdirectory/BaseOnly1.txt.html#L1">1</a></td>
-								
-								
-									
-									<td>1</td>
-								
-							</tr>
-						
-					</table>
-				</div>
-				<div class="section">
-					<h3>src/test/resources/runText/patch/PatchOnly1.txt</h3>
+					<h3>PatchOnly1.txt</h3>
 					<tr class="b">
 					<table border="0" class="bodyTable">
 					        <th></th>
@@ -299,13 +268,44 @@
 							
 								<tr class="b">
 								
-								<td><a name="A10" href = "#A10">#</a></td>
+								<td><a name="A9" href = "#A9">#</a></td>
 								<td>difference</td>
 								<td>patch-diff-report-tool</td>
 								<td>File not found.</td>
 								
 									
 									<td><a href = "xref/src/test/resources/runText/patch/PatchOnly1.txt.html#L1">1</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+					</table>
+				</div>
+				<div class="section">
+					<h3>subdirectory/BaseOnly1.txt</h3>
+					<tr class="b">
+					<table border="0" class="bodyTable">
+					        <th></th>
+							<th>Severity</th>
+							<th>Rule</th>
+							<th>Message</th>
+							<th>Line</th>
+							<th>Col</th>
+						</tr>
+						
+							
+								<tr class="a">
+							
+								<td><a name="A10" href = "#A10">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>File not found.</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/subdirectory/BaseOnly1.txt.html#L1">1</a></td>
 								
 								
 									

--- a/patch-diff-report-tool/src/test/resources/ExpectedReportTextMode.html
+++ b/patch-diff-report-tool/src/test/resources/ExpectedReportTextMode.html
@@ -1,0 +1,321 @@
+<html>
+	<head>
+		<title>checkstyle xml difference report</title>
+		<style type="text/css" media="all">@import url("./css/maven-base.css");@import url("./css/maven-theme.css"); );</style>
+		<http-equiv http-equiv="Content-Language" content="en"></http-equiv>
+	</head>
+	<body class="composite">
+		<div id="contentBox">
+			<div class="section">
+				<h2 a="Checkstyle XML difference report">Checkstyle XML difference report</h2>
+				This is symmetric difference generated from two checkstyle-result.xml reports. <br/>
+				All matching records from each XML file are deleted, then remaining records are merged into single report. <br>
+		        <a href="https://github.com/checkstyle/contribution/tree/master/patch-diff-report-tool">Utility that generated this report.</a>
+			</div>
+
+			
+
+			<div class="section">
+				<h2 a="Summary:">Summary:</h2>
+				<div class="section">
+					<table border="0" class="bodyTable">
+						<tr class="a">
+							<th>Report id</th>
+							<th>Files</th>
+							<th>Violations</th>
+							
+								<th>Severity-difference</th>
+							
+						</tr>
+						<tr class="b">
+							<td>base</td>
+							<td id="filesBase">6</td>
+							<td id="totalBase">5</td>
+							
+								<td id="differenceSeverityNumBase">5</td>
+							
+						</tr>
+						<tr class="a">
+							<td>patch</td>
+							<td id="filesPatch">6</td>
+							<td id="totalPatch">5</td>
+							
+								<td id="differenceSeverityNumPatch">5</td>
+							
+						</tr>
+						<tr class="d">
+							<td>difference</td>
+							<td id="filesDiff">6</td>
+							<td id="totalDiff">10</td>
+							
+								<td id="differenceSeverityNumDiff">10</td>
+							
+						<tr>
+					</table>
+
+					<br />
+					Number of unique base messages reported below: <span id="uniqueMessagesBase">5</span><br />
+					Number of unique patch messages reported below: <span id="uniqueMessagesPatch">5</span><br />
+				</div>
+			</div>
+
+			<div class="section">
+				<h2 a="Violations:">Violations:</h2>
+				<div class="section">
+					<h3>src/test/resources/runText/base/Change1.txt</h3>
+					<tr class="b">
+					<table border="0" class="bodyTable">
+					        <th></th>
+							<th>Severity</th>
+							<th>Rule</th>
+							<th>Message</th>
+							<th>Line</th>
+							<th>Col</th>
+						</tr>
+						
+							
+								<tr class="b">
+								
+								<td><a name="A1" href = "#A1">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 1 Different (Base)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change1.txt.html#L1">1</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+							
+								<tr class="a">
+							
+								<td><a name="A2" href = "#A2">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 1 Different (Patch)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change1.txt.html#L1">1</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+					</table>
+				</div>
+				<div class="section">
+					<h3>src/test/resources/runText/base/Change2.txt</h3>
+					<tr class="b">
+					<table border="0" class="bodyTable">
+					        <th></th>
+							<th>Severity</th>
+							<th>Rule</th>
+							<th>Message</th>
+							<th>Line</th>
+							<th>Col</th>
+						</tr>
+						
+							
+								<tr class="b">
+								
+								<td><a name="A3" href = "#A3">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 2 Different (Base)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change2.txt.html#L2">2</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+							
+								<tr class="a">
+							
+								<td><a name="A4" href = "#A4">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 2 Different (Patch)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change2.txt.html#L2">2</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+					</table>
+				</div>
+				<div class="section">
+					<h3>src/test/resources/runText/base/Change3.txt</h3>
+					<tr class="b">
+					<table border="0" class="bodyTable">
+					        <th></th>
+							<th>Severity</th>
+							<th>Rule</th>
+							<th>Message</th>
+							<th>Line</th>
+							<th>Col</th>
+						</tr>
+						
+							
+								<tr class="a">
+							
+								<td><a name="A5" href = "#A5">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 2a Different (Patch)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change3.txt.html#L2">2</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+							
+								<tr class="a">
+							
+								<td><a name="A6" href = "#A6">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 2b Different (Patch)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change3.txt.html#L3">3</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+					</table>
+				</div>
+				<div class="section">
+					<h3>src/test/resources/runText/base/Change4.txt</h3>
+					<tr class="b">
+					<table border="0" class="bodyTable">
+					        <th></th>
+							<th>Severity</th>
+							<th>Rule</th>
+							<th>Message</th>
+							<th>Line</th>
+							<th>Col</th>
+						</tr>
+						
+							
+								<tr class="b">
+								
+								<td><a name="A7" href = "#A7">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 1 Different (Base)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change4.txt.html#L1">1</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+							
+								<tr class="b">
+								
+								<td><a name="A8" href = "#A8">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>Line 3 Different (Base)</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/Change4.txt.html#L3">3</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+					</table>
+				</div>
+				<div class="section">
+					<h3>src/test/resources/runText/base/subdirectory/BaseOnly1.txt</h3>
+					<tr class="b">
+					<table border="0" class="bodyTable">
+					        <th></th>
+							<th>Severity</th>
+							<th>Rule</th>
+							<th>Message</th>
+							<th>Line</th>
+							<th>Col</th>
+						</tr>
+						
+							
+								<tr class="a">
+							
+								<td><a name="A9" href = "#A9">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>File not found.</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/base/subdirectory/BaseOnly1.txt.html#L1">1</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+					</table>
+				</div>
+				<div class="section">
+					<h3>src/test/resources/runText/patch/PatchOnly1.txt</h3>
+					<tr class="b">
+					<table border="0" class="bodyTable">
+					        <th></th>
+							<th>Severity</th>
+							<th>Rule</th>
+							<th>Message</th>
+							<th>Line</th>
+							<th>Col</th>
+						</tr>
+						
+							
+								<tr class="b">
+								
+								<td><a name="A10" href = "#A10">#</a></td>
+								<td>difference</td>
+								<td>patch-diff-report-tool</td>
+								<td>File not found.</td>
+								
+									
+									<td><a href = "xref/src/test/resources/runText/patch/PatchOnly1.txt.html#L1">1</a></td>
+								
+								
+									
+									<td>1</td>
+								
+							</tr>
+						
+					</table>
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/patch-diff-report-tool/src/test/resources/runText/base/Change1.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/base/Change1.txt
@@ -1,0 +1,2 @@
+Line 1 Different (Base)
+Line 2 Same

--- a/patch-diff-report-tool/src/test/resources/runText/base/Change2.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/base/Change2.txt
@@ -1,0 +1,3 @@
+Line 1 Same
+Line 2 Different (Base)
+Line 3 Same

--- a/patch-diff-report-tool/src/test/resources/runText/base/Change3.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/base/Change3.txt
@@ -1,0 +1,2 @@
+Line 1 Same
+Line 2 Same

--- a/patch-diff-report-tool/src/test/resources/runText/base/Change4.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/base/Change4.txt
@@ -1,0 +1,3 @@
+Line 1 Different (Base)
+Line 2 Same
+Line 3 Different (Base)

--- a/patch-diff-report-tool/src/test/resources/runText/base/Same1.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/base/Same1.txt
@@ -1,0 +1,1 @@
+Line 1 Same

--- a/patch-diff-report-tool/src/test/resources/runText/base/subdirectory/BaseOnly1.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/base/subdirectory/BaseOnly1.txt
@@ -1,0 +1,1 @@
+Base Only

--- a/patch-diff-report-tool/src/test/resources/runText/patch/Change1.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/patch/Change1.txt
@@ -1,0 +1,2 @@
+Line 1 Different (Patch)
+Line 2 Same

--- a/patch-diff-report-tool/src/test/resources/runText/patch/Change2.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/patch/Change2.txt
@@ -1,0 +1,3 @@
+Line 1 Same
+Line 2 Different (Patch)
+Line 3 Same

--- a/patch-diff-report-tool/src/test/resources/runText/patch/Change3.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/patch/Change3.txt
@@ -1,0 +1,4 @@
+Line 1 Same
+Line 2a Different (Patch)
+Line 2b Different (Patch)
+Line 2 Same

--- a/patch-diff-report-tool/src/test/resources/runText/patch/Change4.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/patch/Change4.txt
@@ -1,0 +1,1 @@
+Line 2 Same

--- a/patch-diff-report-tool/src/test/resources/runText/patch/PatchOnly1.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/patch/PatchOnly1.txt
@@ -1,0 +1,1 @@
+Patch Only

--- a/patch-diff-report-tool/src/test/resources/runText/patch/Same1.txt
+++ b/patch-diff-report-tool/src/test/resources/runText/patch/Same1.txt
@@ -1,0 +1,1 @@
+Line 1 Same


### PR DESCRIPTION
Issue #239 

I split this into 2 commits, since the different files between base and patch is a new thing. In the old report, the base and patch files were the exact same, it was the reports that had different violations.