### PR TITLE
Report Diff Summary Improvements

### DIFF
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -307,6 +307,8 @@ def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstyl
     summaryIndexHtml << ('<br />')
     summaryIndexHtml << ('<br />')
     summaryIndexHtml << "Tested projects: ${projectsStatistic.size()}"
+    summaryIndexHtml << ('<br />')
+    summaryIndexHtml << "Total differences found: ${projectsStatistic.values().sum()}"
     summaryIndexHtml << ('</h6>')
 }
 

--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -264,7 +264,9 @@ def generateSummaryIndexHtml(diffDir, checkstyleBaseReportInfo, checkstylePatchR
     def projectsStatistic = getProjectsStatistic(diffDir)
     def summaryIndexHtml = new File("$diffDir/index.html")
 
-    summaryIndexHtml << ('<html><body>')
+    summaryIndexHtml << ('<html><head>')
+    summaryIndexHtml << ('<title>Checkstyle Tester Report Diff Summary</title>')
+    summaryIndexHtml << ('</head><body>')
     summaryIndexHtml << ('\n')
     summaryIndexHtml << ('<h3><span style="color: #ff0000;">')
     summaryIndexHtml << ('<strong>WARNING: Excludes are ignored by diff.groovy.</strong>')

--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -271,7 +271,7 @@ def generateSummaryIndexHtml(diffDir, checkstyleBaseReportInfo, checkstylePatchR
     summaryIndexHtml << ('<h3><span style="color: #ff0000;">')
     summaryIndexHtml << ('<strong>WARNING: Excludes are ignored by diff.groovy.</strong>')
     summaryIndexHtml << ('</span></h3>')
-    printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstylePatchReportInfo)
+    printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstylePatchReportInfo, projectsStatistic)
     projectsStatistic.each {
         project, diffCount ->
             summaryIndexHtml << ("<a href='$project/index.html'>$project</a>")
@@ -286,7 +286,7 @@ def generateSummaryIndexHtml(diffDir, checkstyleBaseReportInfo, checkstylePatchR
     println 'Creating report summary page finished...'
 }
 
-def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstylePatchReportInfo) {
+def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstylePatchReportInfo, projectsStatistic) {
     summaryIndexHtml << ('<h6>')
     if (checkstyleBaseReportInfo) {
         summaryIndexHtml << "Base branch: $checkstyleBaseReportInfo.branch"
@@ -302,6 +302,9 @@ def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstyl
     summaryIndexHtml << "Patch branch last commit SHA: $checkstylePatchReportInfo.commitSha"
     summaryIndexHtml << ('<br />')
     summaryIndexHtml << "Patch branch last commit message: \"$checkstylePatchReportInfo.commitMsg\""
+    summaryIndexHtml << ('<br />')
+    summaryIndexHtml << ('<br />')
+    summaryIndexHtml << "Tested projects: ${projectsStatistic.size()}"
     summaryIndexHtml << ('</h6>')
 }
 

--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -274,7 +274,7 @@ def generateSummaryIndexHtml(diffDir, checkstyleBaseReportInfo, checkstylePatchR
     summaryIndexHtml << ('<strong>WARNING: Excludes are ignored by diff.groovy.</strong>')
     summaryIndexHtml << ('</span></h3>')
     printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstylePatchReportInfo, projectsStatistic)
-    projectsStatistic.each {
+    projectsStatistic.sort { it.key.toLowerCase() }.sort { it.value == 0 ? 1 : 0 }.each {
         project, diffCount ->
             summaryIndexHtml << ("<a href='$project/index.html'>$project</a>")
             if (diffCount.compareTo(0) != 0) {

--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -265,6 +265,7 @@ def generateSummaryIndexHtml(diffDir, checkstyleBaseReportInfo, checkstylePatchR
     def summaryIndexHtml = new File("$diffDir/index.html")
 
     summaryIndexHtml << ('<html><head>')
+    summaryIndexHtml << ('<link rel="icon" href="https://checkstyle.org/images/favicon.png" type="image/x-icon" />')
     summaryIndexHtml << ('<title>Checkstyle Tester Report Diff Summary</title>')
     summaryIndexHtml << ('</head><body>')
     summaryIndexHtml << ('\n')

--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -264,6 +264,7 @@ def generateSummaryIndexHtml(diffDir, checkstyleBaseReportInfo, checkstylePatchR
     def projectsStatistic = getProjectsStatistic(diffDir)
     def summaryIndexHtml = new File("$diffDir/index.html")
 
+    summaryIndexHtml.text = ''
     summaryIndexHtml << ('<html><head>')
     summaryIndexHtml << ('<link rel="icon" href="https://checkstyle.org/images/favicon.png" type="image/x-icon" />')
     summaryIndexHtml << ('<title>Checkstyle Tester Report Diff Summary</title>')


### PR DESCRIPTION
1. add a title to the report diff summary page
2. add tested projects count to report diff summary
3. add checkstyle favicon to report diff summary
4. clear report diff summary if it exists already
5. sort report diff summary, projects with differences first, case-insensitive alphabetical within the two sections
6. add total found differences to report diff summary

![grafik](https://user-images.githubusercontent.com/325196/54827024-59248a00-4cb1-11e9-9c78-e2c5a52fec13.png)
