### PR TITLE
Issue #394: replace sevntu-checkstyle-maven-plugin with sevntu-checks

### DIFF
--- a/checkstyle-tester/LAUNCH_GROOVY_README.md
+++ b/checkstyle-tester/LAUNCH_GROOVY_README.md
@@ -62,7 +62,6 @@ If you you need to use custom (snapshot) versions please update pom.xml to refer
 
 ```
 ls  ~/.m2/repository/com/puppycrawl/tools/checkstyle/
-ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
 ```
 
 To build SNAPSHOT version of `checkstyle` please run in its folder (local git repository):

--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -133,12 +133,10 @@ Even if the regression proves no differences, it may be a false that there is no
 
 Groovy scripts do not currently support sevntu regression. Sevntu can only be run with patch only branch and config. Running full difference regression will always produce no results because the scripts do no install the different versions of sevntu needed to function.
 
-First you must build sevntu checks and sevntu maven plugin by:
+First you must build sevntu checks:
 ```
 cd sevntu-checks
 mvn  -Pno-validations clean install
-cd ../sevntu-checkstyle-maven-plugin/
-mvn clean install
 ``` 
 Sevntu's current version must be referenced at https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/pom.xml#L16 .
 Change config file to reference your  Check - https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/my_check.xml#L22 .

--- a/checkstyle-tester/README_OLD.md
+++ b/checkstyle-tester/README_OLD.md
@@ -21,8 +21,6 @@ and please make sure that
 custom(newly generated) versions are located in your local maven repo 
 ```
 ls  ~/.m2/repository/com/puppycrawl/tools/checkstyle/
-ls  ~/.m2/repository/com/github/sevntu/checkstyle/sevntu-checkstyle-maven-plugin
-
 ```
 
 to build SNAPSHOT version of `checkstyle` please run in his repo

--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -33,7 +33,7 @@
 					</dependency>
 					<dependency>
 						<groupId>com.github.sevntu-checkstyle</groupId>
-						<artifactId>sevntu-checkstyle-maven-plugin</artifactId>
+						<artifactId>sevntu-checks</artifactId>
 						<version>${sevntu-checkstyle.version}</version>
 					</dependency>
 					<dependency>


### PR DESCRIPTION
Issue #394 

`sevntu-checkstyle-maven-plugin` was replaced with `sevntu-checks dependency`