### PR TITLE
config: added RequireEmptyLineBeforeBlockTagGroup

### DIFF
--- a/checkstyle-tester/checks-only-javadoc-error.xml
+++ b/checkstyle-tester/checks-only-javadoc-error.xml
@@ -25,6 +25,7 @@
     <module name="JavadocTagContinuationIndentation"/>
     <module name="MissingDeprecated"/>
     <module name="NonEmptyAtclauseDescription"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
     <module name="SingleLineJavadoc"/>
     <module name="SummaryJavadoc"/>
 


### PR DESCRIPTION
Add RequireEmptyLineBeforeAtClauseBlock check to checks-only-javadoc-error.xml

reference: checkstyle/checkstyle#7932