### PR TITLE
config: remove TypeUseTarget from excludes

### DIFF
--- a/checkstyle-tester/projects-for-circle.properties
+++ b/checkstyle-tester/projects-for-circle.properties
@@ -6,9 +6,9 @@ guava|git|https://github.com/google/guava|v28.2||
 #checkstyle-sonar|git|https://github.com/checkstyle/sonar-checkstyle|master||
 
 #openjdk7|hg|http://hg.openjdk.java.net/jdk7/jdk7/jdk/|||
-#openjdk8|hg|http://hg.openjdk.java.net/jdk8/jdk8/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java
-#All details at checkstyle/checkstyle#3033: TypeUseTarget till checkstyle/checkstyle#3238 ; ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
-#openjdk9|hg|http://hg.openjdk.java.net/jdk9/jdk9/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java,**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
+#openjdk8|hg|http://hg.openjdk.java.net/jdk8/jdk8/jdk/|default|
+#All details at checkstyle/checkstyle#3033: ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
+#openjdk9|hg|http://hg.openjdk.java.net/jdk9/jdk9/jdk/|default|**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
 #infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 #protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 #jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||

--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -9,10 +9,10 @@
 #checkstyle-sonar|git|https://github.com/checkstyle/sonar-checkstyle|master||
 
 #openjdk7|hg|http://hg.openjdk.java.net/jdk7/jdk7/jdk/|||
-#openjdk8|hg|http://hg.openjdk.java.net/jdk8/jdk8/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java
-#All details at checkstyle/checkstyle#3033: TypeUseTarget till checkstyle/checkstyle#3238 ; ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
-#openjdk9|hg|http://hg.openjdk.java.net/jdk9/jdk9/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java,**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
-#openjdk10|hg|http://hg.openjdk.java.net/jdk10/jdk10/jdk/|default|**/test/tools/pack200/typeannos/TypeUseTarget.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
+#openjdk8|hg|http://hg.openjdk.java.net/jdk8/jdk8/jdk/|default|
+#All details at checkstyle/checkstyle#3033: ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
+#openjdk9|hg|http://hg.openjdk.java.net/jdk9/jdk9/jdk/|default|**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
+#openjdk10|hg|http://hg.openjdk.java.net/jdk10/jdk10/jdk/|default|**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
 guava|git|https://github.com/google/guava|v28.2||
 
 #spotbugs|git|https://github.com/spotbugs/spotbugs|3.1.2||


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/issues/3236#issuecomment-578417379 - removing TypeUseTarget.java from the excluded files for the JDK projects since it can be parsed after https://github.com/checkstyle/checkstyle/pull/7407