### PR TITLE
config: enable RequireThis with validateOnlyOverlapping

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -284,11 +284,9 @@
     <module name="ParameterAssignment"/>
     <module name="RequireThis"/>
     <!-- extra config for RequireThis module base of missed regression -->
-    <!-- disabled till NPE is resolved
     <module name="RequireThis">
       <property name="validateOnlyOverlapping" value="false"/>
     </module>
-    -->
     <module name="ReturnCount">
       <property name="maxForVoid" value="0"/>
     </module>

--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -407,7 +407,6 @@
     </module>
     <module name="CommentsIndentation"/>
     <module name="DescendantToken"/>
-    <module name="FileContentsHolder"/>
     <module name="FinalParameters">
       <!--
         we will not use that fanatic validation, extra modifiers pollute a code


### PR DESCRIPTION
We can enable config for `validateOnlyOverlapping` in `RequireThis` based on fix at https://github.com/checkstyle/checkstyle/pull/4859#issuecomment-319543930