### PR TITLE
config: Add jdk10 repo to projects-to-test-on.properties

### DIFF
--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -11,6 +11,7 @@
 #openjdk8|hg|http://hg.openjdk.java.net/jdk8/jdk8/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java
 #All details at checkstyle/checkstyle#3033: TypeUseTarget till checkstyle/checkstyle#3238 ; ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
 #openjdk9|hg|http://hg.openjdk.java.net/jdk9/jdk9/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java,**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
+#openjdk10|hg|http://hg.openjdk.java.net/jdk10/jdk10/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
 guava|git|https://github.com/google/guava|v18.0||
 
 #spotbugs|git|https://github.com/spotbugs/spotbugs|3.1.2||


### PR DESCRIPTION
Since JDK10 is released, we need to start using it for regression testing.