### PR TITLE
minor: allow overriding checkstyle config location

### DIFF
--- a/patch-diff-report-tool/pom.xml
+++ b/patch-diff-report-tool/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <checkstyle.version>8.30</checkstyle.version>
+        <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
         <maven.plugin.checkstyle.version>3.1.0</maven.plugin.checkstyle.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -100,7 +101,7 @@
                             <includeResources>false</includeResources>
                             <includeTestResources>false</includeTestResources>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                            <configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</configLocation>
+                            <configLocation>${checkstyle.configLocation}</configLocation>
                             <propertiesLocation>config/checkstyle.properties</propertiesLocation>
                             <failOnViolation>true</failOnViolation>
                             <logViolationsToConsole>true</logViolationsToConsole>

--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -24,6 +24,7 @@
         <tools.jar.version>${java.version}.0</tools.jar.version>
         <tools.jar.path>${java.home}/../lib/tools.jar</tools.jar.path>
         <checkstyle.version>8.30</checkstyle.version>
+        <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -157,7 +158,7 @@
                         <configuration>
                             <includeResources>false</includeResources>
                             <includeTestResources>false</includeTestResources>
-                            <configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</configLocation>
+                            <configLocation>${checkstyle.configLocation}</configLocation>
                             <propertiesLocation>config/checkstyle.properties</propertiesLocation>
                             <failOnViolation>true</failOnViolation>
                             <linkXRef>false</linkXRef>


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/7706#issuecomment-592980127 .

We need to allow these 2 projects to override the default checkstyle config location for regression.