### PR TITLE
Issue #284: Replace Findbugs with Spotbugs

### DIFF
--- a/checkstyle-tester/LAUNCH_GROOVY_README.md
+++ b/checkstyle-tester/LAUNCH_GROOVY_README.md
@@ -64,7 +64,7 @@ ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
 To build SNAPSHOT version of `checkstyle` please run in its folder (local git repository):
 
 ```
-mvn clean install -DskipTests -Djacoco.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
+mvn clean install -DskipTests -Djacoco.skip=true -Dspotbugs.skip=true -Dpmd.skip=true
 ```
 
 **Attention:** 

--- a/checkstyle-tester/README_OLD.md
+++ b/checkstyle-tester/README_OLD.md
@@ -27,7 +27,7 @@ ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
 
 to build SNAPSHOT version of `checkstyle` please run in his repo
 ```
-mvn clean install -DskipTests -Djacoco.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
+mvn clean install -DskipTests -Djacoco.skip=true -Dspotbugs.skip=true -Dpmd.skip=true
 ```
 
 If you want to validate new check from `sevntu.checkstyle`(https://github.com/sevntu-checkstyle/sevntu.checkstyle) project, 

--- a/checkstyle-tester/launch_diff_antlr.sh
+++ b/checkstyle-tester/launch_diff_antlr.sh
@@ -54,7 +54,7 @@ function parse_arguments {
 }
 
 function mvn_package {
-	mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true -Dxml.skip=true
+	mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true -Dxml.skip=true
 
 	if [ $? -ne 0 ]; then
 		echo "Maven Package Failed!"

--- a/checkstyle-tester/projects-for-wercker.properties
+++ b/checkstyle-tester/projects-for-wercker.properties
@@ -13,7 +13,7 @@ guava|git|https://github.com/google/guava|v18.0||
 
 #hibernate-orm|git|https://github.com/hibernate/hibernate-orm|4.2.19.Final|**/hibernate-orm/documentation/**/*
 
-#findbugs|git|https://github.com/findbugsproject/findbugs|3.0.1||
+#spotbugs|git|https://github.com/spotbugs/spotbugs|3.1.2||
 
 #spring-framework|git|https://github.com/spring-projects/spring-framework|v4.1.6.RELEASE||
 

--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -13,7 +13,7 @@
 #openjdk9|hg|http://hg.openjdk.java.net/jdk9/jdk9/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java,**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
 guava|git|https://github.com/google/guava|v18.0||
 
-#findbugs|git|https://github.com/findbugsproject/findbugs|3.0.1||
+#spotbugs|git|https://github.com/spotbugs/spotbugs|3.1.2||
 #pmd|git|https://github.com/pmd/pmd|pmd_releases/5.3.0|**/pmd/pmd-java/src/test/**/*
 #lombok-ast|git|https://github.com/rzwitserloot/lombok.ast|v0.2|**/lombok-ast/test/**/*
 
@@ -41,7 +41,7 @@ guava|git|https://github.com/google/guava|v18.0||
 # Few projects with excludes to decrease a number of checked files (usefull for some checks which specify overly strong code style policy)
 #checkstyle-with-excludes|git|https://github.com/checkstyle/checkstyle.git|master|**/checkstyle-with-excludes/src/test/**/*,**/checkstyle-with-excludes/src/it/resources/**/*,**/resources-noncompilable/**/*
 #sevntu-checkstyle-with-excludes|git|https://github.com/sevntu-checkstyle/sevntu.checkstyle|master|**/sevntu-checkstyle-with-excludes/sevntu-checks/src/test/**/*
-#findbugs-with-excldues|git|https://github.com/findbugsproject/findbugs|3.0.1|**/findbugs-with-excldues/eclipsePlugin-test/**/*,**/findbugs-with-excldues/findbugsTestCases/**/*,**/findbugs-with-excldues/JSR305-testCases/**/*,**/findbugs-with-excldues/findbugsTestCasesOS/**/*
+#spotbugs-with-excldues|git|https://github.com/spotbugs/spotbugs|3.1.2|**/spotbugs-with-excldues/eclipsePlugin-test/**/*,**/spotbugs-with-excldues/spotbugsTestCases/**/*,**/spotbugs-with-excldues/JSR305-testCases/**/*
 #hibernate-orm-with-excludes|git|https://github.com/hibernate/hibernate-orm|4.2.19.Final|**/hibernate-orm-with-excludes/documentation/**/*,**/hibernate-orm-with-excludes/**/src/test/**/*
 
 # Guava with excldues to generate reports only for those files which are not excluded in Guava's pom.xml for checkstyle-maven-plugin

--- a/checkstyle-web-tester/download-nightly.sh
+++ b/checkstyle-web-tester/download-nightly.sh
@@ -35,6 +35,6 @@ else
 	git pull
 fi
 
-mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
+mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
 
 sudo -u www-data cp target/checkstyle-*-SNAPSHOT-all.jar $DIR/$FILE

--- a/checkstyle-web-tester/download-sevntu-nightly.sh
+++ b/checkstyle-web-tester/download-sevntu-nightly.sh
@@ -68,6 +68,6 @@ cd $CS_DIR/checkstyle
 
 #############################################
 
-mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
+mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
 
 sudo -u www-data cp target/checkstyle-*-SNAPSHOT-all.jar $DIR/$FILE

--- a/checkstyle-web-tester/download-sevntu.sh
+++ b/checkstyle-web-tester/download-sevntu.sh
@@ -73,6 +73,6 @@ cd $CS_DIR/checkstyle
 
 #############################################
 
-mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dfindbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
+mvn --batch-mode clean package -Passembly -Dmaven.test.skip=true -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dforbiddenapis.skip=true
 
 sudo -u www-data cp target/checkstyle-*-all.jar $DIR/$FILE

--- a/qulice/README.md
+++ b/qulice/README.md
@@ -11,7 +11,7 @@ We do that because we want to use Qulice's custom checks for Checkstyle.
 
 Build and install Checkstyle:
 ```
-mvn clean install -DskipTests -Djacoco.skip=true -Dfindbugs.skip=true -Dpmd.skip=true
+mvn clean install -DskipTests -Djacoco.skip=true -Dspotbugs.skip=true -Dpmd.skip=true
 ```
 
 Launch command for testing Checkstyle project against Qulice's custom config:

--- a/qulice/projects-to-test-on.properties
+++ b/qulice/projects-to-test-on.properties
@@ -9,7 +9,7 @@ checkstyle|github|checkstyle/checkstyle|master|**/checkstyle/src/test/**/*,**/ch
 #openjdk|hg|http://hg.openjdk.java.net/jdk7/jdk7/jdk/
 #guava|github|google/guava|v18.0
 
-#findbugs|git|https://code.google.com/p/findbugs/|3.0.1
+#spotbugs|git|https://code.google.com/p/spotbugs/|3.1.2
 #pmd|github|pmd/pmd|pmd_releases/5.3.0|**/pmd/pmd-java/src/test/**/*
 #lombok-ast|github|rzwitserloot/lombok.ast|v0.2|**/lombok-ast/test/**/*
 


### PR DESCRIPTION
Issue #284

Flag `findbugs.skip` replaced with `spotbugs.skip`.
Finbugs repo in the congif file projects-to-test-on.properties replaced with Spotbugs.