### PR TITLE
Issue #320: add todaysDate variable to releasenotes

### DIFF
--- a/releasenotes-builder/config/import-control.xml
+++ b/releasenotes-builder/config/import-control.xml
@@ -7,6 +7,7 @@
     <allow pkg="java.io"/>
     <allow pkg="java.net"/>
     <allow pkg="java.nio"/>
+    <allow pkg="java.text"/>
     <allow pkg="java.util"/>
     <allow pkg="org.apache.commons.cli"/>
     <allow pkg="org.apache.commons.lang"/>

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/TemplateProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/TemplateProcessor.java
@@ -24,7 +24,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -88,6 +90,8 @@ public final class TemplateProcessor {
             String releaseNumber) {
 
         final Map<String, Object> variables = new HashMap<>();
+        variables.put("todaysDate",
+                new SimpleDateFormat("dd.MM.yyyy", Locale.US).format(new Date()));
         variables.put("remoteRepoPath", remoteRepoPath);
         variables.put("releaseNo", releaseNumber);
         variables.put("breakingMessages", releaseNotes.get(Constants.BREAKING_COMPATIBILITY_LABEL));

--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
@@ -1,4 +1,5 @@
   <#escape x as x?html>
+    <div class="releaseDate">${todaysDate}</div>
     <section name="Release ${releaseNo}">
       <#if breakingMessages?has_content>
       <p>Breaking backward compatibility:</p>

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/TemplateProcessorTest.java
@@ -57,6 +57,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyBreakingCompatibilitySection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("todaysDate", "XX.XX.XXXX");
         templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("breakingMessages", getMockReleasenotesMessages());
@@ -75,6 +76,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyNewSection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("todaysDate", "XX.XX.XXXX");
         templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("newMessages", getMockReleasenotesMessages());
@@ -92,6 +94,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyBugSection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("todaysDate", "XX.XX.XXXX");
         templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("bugMessages", getMockReleasenotesMessages());
@@ -109,6 +112,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerOnlyNotesSection() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("todaysDate", "XX.XX.XXXX");
         templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("notesMessages", getMockReleasenotesMessages());
@@ -126,6 +130,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateWithFreemarkerAllSections() throws Exception {
         final Map<String, Object> templateVariables = new HashMap<>();
+        templateVariables.put("todaysDate", "XX.XX.XXXX");
         templateVariables.put("remoteRepoPath", "checkstyle/checkstyle");
         templateVariables.put("releaseNo", "1.0.0");
         templateVariables.put("breakingMessages", getMockReleasenotesMessages());

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_all_sections.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_all_sections.txt
@@ -1,4 +1,5 @@
   
+    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
       <p>Breaking backward compatibility:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_breaking_compatibility_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_breaking_compatibility_section.txt
@@ -1,4 +1,5 @@
   
+    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
       <p>Breaking backward compatibility:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_bug_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_bug_section.txt
@@ -1,4 +1,5 @@
   
+    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
       <p>Bug fixes:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_new_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_new_section.txt
@@ -1,4 +1,5 @@
   
+    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
       <p>New:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_notes_section.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/correct_notes_section.txt
@@ -1,4 +1,5 @@
   
+    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
       <p>Notes:</p>
         <ul>


### PR DESCRIPTION
Issue #320

Patch to main repo:
````
diff --git a/src/site/resources/css/site.css b/src/site/resources/css/site.css
index f77781f..da6cf05 100644
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -62,3 +62,7 @@
   white-space: -o-pre-wrap !important;
   word-wrap: break-word !important;
 }
+
+.releaseDate {
+  float: right;
+}
diff --git a/src/xdocs/releasenotes.xml b/src/xdocs/releasenotes.xml
index 68da3d0..b80cf9c 100644
--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -16,6 +16,7 @@
   <body>
     <!-- placeholder for a new section -->
 
+    <div class="releaseDate">7/2/2018</div>
     <section name="Release 8.11">
       <p>Breaking backward compatibility:</p>
         <ul>
@@ -91,6 +92,7 @@
         </ul>
     </section>
 
+    <div class="releaseDate">7/1/2018</div>
     <section name="Release 8.10.1">
       <p>Bug fixes:</p>
         <ul>

````

![notes1](https://user-images.githubusercontent.com/5427943/42193540-7e61208e-7e5e-11e8-9831-caa23726fb3e.png)
![notes2](https://user-images.githubusercontent.com/5427943/42193541-7e823a1c-7e5e-11e8-9718-14e22607e13b.png)

Any changes to display can be fixed in main repo with CSS.