### PR TITLE
doc: suppression for javadoc parsing errors

### DIFF
--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -81,6 +81,32 @@ When the script finishes its work the following directory structure will be crea
 
 You will find *index.html* file in /reports/diff directory. The file represents summary diff report.
 
+## Javadoc regression:
+Many javadoc comments contain errors. To avoid report pollution with
+parsing errors, add suppression to the configuration:
+```
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="haltOnException" value="false"/>
+  <module name="TreeWalker">
+    <module name="SummaryJavadoc" />
+
+    <!-- suppress javadoc parsing errors -->
+    <module name="SuppressionXpathSingleFilter">
+      <property name="message" value="Javadoc comment at column \d+ has parse error"/>
+    </module>
+  </module>
+  <!-- suppress java parsing errors -->
+  <module name="SuppressionSingleFilter">
+    <property name="message" value="Exception occurred while parsing"/>
+    <property name="checks" value="Checker"/>
+  </module>
+</module>
+```
+
 ATTENTION: 
 
 Administrators recommend you modify `projects-to-test-on.properties` and test as many projects as possible. Each project has its own unique style and it is common to find regression in 1 and not the others.

--- a/checkstyle-tester/my_check.xml
+++ b/checkstyle-tester/my_check.xml
@@ -26,11 +26,23 @@
          <module name="ThrowsCount">
              <property name="max" value="20000000"/>
          </module>
+         <!-- uncomment to suppress javadoc parsing errors
+         <module name="SuppressionXpathSingleFilter">
+            <property name="message" value="Javadoc comment at column \d+ has parse error"/>
+         </module>
+          -->
+
     </module>
 <!--
     <module name="SeverityMatchFilter">
         <property name="severity" value="warning"/>
         <property name="acceptOnMatch" value="false"/>
     </module>
+-->
+  <!-- uncomment to suppress java parsing errors
+  <module name="SuppressionSingleFilter">
+    <property name="message" value="Exception occurred while parsing"/>
+    <property name="checks" value="Checker"/>
+  </module>
 -->
 </module>


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/6931#pullrequestreview-270506952

It is hard to read regression tests for a new javadoc check due to many parsing errors.
This PR shows how to suppress them.