### PR TITLE
minor: resolve IDEA 'Use of obsolete date-time API' violations

### DIFF
--- a/releasenotes-builder/config/suppressions.xml
+++ b/releasenotes-builder/config/suppressions.xml
@@ -15,4 +15,7 @@
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
+
+    <suppress id="ImportControlMain" message=".* - java\.time\..*"/>
+
 </suppressions>

--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.plugin.guava.version>27.1-jre</maven.plugin.guava.version>
-        <maven.plugin.checkstyle.version>3.0.0</maven.plugin.checkstyle.version>
+        <maven.plugin.checkstyle.version>3.1.0</maven.plugin.checkstyle.version>
         <maven.plugin.github-api.version>1.95</maven.plugin.github-api.version>
         <maven.plugin.jgit.version>4.1.0.201509280440-r</maven.plugin.jgit.version>
         <maven.plugin.slf4j.version>1.7.12</maven.plugin.slf4j.version>

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
@@ -29,8 +29,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
@@ -128,7 +128,7 @@ public final class TemplateProcessor {
 
         final Map<String, Object> variables = new HashMap<>();
         variables.put("todaysDate",
-                new SimpleDateFormat("dd.MM.yyyy", Locale.US).format(LocalDate.now()));
+                LocalDate.now().format(DateTimeFormatter.ofPattern("dd.MM.yyyy", Locale.US)));
         variables.put("remoteRepoPath", remoteRepoPath);
         variables.put("releaseNo", releaseNumber);
         variables.put("breakingMessages", releaseNotes.get(Constants.BREAKING_COMPATIBILITY_LABEL));

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
@@ -30,6 +30,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -128,7 +129,7 @@ public final class TemplateProcessor {
 
         final Map<String, Object> variables = new HashMap<>();
         variables.put("todaysDate",
-                new SimpleDateFormat("dd.MM.yyyy", Locale.US).format(new Date()));
+                new SimpleDateFormat("dd.MM.yyyy", Locale.US).format(LocalDate.now()));
         variables.put("remoteRepoPath", remoteRepoPath);
         variables.put("releaseNo", releaseNumber);
         variables.put("breakingMessages", releaseNotes.get(Constants.BREAKING_COMPATIBILITY_LABEL));

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -30,7 +30,6 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -26,8 +26,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -324,7 +324,8 @@ public class TemplateProcessorTest {
         final String expectedXdoc =
                 getFileContents(getPath(expectedName).toFile());
         final String actualXdoc = getFileContents(new File(temporaryFolder.getRoot(), actualName))
-                .replace(new SimpleDateFormat("dd.MM.yyyy", Locale.US).format(LocalDate.now()),
+                .replace(LocalDate.now()
+                                .format(DateTimeFormatter.ofPattern("dd.MM.yyyy", Locale.US)),
                         "XX.XX.XXXX");
 
         Assert.assertEquals(expectedXdoc, actualXdoc);

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -324,7 +325,7 @@ public class TemplateProcessorTest {
         final String expectedXdoc =
                 getFileContents(getPath(expectedName).toFile());
         final String actualXdoc = getFileContents(new File(temporaryFolder.getRoot(), actualName))
-                .replace(new SimpleDateFormat("dd.MM.yyyy", Locale.US).format(new Date()),
+                .replace(new SimpleDateFormat("dd.MM.yyyy", Locale.US).format(LocalDate.now()),
                         "XX.XX.XXXX");
 
         Assert.assertEquals(expectedXdoc, actualXdoc);


### PR DESCRIPTION
Inspection: Use of obsolete date-time API
Reports any uses of java.util.Date, java.util.Calendar, java.util.GregorianCalendar, java.util.TimeZone, and java.util.SimpleTimeZone. While still supported, these classes were made obsolete by the JDK8 Date-Time API, and should probably not be used in new development.

Soe links:
https://programminghints.com/2017/05/still-using-java-util-date-dont/
https://docs.oracle.com/javase/tutorial/datetime/index.html

but it is not deprecated class:
https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Date.html

new way of formatting: https://www.baeldung.com/migrating-to-java-8-date-time-api#highlighter_574295