### PR TITLE
checkstyle-tester: do not fail if analysed project does not contain Java files because no report is present then

### DIFF
--- a/checkstyle-tester/launch.groovy
+++ b/checkstyle-tester/launch.groovy
@@ -259,23 +259,26 @@ def removeNonReferencedXrefFiles(siteDir) {
     def linesFromIndexHtml = Files.readAllLines(Paths.get("$siteDir/index.html"))
     def filesReferencedInReport = getFilesReferencedInReport(linesFromIndexHtml)
 
-    Paths.get(getOsSpecificPath("$siteDir", "xref")).toFile().eachFileRecurse {
-        fileObj ->
-            def path = fileObj.path
-            path = path.substring(path.indexOf("xref"))
-            if (isWindows()) {
-                path = path.replace("\\", "/")
-            }
-            def fileName = fileObj.name
-            if (fileObj.isFile()
+    def xrefPath = Paths.get(getOsSpecificPath("$siteDir", "xref"))
+    if (Files.isDirectory(xrefPath)) {
+        xrefPath.toFile().eachFileRecurse {
+            fileObj ->
+                def path = fileObj.path
+                path = path.substring(path.indexOf("xref"))
+                if (isWindows()) {
+                    path = path.replace("\\", "/")
+                }
+                def fileName = fileObj.name
+                if (fileObj.isFile()
                     && !filesReferencedInReport.contains(path)
                     && 'stylesheet.css' != fileName
                     && 'allclasses-frame.html' != fileName
                     && 'index.html' != fileName
                     && 'overview-frame.html' != fileName
                     && 'overview-summary.html' != fileName) {
-                fileObj.delete()
-            }
+                    fileObj.delete()
+                }
+        }
     }
 }
 


### PR DESCRIPTION
When I batch-added all my 170 locally available projects, there were some without Java files.
For those no report was generated and then the removeNonReferencedXrefFiles step failed with FileNotFoundException.
With this change, this is simply ignored.