### PR TITLE
minor: bump guava to 24.0-jre, suppress inspection violation from ResultOfMethodCallIgnored to pass TC CI

### DIFF
--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.plugin.guava.version>18.0</maven.plugin.guava.version>
+        <maven.plugin.guava.version>24.0-jre</maven.plugin.guava.version>
         <maven.plugin.checkstyle.version>2.17</maven.plugin.checkstyle.version>
         <maven.plugin.github-api.version>1.70</maven.plugin.github-api.version>
         <maven.plugin.jgit.version>4.1.0.201509280440-r</maven.plugin.jgit.version>

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
@@ -526,6 +526,7 @@ public final class CliOptions {
         /**
          * Verify options and set defaults.
          * @return new CliOption instance
+         * @noinspection ResultOfMethodCallIgnored
          */
         public CliOptions build() {
             if (endRef == null) {

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
@@ -138,9 +138,10 @@ public final class NotesBuilder {
      * @return a list of commits.
      * @throws IOException if I/O error occurs.
      * @throws GitAPIException if an error occurs when accessing Git API.
+     * @noinspection ResultOfMethodCallIgnored
      */
     private static Set<RevCommit> getCommitsBetweenReferences(String repoPath, String startRef,
-        String endRef) throws IOException, GitAPIException {
+                                                              String endRef) throws IOException, GitAPIException {
 
         final FileRepositoryBuilder builder = new FileRepositoryBuilder();
         final Path path = Paths.get(repoPath);

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
@@ -141,7 +141,7 @@ public final class NotesBuilder {
      * @noinspection ResultOfMethodCallIgnored
      */
     private static Set<RevCommit> getCommitsBetweenReferences(String repoPath, String startRef,
-                                                              String endRef) throws IOException, GitAPIException {
+            String endRef) throws IOException, GitAPIException {
 
         final FileRepositoryBuilder builder = new FileRepositoryBuilder();
         final Path path = Paths.get(repoPath);


### PR DESCRIPTION
TC failres: https://teamcity.jetbrains.com/viewLog.html?buildId=1332069&tab=Inspection&buildTypeId=Checkstyle_ContributionIdeaInspectionsMaster 

```
Result of method call ignored (14)
src/main/java/com/github/checkstyle
 CliOptions.java (13)
537: build() Result of Verify.verifyNotNull() is ignored
539: build() Result of Verify.verifyNotNull() is ignored
540: build() Result of Verify.verifyNotNull() is ignored
543: build() Result of Verify.verifyNotNull() is ignored
547: build() Result of Verify.verifyNotNull() is ignored
548: build() Result of Verify.verifyNotNull() is ignored
550: build() Result of Verify.verifyNotNull() is ignored
551: build() Result of Verify.verifyNotNull() is ignored
556: build() Result of Verify.verifyNotNull() is ignored
560: build() Result of Verify.verifyNotNull() is ignored
561: build() Result of Verify.verifyNotNull() is ignored
565: build() Result of Verify.verifyNotNull() is ignored
568: build() Result of Verify.verifyNotNull() is ignored
 NotesBuilder.java (1)
150: getCommitsBetweenReferences() Result of Verify.verifyNotNull() is ignored
```