### PR TITLE
config: upgraded sevntu-checkstyle-maven-plugin to 1.30.0

### DIFF
--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -13,7 +13,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<checkstyle-plugin.version>2.17</checkstyle-plugin.version>
 		<checkstyle.version>8.12-SNAPSHOT</checkstyle.version>
-		<sevntu-checkstyle.version>1.29.0</sevntu-checkstyle.version>
+		<sevntu-checkstyle.version>1.30.0</sevntu-checkstyle.version>
 		<jxr-plugin.version>2.5</jxr-plugin.version>
 		<checkstyle.config.location>https://raw.githubusercontent.com/checkstyle/checkstyle/master/src/main/resources/google_checks.xml</checkstyle.config.location>
 		<checkstyle.failsOnError>true</checkstyle.failsOnError>


### PR DESCRIPTION
Identified at https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/709#issuecomment-408118508 ,

> wercker
org.eclipse.aether.resolution.ArtifactResolutionException: Failure to find com.github.sevntu-checkstyle:sevntu-checkstyle-maven-plugin:jar:1.30.0