### PR TITLE
Issue #286: fix for crash on incorrect Revert

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
@@ -88,6 +88,7 @@ public final class NotesBuilder {
         for (RevCommit commit : commitsForRelease) {
             String commitMessage = commit.getFullMessage();
             if (isRevertCommit(commitMessage)) {
+                System.out.println(commitMessage);
                 final int firstQuoteIndex = commitMessage.indexOf('"');
                 final int lastQuoteIndex = commitMessage.lastIndexOf('"');
                 commitMessage = commitMessage.substring(firstQuoteIndex, lastQuoteIndex);
@@ -163,7 +164,9 @@ public final class NotesBuilder {
      * @return true if a commit message starts with the 'Revert' word.
      */
     private static boolean isRevertCommit(String commitMessage) {
-        return commitMessage.startsWith("Revert");
+        return commitMessage.startsWith("Revert")
+                && commitMessage.indexOf('"') != -1
+                && commitMessage.lastIndexOf('"') == commitMessage.length() - 1;
     }
 
     /**


### PR DESCRIPTION
issue #286

result will be 
```
Notes:

  Revert config: bump pmd plugin to 3.9.0 version
  Drop findbugs
  Replace java.awt.event.InputEvent#getModifiers() with getModifiersEx()

```