### PR TITLE
minor: upgrade maven-checkstyle-plugin

### DIFF
--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<checkstyle-plugin.version>3.1.0</checkstyle-plugin.version>
+		<checkstyle-plugin.version>3.1.1</checkstyle-plugin.version>
 		<checkstyle.version>8.31-SNAPSHOT</checkstyle.version>
 		<sevntu-checkstyle.version>1.37.1</sevntu-checkstyle.version>
 		<jxr-plugin.version>2.5</jxr-plugin.version>


### PR DESCRIPTION
This PR will upgrade maven-checkstyle-plugin to 3.1.1 for Checkstyle's regression testing.

Related to Issue:
Issue: checkstyle/checkstyle/issues/7190
PR: checkstyle/checkstyle#7778