### PR TITLE
Remove deprecated CodeNarc rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ matrix:
       env:
         - DESC="codenarc validation for groovy files"
         - CMD1=" cd checkstyle-tester "
-        - CMD2=" && ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=10; p3=18)' diff.log"
-        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=23; p3=6)' launch.log"
+        - CMD2=" && ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=11; p3=18)' diff.log"
+        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=26; p3=6)' launch.log"
         - CMD4=" "
         - CMD=$CMD1$CMD2$CMD3$CMD4
     # disable as for now java8 is not supoorted jdk for travis MacOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ matrix:
       env:
         - DESC="codenarc validation for groovy files"
         - CMD1=" cd checkstyle-tester "
-        - CMD2=" && ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=11; p3=18)' diff.log"
-        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=26; p3=6)' launch.log"
+        - CMD2=" && ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=8; p3=0)' diff.log"
+        - CMD3=" && ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=20; p3=1)' launch.log"
         - CMD4=" "
         - CMD=$CMD1$CMD2$CMD3$CMD4
     # disable as for now java8 is not supoorted jdk for travis MacOS

--- a/checkstyle-tester/StarterRuleSet-AllRulesByCategory.groovy.txt
+++ b/checkstyle-tester/StarterRuleSet-AllRulesByCategory.groovy.txt
@@ -218,7 +218,6 @@ ruleset {
     GrailsMassAssignment
     GrailsPublicControllerMethod
     GrailsServletContextReference
-    GrailsSessionReference   // DEPRECATED
     GrailsStatelessService
 
     // rulesets/groovyism.xml
@@ -350,7 +349,6 @@ ruleset {
     SerializableClassMustDefineSerialVersionUID
 
     // rulesets/size.xml
-    AbcComplexity   // DEPRECATED: Use the AbcMetric rule instead. Requires the GMetrics jar
     AbcMetric   // Requires the GMetrics jar
     ClassSize
     CrapMetric   // Requires the GMetrics jar and a Cobertura coverage file

--- a/checkstyle-tester/codenarc.sh
+++ b/checkstyle-tester/codenarc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 @Grapes(
-@Grab('org.codenarc:CodeNarc:0.26.0')
+@Grab('org.codenarc:CodeNarc:1.1')
 )
 @GrabExclude('org.codehaus.groovy:groovy-xml')
 import org.codenarc.CodeNarc

--- a/checkstyle-tester/launch.groovy
+++ b/checkstyle-tester/launch.groovy
@@ -1,8 +1,8 @@
+import static java.lang.System.err
+
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.regex.Pattern
-
-import static java.lang.System.err
 
 static void main(String[] args) {
     def cliOptions = getCliOptions(args)
@@ -31,10 +31,10 @@ def areValidCliOptions(options) {
     def listOfProjectsFile = new File(options.listOfProjects)
     def checkstyleCfgFile = new File(options.config)
     if (!listOfProjectsFile.exists()) {
-        err.println "Error: file ${listOfProjectsFile.getName()} does not exist!"
+        err.println "Error: file ${listOfProjectsFile.name} does not exist!"
         valid = false
     } else if (!checkstyleCfgFile.exists()) {
-        err.println "Error: file ${checkstyleCfgFile.getName()} does not exist!"
+        err.println "Error: file ${checkstyleCfgFile.name} does not exist!"
         valid = false
     }
     return valid
@@ -49,12 +49,12 @@ def generateCheckstyleReport(cliOptions) {
     def reportsDir = 'reports'
     createWorkDirsIfNotExist(srcDir, reposDir, reportsDir)
 
-    def REPO_NAME_PARAM_NO = 0
-    def REPO_TYPE_PARAM_NO = 1
-    def REPO_URL_PARAM_NO = 2
-    def REPO_COMMIT_ID_PARAM_NO = 3
-    def REPO_EXCLUDES_PARAM_NO = 4
-    def FULL_PARAM_LIST_SIZE = 5
+    final REPO_NAME_PARAM_NO = 0
+    final REPO_TYPE_PARAM_NO = 1
+    final REPO_URL_PARAM_NO = 2
+    final REPO_COMMIT_ID_PARAM_NO = 3
+    final REPO_EXCLUDES_PARAM_NO = 4
+    final FULL_PARAM_LIST_SIZE = 5
 
     def checkstyleCfg = cliOptions.config
     def ignoreExceptions = cliOptions.ignoreExceptions
@@ -245,12 +245,12 @@ def removeNonReferencedXrefFiles(siteDir) {
 
     Paths.get(getOsSpecificPath("$siteDir", "xref")).toFile().eachFileRecurse {
         fileObj ->
-            def path = fileObj.getPath()
+            def path = fileObj.path
             path = path.substring(path.indexOf("xref"))
             if (isWindows()) {
                 path = path.replace("\\", "/")
             }
-            def fileName = fileObj.getName()
+            def fileName = fileObj.name
             if (fileObj.isFile()
                     && !filesReferencedInReport.contains(path)
                     && 'stylesheet.css' != fileName


### PR DESCRIPTION
Running the latest stable version of CodeNarc (`1.1`) with the StarterRuleSet file caused a couple of errors:

    ERROR: No such rule named [GrailsSessionReference]. . Expression: ruleClass. Values: ruleClass =     
    ERROR: No such rule named [AbcComplexity]. . Expression: ruleClass. Values: ruleClass = null

This PR removes the two deprecated rules, updates the test script with CodeNarc 1.1, and fixes several warnings in the `checkstyle-tester` Groovy scripts.

<sub><sup>Once approved, please use a *normal* GitHub merge (i.e. **NO rebase/squash** merge) to integrate the commit(s) from the branch of this pull request. The changes are broken up into meaningful, [atomic commits](https://www.freshconsulting.com/atomic-commits/), and my branch should already be up-to-date with the latest target branch. If it isn't, or if you'd like me to combine something, please let me know, and I will make the necessary updates as soon as possible. Thank you!</sup></sub>