### PR TITLE
config: bump jackson-databind to 2.10.0 to avoid security alert

### DIFF
--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -32,6 +32,19 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
             <version>${maven.plugin.github-api.version}</version>
+            <!-- till github-api next version above 1.95 -->
+            <exclusions>
+              <exclusion>
+                <artifactId>com.fasterxml.jackson.core</artifactId>
+                <groupId>jackson-databind</groupId>
+              </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- till github-api next version above 1.95 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-472980

detected at https://app.snyk.io/org/checkstyle/project/6464a1a8-78eb-4b93-aa92-c6889786636a?utm_campaign=vuln_alert&utm_medium=email&utm_source=Project&fromGitHubAuth=true

https://github.com/github-api/github-api/pull/575#event-2731051465

