### PR TITLE
Issue #282: Replace Cobertura with JaCoCo

### DIFF
--- a/checkstyle-tester/LAUNCH_GROOVY_README.md
+++ b/checkstyle-tester/LAUNCH_GROOVY_README.md
@@ -64,7 +64,7 @@ ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
 To build SNAPSHOT version of `checkstyle` please run in its folder (local git repository):
 
 ```
-mvn clean install -DskipTests -Dcobertura.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
+mvn clean install -DskipTests -Djacoco.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
 ```
 
 **Attention:** 

--- a/checkstyle-tester/README_OLD.md
+++ b/checkstyle-tester/README_OLD.md
@@ -27,7 +27,7 @@ ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
 
 to build SNAPSHOT version of `checkstyle` please run in his repo
 ```
-mvn clean install -DskipTests -Dcobertura.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
+mvn clean install -DskipTests -Djacoco.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
 ```
 
 If you want to validate new check from `sevntu.checkstyle`(https://github.com/sevntu-checkstyle/sevntu.checkstyle) project, 

--- a/checkstyle-tester/launch_diff_antlr.sh
+++ b/checkstyle-tester/launch_diff_antlr.sh
@@ -54,7 +54,7 @@ function parse_arguments {
 }
 
 function mvn_package {
-	mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Dcobertura.skip=true -Dforbiddenapis.skip=true -Dxml.skip=true
+	mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true -Dxml.skip=true
 
 	if [ $? -ne 0 ]; then
 		echo "Maven Package Failed!"

--- a/checkstyle-web-tester/download-nightly.sh
+++ b/checkstyle-web-tester/download-nightly.sh
@@ -35,6 +35,6 @@ else
 	git pull
 fi
 
-mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Dcobertura.skip=true -Dforbiddenapis.skip=true
+mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
 
 sudo -u www-data cp target/checkstyle-*-SNAPSHOT-all.jar $DIR/$FILE

--- a/checkstyle-web-tester/download-sevntu-nightly.sh
+++ b/checkstyle-web-tester/download-sevntu-nightly.sh
@@ -68,6 +68,6 @@ cd $CS_DIR/checkstyle
 
 #############################################
 
-mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Dcobertura.skip=true -Dforbiddenapis.skip=true
+mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
 
 sudo -u www-data cp target/checkstyle-*-SNAPSHOT-all.jar $DIR/$FILE

--- a/checkstyle-web-tester/download-sevntu.sh
+++ b/checkstyle-web-tester/download-sevntu.sh
@@ -73,6 +73,6 @@ cd $CS_DIR/checkstyle
 
 #############################################
 
-mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Dcobertura.skip=true -Dforbiddenapis.skip=true
+mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
 
 sudo -u www-data cp target/checkstyle-*-all.jar $DIR/$FILE

--- a/qulice/README.md
+++ b/qulice/README.md
@@ -11,7 +11,7 @@ We do that because we want to use Qulice's custom checks for Checkstyle.
 
 Build and install Checkstyle:
 ```
-mvn clean install -DskipTests -Dcobertura.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
+mvn clean install -DskipTests -Djacoco.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
 ```
 
 Launch command for testing Checkstyle project against Qulice's custom config:


### PR DESCRIPTION
Issue #282 

There flag `cobertura.skip` has no effect anymore and should be replaced with `jacoco.skip`.