### PR TITLE
launch_diff: upgraded util to not rely on maven plugin

### DIFF
--- a/checkstyle-tester/launch_diff_variables.sh
+++ b/checkstyle-tester/launch_diff_variables.sh
@@ -5,7 +5,6 @@
 # Note: Use full paths
 # ============================================================
 
-MINIMIZE=true
 CONTACTSERVER=true
 
 PULL_REMOTE=pull
@@ -21,9 +20,11 @@ DIFF_JAR=$CONTRIBUTION_DIR/patch-diff-report-tool/target/patch-diff-report-tool-
 REPOSITORIES_DIR=$TESTER_DIR/repositories
 FINAL_RESULTS_DIR=$TESTER_DIR/reports/diff
 
-SITE_SOURCES_DIR=$TESTER_DIR/src/main/java
 SITE_SAVE_MASTER_DIR=$TESTER_DIR/reports/savemaster
 SITE_SAVE_PULL_DIR=$TESTER_DIR/reports/savepull
+
+# to be removed after antlr update
+SITE_SOURCES_DIR=$TESTER_DIR/src/main/java
 SITE_SAVE_REF_DIR=$TESTER_DIR/reports/saverefs
 
 # ============================================================


### PR DESCRIPTION
To show how https://github.com/checkstyle/contribution/issues/273 should be done, I updated my own script to not rely on maven anymore.
It uses the pure Checkstyle CLI with no updates to patch-diff-report-tool needed and not extra dependencies.

* All `install` commands where changed to `package` now.
* `github` support was removed, should just rely on `git`.
* added extra code to prevent switching to `master` as if it was a different branch.
* added branch names and commit ids to final report like groovy scripts.

Here is an example run of the differences for the same PR and config:

Maven: http://rveach.no-ip.org/checkstyle/regression/reports/149/
CLI: http://rveach.no-ip.org/checkstyle/regression/reports/150/

Only real difference is counts for number of files being processed overall. Maven was restricting us to Java only file types while CLI pulls in all files.
No changes in difference reporting. No changes to internal web page acting as interface for user to program.
Slight speed increase as we don't need to copy large quantity of files around (twice) or try to minimize those files. Less output to console too (263kb versus 103kb).

An external change will be needed to switch to using CLI full time. Excludes uses a wildcard match while CLI excludes must be a pattern matching. So all excludes will need to be updated in scope of https://github.com/checkstyle/contribution/issues/273 .