### PR TITLE
doc: move the release date div inside the section to generate valid markup

### DIFF
--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
@@ -1,6 +1,6 @@
   <#escape x as x?html>
-    <div class="releaseDate">${todaysDate}</div>
     <section name="Release ${releaseNo}">
+      <div class="releaseDate">${todaysDate}</div>
       <#if breakingMessages?has_content>
       <p>Breaking backward compatibility:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
@@ -1,6 +1,6 @@
   
-    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
+      <div class="releaseDate">XX.XX.XXXX</div>
       <p>Breaking backward compatibility:</p>
         <ul>
           <li>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
@@ -1,6 +1,6 @@
   
-    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
+      <div class="releaseDate">XX.XX.XXXX</div>
       <p>Breaking backward compatibility:</p>
         <ul>
           <li>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -1,6 +1,6 @@
   
-    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
+      <div class="releaseDate">XX.XX.XXXX</div>
       <p>Bug fixes:</p>
         <ul>
           <li>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -1,6 +1,6 @@
   
-    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
+      <div class="releaseDate">XX.XX.XXXX</div>
       <p>Notes:</p>
         <ul>
           <li>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
@@ -1,6 +1,6 @@
   
-    <div class="releaseDate">XX.XX.XXXX</div>
     <section name="Release 1.0.0">
+      <div class="releaseDate">XX.XX.XXXX</div>
       <p>New:</p>
         <ul>
           <li>


### PR DESCRIPTION
This is a follow-up fix for https://github.com/checkstyle/checkstyle/pull/6514#discussion_r262939233 where the results of the generated text had to be changed to make the site files pass validation.