### PR TITLE
infra: use checkstyle project (at it has incompilable files) for diff.groovy

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -44,8 +44,8 @@ checkstyle-tester-diff-groovy-patch)
   cd .ci-temp/checkstyle
   git checkout -b patch-branch
   cd ../../checkstyle-tester
-  #sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
-  #sed -i'' 's/#checkstyle/checkstyle/' projects-for-wercker.properties
+  sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
+  sed -i'' 's/#checkstyle/checkstyle/' projects-for-wercker.properties
   groovy diff.groovy -l projects-for-travis.properties \
     -c my_check.xml -b master -p patch-branch -r ../.ci-temp/checkstyle
   ;;


### PR DESCRIPTION
this PR is passing, unfortunately on local maven does not skip incompilable files and execution is failing, even maven is instructed to ignore exceptions

I can run regression only with code changes like (`--ignoreExcludes` is removed):
```
✔ ~/java/github/checkstyle/contribution/checkstyle-tester [config-error L|✚ 2…1] 
$ git diff
diff --git a/checkstyle-tester/diff.groovy b/checkstyle-tester/diff.groovy
index e913dce..5b07293 100644
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -185,7 +185,7 @@ def generateCheckstyleReport(cfg) {
 
     executeCmd("mvn --batch-mode -Pno-validations clean install", cfg.localGitRepo)
     executeCmd("""groovy launch.groovy --listOfProjects $cfg.listOfProjects
-            --config $cfg.checkstyleCfg --ignoreExceptions --ignoreExcludes --checkstyleVersion $checkstyleVersion""")
+            --config $cfg.checkstyleCfg --ignoreExceptions --checkstyleVersion $checkstyleVersion""")
     println "Moving Checkstyle report into $cfg.destDir ..."
     moveDir("reports", cfg.destDir)
```