### PR TITLE
doc: update and re-organize checkstyle-tester read me

### DIFF
--- a/checkstyle-tester/checks-import-order/projects-to-test-imports-guava.properties
+++ b/checkstyle-tester/checks-import-order/projects-to-test-imports-guava.properties
@@ -1,5 +1,5 @@
 # List of GIT repositories to clone / pull for checking with Checkstyle
-# File format: REPO_NAME|[github|git|hg]|REPO_GIT_URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
 # Please note that bash comments works in this file
 
 # option=TOP separated=true

--- a/checkstyle-tester/checks-import-order/projects-to-test-imports-java-design-patterns.properties
+++ b/checkstyle-tester/checks-import-order/projects-to-test-imports-java-design-patterns.properties
@@ -1,5 +1,5 @@
 # List of GIT repositories to clone / pull for checking with Checkstyle
-# File format: REPO_NAME|[github|git|hg]|REPO_GIT_URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
 # Please note that bash comments works in this file
 
 # option=TOP separated=true groups=org,java staticGroups=org,java

--- a/checkstyle-tester/projects-for-circle.properties
+++ b/checkstyle-tester/projects-for-circle.properties
@@ -1,5 +1,5 @@
 # List of GIT repositories to clone / pull for checking with Checkstyle
-# File format: REPO_NAME|[local|git|hg]|REPO_GIT_URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
 # Please note that bash comments works in this file
 
 guava|git|https://github.com/google/guava|v25.0||

--- a/checkstyle-tester/projects-for-travis.properties
+++ b/checkstyle-tester/projects-for-travis.properties
@@ -1,5 +1,5 @@
 # List of GIT repositories to clone / pull for checking with Checkstyle
-# File format: REPO_NAME|[local|git|hg]|REPO_GIT_URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
 # Please note that bash comments works in this file
 
 guava|git|https://github.com/google/guava|v18.0||

--- a/checkstyle-tester/projects-for-wercker.properties
+++ b/checkstyle-tester/projects-for-wercker.properties
@@ -1,5 +1,5 @@
 # List of GIT repositories to clone / pull for checking with Checkstyle
-# File format: REPO_NAME|[local|git|hg]|REPO_GIT_URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
 # Please note that bash comments works in this file
 
 #apache-struts|git|https://github.com/apache/struts.git|master|**/apache-struts/**/resources/**/*

--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -1,5 +1,5 @@
 # List of GIT repositories to clone / pull for checking with Checkstyle
-# File format: REPO_NAME|[local|git|hg]|REPO_GIT_URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
 # Please note that bash comments works in this file
 
 # Few projects that delivers set of unusual Java constructions that shall be correctly handled by AST visitor


### PR DESCRIPTION
Updated and re-organized the read me so it flows better. Add specific sections for new things like special configs and split existing sections into their own unique section and added a specific order to the document.

Some minor things may have been removed, but for the most part everything is still there, just re-ordered and with some new wording.