### PR TITLE
config: removed maxLineLength in LeftCurlyCheck

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -180,9 +180,7 @@
       <property name="option" value="text"/>
     </module>
     <module name="EmptyCatchBlock"/>
-    <module name="LeftCurly">
-      <property name="maxLineLength" value="100"/>
-    </module>
+    <module name="LeftCurly"/>
     <module name="NeedBraces"/>
     <module name="NeedBraces">
       <property name="tokens" value="LAMBDA"/>


### PR DESCRIPTION
This PR is being created because of a backward breaking change being made in CheckStyle.
PR: checkstyle/checkstyle#4893
Issue: checkstyle/checkstyle#3671

We are breaking multiple APIs in Checkstyle 8 to clean up deprecated methods and such. This removed the deprecated property maxLineLength in LeftCurly as it wasn't doing anything and it's functionality was removed some time ago.