### PR TITLE
Issue #309: allow remote repository path variable in freemarker

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
@@ -161,10 +161,11 @@ public final class Main {
     private static void runPostGeneration(Multimap<String, ReleaseNotesMessage> releaseNotes,
             CliOptions cliOptions) throws IOException, TemplateException {
 
+        final String remoteRepoPath = cliOptions.getRemoteRepoPath();
         final String releaseNumber = cliOptions.getReleaseNumber();
         final String outputLocation = cliOptions.getOutputLocation();
-        final Map<String, Object> templateVariables =
-                TemplateProcessor.getTemplateVariables(releaseNotes, releaseNumber);
+        final Map<String, Object> templateVariables = TemplateProcessor.getTemplateVariables(
+                releaseNotes, releaseNumber, remoteRepoPath);
 
         if (cliOptions.isGenerateAll() || cliOptions.isGenerateXdoc()) {
             TemplateProcessor.generateWithFreemarker(templateVariables,

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/TemplateProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/TemplateProcessor.java
@@ -75,13 +75,16 @@ public final class TemplateProcessor {
     /**
      * Returns the map which represents template variables.
      * @param releaseNotes release notes map.
+     * @param remoteRepoPath remote repository path.
      * @param releaseNumber release number.
      * @return the map which represents template variables.
      */
     public static Map<String, Object> getTemplateVariables(
-        Multimap<String, ReleaseNotesMessage> releaseNotes, String releaseNumber) {
+            Multimap<String, ReleaseNotesMessage> releaseNotes, String remoteRepoPath,
+            String releaseNumber) {
 
         final Map<String, Object> variables = new HashMap<>();
+        variables.put("remoteRepoPath", remoteRepoPath);
         variables.put("releaseNo", releaseNumber);
         variables.put("breakingMessages", releaseNotes.get(Constants.BREAKING_COMPATIBILITY_LABEL));
 

--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
@@ -5,7 +5,7 @@
         <ul>
         <#list breakingMessages as message>
           <li>
-            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/checkstyle/checkstyle/issues/${message.issueNo}">#${message.issueNo}</a></#if>
+            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/${remoteRepoPath}/issues/${message.issueNo}">#${message.issueNo}</a></#if>
           </li>
         </#list>
         </ul>
@@ -15,7 +15,7 @@
         <ul>
           <#list newMessages as message>
           <li>
-            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/checkstyle/checkstyle/issues/${message.issueNo}">#${message.issueNo}</a></#if>
+            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/${remoteRepoPath}/issues/${message.issueNo}">#${message.issueNo}</a></#if>
           </li>
           </#list>
         </ul>
@@ -25,7 +25,7 @@
         <ul>
           <#list bugMessages as message>
           <li>
-            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/checkstyle/checkstyle/issues/${message.issueNo}">#${message.issueNo}</a></#if>
+            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/${remoteRepoPath}/issues/${message.issueNo}">#${message.issueNo}</a></#if>
           </li>
           </#list>
         </ul>
@@ -35,7 +35,7 @@
         <ul>
           <#list notesMessages as message>
           <li>
-            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/checkstyle/checkstyle/issues/${message.issueNo}">#${message.issueNo}</a></#if>
+            ${message.title}. Author: ${message.author}<#if message.issueNo != -1> <a href="https://github.com/${remoteRepoPath}/issues/${message.issueNo}">#${message.issueNo}</a></#if>
           </li>
           </#list>
         </ul>

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/TemplateProcessorTest.java
@@ -53,6 +53,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyBreakingCompatibilitySection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("breakingMessages", getMockReleasenotesMessages());
 
@@ -70,6 +71,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyNewSection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("newMessages", getMockReleasenotesMessages());
 
@@ -86,6 +88,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyBugSection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("bugMessages", getMockReleasenotesMessages());
 
@@ -102,6 +105,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyNotesSection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("notesMessages", getMockReleasenotesMessages());
 
@@ -118,6 +122,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerAllSections() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("breakingMessages", getMockReleasenotesMessages());
         templateVariables.put("newMessages", getMockReleasenotesMessages());


### PR DESCRIPTION
Issue #309

It is a required field, so we should allow it to be used in templates.