### PR TITLE
config: added JavadocMissingWhitespaceAfterAsteriskCheck

### DIFF
--- a/checkstyle-tester/checks-only-javadoc-error.xml
+++ b/checkstyle-tester/checks-only-javadoc-error.xml
@@ -20,6 +20,7 @@
     <module name="AtclauseOrder"/>
     <module name="JavadocBlockTagLocation"/>
     <module name="JavadocContentLocation"/>
+    <module name="JavadocMissingWhitespaceAfterAsterisk"/>
     <module name="JavadocParagraph"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="MissingDeprecated"/>


### PR DESCRIPTION
Add `JavadocMissingWhitespaceAfterAsteriskCheck` check to `checks-only-javadoc-error.xml`

reference: checkstyle/checkstyle#7775