### PR TITLE
minor: releasenotes-builder: print link to issue to ease navigation from logs to issue

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
@@ -66,6 +66,18 @@ public final class NotesBuilder {
             + "^doc: release notes.*[\r\n]?$|"
             + "^(config:|minor:|infra:|dependency:)(.|\n)*[\r|\n]?$");
 
+    /** String format pattern for github issue. */
+    private static final String GITHUB_ISSUE_TEMPLATE =
+            " https://github.com/%s/issues/%d";
+    /** String format pattern for warning if issue is not closed. */
+    private static final String MESSAGE_NOT_CLOSED = "[WARN] Issue #%d \"%s\" is not closed!"
+                            + " Please review issue"
+                            + GITHUB_ISSUE_TEMPLATE;
+    /** String format pattern for error if no label on issue. */
+    private static final String MESSAGE_NO_LABEL = "[ERROR] Issue #%d does not have %s label!"
+                            + " Please set label at"
+                            + GITHUB_ISSUE_TEMPLATE;
+
     /** Default constructor. */
     private NotesBuilder() {
     }
@@ -109,15 +121,17 @@ public final class NotesBuilder {
 
                 final GHIssue issue = remoteRepo.getIssue(issueNo);
                 if (issue.getState() != GHIssueState.CLOSED) {
-                    result.addWarning(String.format("[WARN] Issue #%d \"%s\" is not closed!",
-                        issueNo, issue.getTitle()));
+                    result.addWarning(String.format(MESSAGE_NOT_CLOSED,
+                        issueNo, issue.getTitle(), remoteRepoPath, issueNo));
                 }
 
                 final String issueLabel = getIssueLabelFrom(issue);
                 if (issueLabel.isEmpty()) {
-                    final String error = String.format("[ERROR] Issue #%d does not have %s label!",
-                        issueNo, Arrays.stream(Constants.ISSUE_LABELS)
-                            .collect(Collectors.joining(SEPARATOR)));
+                    final String error = String.format(MESSAGE_NO_LABEL,
+                        issueNo,
+                        Arrays.stream(Constants.ISSUE_LABELS)
+                                .collect(Collectors.joining(SEPARATOR)),
+                        remoteRepoPath, issueNo);
                     result.addError(error);
                 }
                 final Set<RevCommit> issueCommits = getCommitsForIssue(commitsForRelease, issueNo);


### PR DESCRIPTION
it is hard to find example of build failure as i usually fix such failures quickly.
but it will be helpful.

Example of WARN - https://travis-ci.org/checkstyle/checkstyle/jobs/630142958#L550

testing:
```
This reverts commit 1ed4da5951284a3f92a42f96edc7d74f6785658f.


[WARN] Issue #5777 "Update AbstractChecks to log DetailAST (part3)" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/5777
[WARN] Issue #6916 "Upgrade to junit 5" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/6916
[WARN] Issue #7380 "JavadocMethod: missed throws tag for throw in method body" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/7380

Execution succeeded!

```