### PR TITLE
checkstyle/checkstyle#7329: remove deprecated properties from JavadocMethod

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -382,8 +382,7 @@
     -->
     <module name="InvalidJavadocPosition"/>
     <module name="JavadocMethod">
-      <property name="allowUndeclaredRTE" value="true"/>
-      <property name="allowThrowsTagsForSubclasses" value="true"/>
+      <property name="validateThrows" value="true"/>
     </module>
     <!-- JavadocAST Checks - disabled due to performance problem
     <module name="JavadocParagraph"/>


### PR DESCRIPTION
chekcstyle PR for checkstyle/checkstyle#7329 is merged 

it is problem at https://ci.appveyor.com/project/Checkstyle/contribution/builds/29688263/job/uocbc27m1d0j5lx3#L357
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site
 (default-site) on project sample: Error during page generation: Error rendering
 Maven report:
 Failed during checkstyle configuration: cannot initialize module TreeWalker -
 cannot initialize module JavadocMethod - Property 'allowUndeclaredRTE' 
does not exist,
 please check the documentation -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site (default-site) on project sample:
 Error during page generation
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:216)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at 
```