### PR TITLE
Issue #289: fix revert commit detection for releasenotes

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/NotesBuilder.java
@@ -166,7 +166,7 @@ public final class NotesBuilder {
     private static boolean isRevertCommit(String commitMessage) {
         return commitMessage.startsWith("Revert")
                 && commitMessage.indexOf('"') != -1
-                && commitMessage.lastIndexOf('"') == commitMessage.length() - 1;
+                && commitMessage.lastIndexOf('"', commitMessage.lastIndexOf('"') + 1) != -1;
     }
 
     /**


### PR DESCRIPTION
Issue #289 .

Changed detection from `"` on end of commit message to just having 2 `"`.

Verified locally with `-localRepoPath M:\checkstyleWorkspace\checkstyle -remoteRepoPath checkstyle/checkstyle -startRef checkstyle-8.8 -endRef checkstyle-8.9 -releaseNumber 8.9 -generateXdoc`.