### PR TITLE
Issue checkstyle/checkstyle#3279: introduction of diff regression local-checkstyle

### DIFF
--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -74,6 +74,12 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jxr-plugin</artifactId>
             <version>${jxr-plugin.version}</version>
+            <!-- plugin do not have ability to define followinng by system property -->
+            <configuration>
+              <excludes>
+                <exclude>**/.ci-temp/**/*</exclude>
+              </excludes>
+            </configuration>
           </plugin>
 
 		</plugins>

--- a/checkstyle-tester/projects-for-wercker.properties
+++ b/checkstyle-tester/projects-for-wercker.properties
@@ -7,6 +7,7 @@
 # Few projects that delivers set of unusual Java constructions that shall be correctly handled by AST visitor
 # 'InputAllEscapedUnicodeCharacters' must be skipped because it is too big and slows down JXR
 #checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/checkstyle/src/test/resources-noncompilable/**/*,**/InputAllEscapedUnicodeCharacters.java
+#local-checkstyle|local|../../../|master|**/.ci-temp/**/*,**/resources-noncompilable/**/*,**/InputAllEscapedUnicodeCharacters.java
 #sevntu-checkstyle|git|https://github.com/sevntu-checkstyle/sevntu.checkstyle|master||
 
 guava|git|https://github.com/google/guava|v18.0||


### PR DESCRIPTION
Issue checkstyle/checkstyle#3279

fix in pom is required to avoid problem with jxr plugin that try to parse all files:
```
✘-1 ~/java/github/romani/checkstyle/.ci-temp/contribution/checkstyle-tester [master|✚ 3] 
$ mvn -X -e --batch-mode site -Dcheckstyle.config.location=checks-nonjavadoc-error.xml -Dcheckstyle.excludes=**/.ci-temp/**/*,**/resources-noncompilable/**/*,**/InputAllEscapedUnicodeCharacters.java

....

[DEBUG] parsing... local-checkstyle/.ci-temp/contribution/patch-diff-report-tool/src/test/resources/run/PatchOnly2.java
[DEBUG] parsing... local-checkstyle/.ci-temp/contribution/patch-diff-report-tool/src/test/resources/run/Same1.java
[DEBUG] parsing... local-checkstyle/.ci-temp/contribution/patch-diff-report-tool/src/test/resources/run/NonCompilable.java
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.384 s
[INFO] Finished at: 2019-09-22T21:45:21-07:00
[INFO] Final Memory: 30M/455M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site (default-site) on project sample: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.3:site failed. NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site (default-site) on project sample: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.3:site failed.
  at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
  at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
  at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
  at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
  at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
  at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
  at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
  at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
  at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
  at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
  at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
  at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
  at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
  at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
  at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
  at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.3:site failed.
  at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:145)
  at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
  ... 20 more
Caused by: java.lang.NullPointerException
  at org.apache.maven.jxr.pacman.JavaFileImpl.parse(JavaFileImpl.java:108)
  at org.apache.maven.jxr.pacman.JavaFileImpl.<init>(JavaFileImpl.java:64)
  at org.apache.maven.jxr.pacman.FileManager.getFile(FileManager.java:68)
  at org.apache.maven.jxr.pacman.PackageManager.parse(PackageManager.java:123)
  at org.apache.maven.jxr.pacman.PackageManager.process(PackageManager.java:161)
  at org.apache.maven.jxr.JXR.xref(JXR.java:262)
  at org.apache.maven.plugin.jxr.AbstractJxrReport.createXref(AbstractJxrReport.java:279)
  at org.apache.maven.plugin.jxr.AbstractJxrReport.executeReport(AbstractJxrReport.java:473)
  at org.apache.maven.reporting.AbstractMavenReport.generate(AbstractMavenReport.java:255)
  at org.apache.maven.plugins.site.ReportDocumentRenderer.renderDocument(ReportDocumentRenderer.java:219)
  at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.renderModule(DefaultSiteRenderer.java:319)
  at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render(DefaultSiteRenderer.java:135)
  at org.apache.maven.plugins.site.SiteMojo.renderLocale(SiteMojo.java:175)
  at org.apache.maven.plugins.site.SiteMojo.execute(SiteMojo.java:138)
  at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
  ... 21 more
[ERROR] 
```