### PR TITLE
config: added JavadocBlockTagLocationCheck

### DIFF
--- a/checkstyle-tester/checks-only-javadoc-error.xml
+++ b/checkstyle-tester/checks-only-javadoc-error.xml
@@ -18,6 +18,7 @@
     <property name="tabWidth" value="4"/>
     <!-- All AbstractJavadocCheck children -->
     <module name="AtclauseOrder"/>
+    <module name="JavadocBlockTagLocation"/>
     <module name="JavadocParagraph"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="MissingDeprecated"/>


### PR DESCRIPTION
Add `JavadocBlockTagLocation` check to `checks-only-javadoc-error.xml`

 reference: checkstyle/checkstyle#6929