### PR TITLE
minor: fix violations from RequireEmptyLineBeforeAtClauseBlock

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
@@ -44,6 +44,7 @@ import com.github.checkstyle.site.SiteGenerator;
 
 /**
  * Utility class, contains main function and its auxiliary routines.
+ *
  * @author attatrol
  */
 public final class Main {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliPaths.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliPaths.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 
 /**
  * POJO class that hold input paths.
+ *
  * @author attatrol
  */
 public final class CliPaths {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleReportsParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleReportsParser.java
@@ -111,6 +111,7 @@ public final class CheckstyleReportsParser {
      * which process their XML files in rotation and try
      * to write their results to the ParsedContent class
      * inner map, where they are eagerly compared.
+     *
      * @param baseXml
      *        path to base XML file.
      * @param patchXml

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/EmptyXmlEventReader.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/EmptyXmlEventReader.java
@@ -27,6 +27,7 @@ import javax.xml.stream.events.XMLEvent;
 
 /**
  * Simple {@link XMLEventReader} with no elements.
+ *
  * @author Richard Veach
  */
 public final class EmptyXmlEventReader implements XMLEventReader {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -42,6 +42,7 @@ import com.github.checkstyle.data.Statistics;
  * Generates site report using thymeleaf template engine. Instead of single
  * template 3 smaller ones are used with purpose of avoiding creation of extra
  * large Context instance.
+ *
  * @author attatrol
  */
 public final class SiteGenerator {

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
@@ -29,6 +29,7 @@ import com.google.common.base.Verify;
 /**
  * Helper structure class to clear show what command line arguments are required for NotesBuilder
  * to run.
+ *
  * @author Andrei Selkin
  */
 public final class CliOptions {
@@ -227,6 +228,7 @@ public final class CliOptions {
 
     /**
      * Creates a new Builder instance.
+     *
      * @return new Builder instance.
      */
     public static Builder newBuilder() {
@@ -244,6 +246,7 @@ public final class CliOptions {
 
         /**
          * Specify Local repository path.
+         *
          * @param path Local repository path
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -255,6 +258,7 @@ public final class CliOptions {
 
         /**
          * Specify Remote repository path.
+         *
          * @param path Remote repository path
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -266,6 +270,7 @@ public final class CliOptions {
 
         /**
          * Specify Start git reference.
+         *
          * @param ref Start reference
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -277,6 +282,7 @@ public final class CliOptions {
 
         /**
          * Specify End git reference.
+         *
          * @param ref End reference
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -288,6 +294,7 @@ public final class CliOptions {
 
         /**
          * Specify release number.
+         *
          * @param number Release Number
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -299,6 +306,7 @@ public final class CliOptions {
 
         /**
          * Specify Auth Token.
+         *
          * @param token Auth Token
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -310,6 +318,7 @@ public final class CliOptions {
 
         /**
          * Specify Output location.
+         *
          * @param outputLoc Output location
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -321,6 +330,7 @@ public final class CliOptions {
 
         /**
          * Specify flag to generate all.
+         *
          * @param genAll flag to generate all
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -332,6 +342,7 @@ public final class CliOptions {
 
         /**
          * Specify flag to generate xdoc.
+         *
          * @param genXdoc flag to generate xdoc
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -343,6 +354,7 @@ public final class CliOptions {
 
         /**
          * Spacify flag to generate twiter post.
+         *
          * @param genTw flag to generate twitt
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -354,6 +366,7 @@ public final class CliOptions {
 
         /**
          * Specify flag to generate RSS post.
+         *
          * @param genRss flag to generate RSS post
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -365,6 +378,7 @@ public final class CliOptions {
 
         /**
          * Spacify flag to generate Mail-list post.
+         *
          * @param genMlist flag to generate mail-list post
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -376,6 +390,7 @@ public final class CliOptions {
 
         /**
          * Specify xdoc template.
+         *
          * @param xdocTemp xdoc template
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -387,6 +402,7 @@ public final class CliOptions {
 
         /**
          * Specify twitter template.
+         *
          * @param twitterTemp twitter template
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -398,6 +414,7 @@ public final class CliOptions {
 
         /**
          * Specify rss template.
+         *
          * @param rssTemp rss template
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -409,6 +426,7 @@ public final class CliOptions {
 
         /**
          * Specify mailing list template.
+         *
          * @param mlistTemp mailing list template
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -420,6 +438,7 @@ public final class CliOptions {
 
         /**
          * Spacify to do publish all social posts.
+         *
          * @param pubAllSocial flag to generate all social posts
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -431,6 +450,7 @@ public final class CliOptions {
 
         /**
          * Specify to do publish only for twitter.
+         *
          * @param publishTw flag to publish twitt
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -442,6 +462,7 @@ public final class CliOptions {
 
         /**
          * Specify Twitter consumer key.
+         *
          * @param twConsKey twitter consumer key
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -453,6 +474,7 @@ public final class CliOptions {
 
         /**
          * Specify Twitter Consumer secret.
+         *
          * @param twConsSecret twitter consumer secret
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -464,6 +486,7 @@ public final class CliOptions {
 
         /**
          * Specify Twitter Access Token.
+         *
          * @param twAccessToken twitter access token
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -475,6 +498,7 @@ public final class CliOptions {
 
         /**
          * Specify Access Token Secret.
+         *
          * @param twAccessTokenSecret twitter access token secret
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -486,6 +510,7 @@ public final class CliOptions {
 
         /**
          * Specify Twitter Properties.
+         *
          * @param twProperties twitter properties
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -497,6 +522,7 @@ public final class CliOptions {
 
         /**
          * Specify to publish Xdoc update.
+         *
          * @param pubXdoc flag to publish xdoc file update
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -508,6 +534,7 @@ public final class CliOptions {
 
         /**
          * Specify to publish xdoc update and do push to remote git.
+         *
          * @param pubXdocWithPush flag to publish xdoc and push to remote repo
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -519,6 +546,7 @@ public final class CliOptions {
 
         /**
          * Specify to do publication only for mailing list.
+         *
          * @param pubMlist flag to publish to mailing list
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -530,6 +558,7 @@ public final class CliOptions {
 
         /**
          * Specify username to publish to mailing list.
+         *
          * @param username mailing list username
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -541,6 +570,7 @@ public final class CliOptions {
 
         /**
          * Specify password to publish to mailing list.
+         *
          * @param password mailing list password
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -552,6 +582,7 @@ public final class CliOptions {
 
         /**
          * Specify mailing list properties.
+         *
          * @param mlistProps mailing list properties
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -563,6 +594,7 @@ public final class CliOptions {
 
         /**
          * Specify to do publication only for RSS.
+         *
          * @param pubRss flag to publish to RSS
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -574,6 +606,7 @@ public final class CliOptions {
 
         /**
          * Specify mailing list properties.
+         *
          * @param token sourceforge bearer token
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -585,6 +618,7 @@ public final class CliOptions {
 
         /**
          * Specify RSS properties.
+         *
          * @param rssProps mailing list properties
          * @return Builder Object
          * @noinspection ReturnOfInnerClass
@@ -596,6 +630,7 @@ public final class CliOptions {
 
         /**
          * Verify options and set defaults.
+         *
          * @return new CliOption instance
          */
         public CliOptions build() {
@@ -645,6 +680,7 @@ public final class CliOptions {
 
         /**
          * Whether Twitter properties should be loaded.
+         *
          * @return true, if Twitter properties should be loaded.
          */
         private boolean shouldLoadTwitterProperties() {
@@ -688,6 +724,7 @@ public final class CliOptions {
 
         /**
          * Whether RSS properties should be loaded.
+         *
          * @return true, if RSS properties should be loaded.
          */
         private boolean shouldLoadMlistProperties() {
@@ -738,6 +775,7 @@ public final class CliOptions {
 
         /**
          * Get new CliOptions instance.
+         *
          * @return new CliOptions instance.
          */
         // -@cs[ExecutableStatementCount] long list of options being assigned to single instance

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
@@ -34,6 +34,7 @@ import org.apache.commons.cli.ParseException;
 
 /**
  * Helper class to process command line arguments for NotesBuilder.
+ *
  * @author Andrei Selkin
  */
 public class CliProcessor {
@@ -119,6 +120,7 @@ public class CliProcessor {
 
     /**
      * Constructs CliProcessor object.
+     *
      * @param args command line cmdArgs.
      */
     public CliProcessor(String... args) {
@@ -128,6 +130,7 @@ public class CliProcessor {
 
     /**
      * Process command line arguments.
+     *
      * @throws ParseException if an error occurs while parsing command line arguments.
      */
     public void process() throws ParseException {
@@ -138,6 +141,7 @@ public class CliProcessor {
 
     /**
      * Checks whether any errors occurred while processing command line arguments.
+     *
      * @return true if any errors occurred while processing command line arguments.
      */
     public boolean hasErrors() {
@@ -146,6 +150,7 @@ public class CliProcessor {
 
     /**
      * Returns a list of error messages.
+     *
      * @return a list of error messages.
      */
     public List<String> getErrorMessages() {
@@ -154,6 +159,7 @@ public class CliProcessor {
 
     /**
      * Does validation of command line options.
+     *
      * @return list of violations.
      */
     // -@cs[CyclomaticComplexity|NPathComplexity] This code is not complicated and is better to
@@ -212,6 +218,7 @@ public class CliProcessor {
 
     /**
      * Util method to convert CommandLine type to POJO object.
+     *
      * @return command line options as POJO object.
      */
     public CliOptions getCliOptions() {
@@ -254,6 +261,7 @@ public class CliProcessor {
 
     /**
      * Builds and returns list of parameters supported by cli Main.
+     *
      * @return available options.
      */
     private static Options buildOptions() {

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
@@ -31,6 +31,7 @@ import freemarker.template.TemplateException;
 
 /**
  * Class for command line usage.
+ *
  * @author Andrei Selkin
  */
 public final class Main {
@@ -44,6 +45,7 @@ public final class Main {
 
     /**
      * Entry point.
+     *
      * @param args command line arguments.
      */
     public static void main(String... args) {
@@ -90,6 +92,7 @@ public final class Main {
 
     /**
      * Executes NotesBuilder based on passed command line options.
+     *
      * @param cliOptions command line options.
      * @return result of NotesBuilder work.
      * @throws IOException if an I/O error occurs.
@@ -117,6 +120,7 @@ public final class Main {
 
     /**
      * Prints a list of elements in standard out.
+     *
      * @param entities a list.
      */
     private static void printListOf(List<String> entities) {

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -64,6 +64,7 @@ public final class MainProcess {
 
     /**
      * Generate posts and publish them.
+     *
      * @param releaseNotes map of release notes messages.
      * @param cliOptions command line options.
      * @return list of publication errors.
@@ -78,6 +79,7 @@ public final class MainProcess {
 
     /**
      * Generate posts and write them to files.
+     *
      * @param releaseNotes map of release notes messages.
      * @param cliOptions command line options.
      * @throws IOException if I/O error occurs.
@@ -118,6 +120,7 @@ public final class MainProcess {
 
     /**
      * Publish social posts.
+     *
      * @param cliOptions command line options.
      * @return list of publication errors.
      */
@@ -140,6 +143,7 @@ public final class MainProcess {
 
     /**
      * Publish on xdoc.
+     *
      * @param cliOptions command line options.
      * @param errors list of publication errors.
      */
@@ -159,6 +163,7 @@ public final class MainProcess {
 
     /**
      * Publish on Twitter.
+     *
      * @param cliOptions command line options.
      * @param errors list of publication errors.
      */
@@ -178,6 +183,7 @@ public final class MainProcess {
 
     /**
      * Publish on mailing list.
+     *
      * @param cliOptions command line options.
      * @param errors list of publication errors.
      */
@@ -196,6 +202,7 @@ public final class MainProcess {
 
     /**
      * Publish on RSS.
+     *
      * @param cliOptions command line options.
      * @param errors list of publication errors.
      */

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
@@ -52,6 +52,7 @@ import com.google.common.collect.Sets;
 
 /**
  * Contains methods for release notes generation.
+ *
  * @author Andrei Selkin
  */
 public final class NotesBuilder {
@@ -84,6 +85,7 @@ public final class NotesBuilder {
 
     /**
      * Forms release notes as a map.
+     *
      * @param localRepoPath path to local git repository.
      * @param authToken the authorization token.
      * @param remoteRepoPath path to remote git repository.
@@ -154,6 +156,7 @@ public final class NotesBuilder {
 
     /**
      * Creates the connection to the remote repository.
+     *
      * @param authToken the authorization token.
      * @param remoteRepoPath path to remote git repository.
      * @return the remote repository object.
@@ -174,6 +177,7 @@ public final class NotesBuilder {
 
     /**
      * Returns a list of commits between two references.
+     *
      * @param repoPath path to local git repository.
      * @param startRef start reference.
      * @param endRef end reference.
@@ -200,6 +204,7 @@ public final class NotesBuilder {
 
     /**
      * Checks whether a commit message starts with the 'Revert' word.
+     *
      * @param commitMessage commit message.
      * @return true if a commit message starts with the 'Revert' word.
      */
@@ -213,6 +218,7 @@ public final class NotesBuilder {
      * Returns a set of ignored commits.
      * Ignored commits are 'revert' commits and commits which were reverted by the 'revert' commits
      * in current release.
+     *
      * @param commitsForRelease commits for release.
      * @return a set of ignored commits.
      */
@@ -251,6 +257,7 @@ public final class NotesBuilder {
 
     /**
      * Checks commit message to determine whether commit should be ignored.
+     *
      * @param commitMessage commit message.
      * @return if commit with the message should be ignored.
      */
@@ -261,6 +268,7 @@ public final class NotesBuilder {
 
     /**
      * Returns actual SHA-1 object by commit reference.
+     *
      * @param repo git repository.
      * @param ref string representation of commit reference.
      * @return actual SHA-1 object.
@@ -282,6 +290,7 @@ public final class NotesBuilder {
 
     /**
      * Extracts an issue number from commit message.
+     *
      * @param commitMessage commit message.
      * @return issue number.
      */
@@ -293,6 +302,7 @@ public final class NotesBuilder {
 
     /**
      * Returns a list of commits which are associated with the current issue.
+     *
      * @param commits commits.
      * @param issueNo issue number.
      * @return a list of commits which are associated with the current issue.
@@ -315,6 +325,7 @@ public final class NotesBuilder {
      * Checks whether commits message is associated with a pull request or an issue.
      * Commit message which is associated with a pull request or an issue starts with 'Pull'
      * or 'Issue' prefix.
+     *
      * @param commitMessage commit message.
      * @return true if commits message is associated with a pull request or an issue.
      */
@@ -324,6 +335,7 @@ public final class NotesBuilder {
 
     /**
      * Forms a string which represents the authors who are referenced in the commits.
+     *
      * @param commits commits.
      * @return string which represents the authors who are referenced in the commits.
      */
@@ -334,6 +346,7 @@ public final class NotesBuilder {
 
     /**
      * Finds authors of the commits.
+     *
      * @param commits current issue commits.
      * @return a list of authors who work on the current issue.
      */
@@ -348,6 +361,7 @@ public final class NotesBuilder {
 
     /**
      * Returns issue label for release notes.
+     *
      * @param issue issue.
      * @return issue label for release notes
      * @throws IOException if an I/o error occurs.

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/globals/Constants.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/globals/Constants.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 /**
  * Container for constants.
+ *
  * @author Andrei Selkin
  */
 public final class Constants {
@@ -40,6 +41,7 @@ public final class Constants {
 
     /**
      * The array which represents the issue labels for release notes.
+     *
      * @noinspection PublicStaticArrayField
      */
     public static final String[] ISSUE_LABELS;

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
@@ -23,6 +23,7 @@ import org.kohsuke.github.GHIssue;
 
 /**
  * Represents a release notes message.
+ *
  * @author Andrei Selkin
  */
 public final class ReleaseNotesMessage {
@@ -44,6 +45,7 @@ public final class ReleaseNotesMessage {
 
     /**
      * Constructs a release notes message for issue.
+     *
      * @param issue issue.
      * @param author author.
      */
@@ -56,6 +58,7 @@ public final class ReleaseNotesMessage {
 
     /**
      * Constructs a release notes message for commit.
+     *
      * @param title commit title.
      * @param author commit author.
      */
@@ -84,6 +87,7 @@ public final class ReleaseNotesMessage {
 
     /**
      * Returns actual title of issue or pull request which is represented as an issue.
+     *
      * @param issue issue object.
      * @return actual title of issue or pull request which is represented as an issue.
      */
@@ -101,6 +105,7 @@ public final class ReleaseNotesMessage {
 
     /**
      * Splits the given string by the max line size into multiple lines.
+     *
      * @param str The string to examine.
      * @return The split string.
      */

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/globals/Result.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/globals/Result.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Multimap;
 
 /**
  * Represents the result of release notes generation.
+ *
  * @author Andrei Selkin
  */
 public final class Result {
@@ -52,6 +53,7 @@ public final class Result {
 
     /**
      * Puts release notes message into release notes map.
+     *
      * @param label section label.
      * @param message release notes message.
      */
@@ -75,6 +77,7 @@ public final class Result {
 
     /**
      * Adds error message into result.
+     *
      * @param message error message.
      */
     public void addError(String message) {
@@ -83,6 +86,7 @@ public final class Result {
 
     /**
      * Adds warning message into result.
+     *
      * @param message warning message.
      */
     public void addWarning(String message) {
@@ -91,6 +95,7 @@ public final class Result {
 
     /**
      * Checks whether result has errors.
+     *
      * @return true if result has errors.
      */
     public boolean hasErrors() {
@@ -99,6 +104,7 @@ public final class Result {
 
     /**
      * Checks whether result has warnings.
+     *
      * @return true if result has warnings.
      */
     public boolean hasWarnings() {

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/MailingListPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/MailingListPublisher.java
@@ -38,6 +38,7 @@ import javax.mail.internet.MimeMultipart;
 
 /**
  * Class for mailing list publication.
+ *
  * @author Vladislav Lisetskii
  */
 public class MailingListPublisher {
@@ -62,6 +63,7 @@ public class MailingListPublisher {
 
     /**
      * Default constructor.
+     *
      * @param postFilename the name of the file to get post from.
      * @param username username for publishing.
      * @param password password for publishing.
@@ -77,6 +79,7 @@ public class MailingListPublisher {
 
     /**
      * Publish post.
+     *
      * @throws MessagingException if an error occurs while publishing.
      * @throws IOException if there are problems with reading file with the post text.
      */

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/SourceforgeRssPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/SourceforgeRssPublisher.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 
 /**
  * Class for RSS post publication.
+ *
  * @author Vladislav Lisetskii
  */
 public class SourceforgeRssPublisher {
@@ -57,6 +58,7 @@ public class SourceforgeRssPublisher {
 
     /**
      * Default constructor.
+     *
      * @param postFilename the name of the file to get post text from.
      * @param bearerToken token for posting.
      * @param releaseNumber release number.
@@ -69,6 +71,7 @@ public class SourceforgeRssPublisher {
 
     /**
      * Publish release notes.
+     *
      * @throws IOException if problem with access to files appears.
      */
     public void publish() throws IOException {
@@ -99,6 +102,7 @@ public class SourceforgeRssPublisher {
 
     /**
      * Get number of posts in RSS feed.
+     *
      * @return number of posts in RSS feed or -1 if number is not found in response.
      * @throws IOException in case of problems with connection or InputStream.
      */

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/TwitterPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/TwitterPublisher.java
@@ -31,6 +31,7 @@ import twitter4j.auth.AccessToken;
 
 /**
  * Class for Twitter post publication.
+ *
  * @author Vladislav Lisetskii
  */
 public class TwitterPublisher {
@@ -49,6 +50,7 @@ public class TwitterPublisher {
 
     /**
      * Default constructor.
+     *
      * @param postFilename the name of the file to get post text from.
      * @param consumerKey consumer key.
      * @param consumerSecret consumer secret.
@@ -66,6 +68,7 @@ public class TwitterPublisher {
 
     /**
      * Publish post.
+     *
      * @throws TwitterException if an error occurs while publishing.
      * @throws IOException if there are problems with reading file with the post text.
      */

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/XdocPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/XdocPublisher.java
@@ -36,6 +36,7 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 /**
  * Class for xdoc publication.
+ *
  * @author Vladislav Lisetskii
  */
 public class XdocPublisher {
@@ -65,6 +66,7 @@ public class XdocPublisher {
 
     /**
      * Default constructor.
+     *
      * @param postFilename the name of the file to get post xml from.
      * @param localRepoPath path to a local git repository.
      * @param releaseNumber release number.
@@ -82,6 +84,7 @@ public class XdocPublisher {
 
     /**
      * Publish release notes.
+     *
      * @throws IOException if problem with access to files appears.
      * @throws GitAPIException for problems with jgit.
      */
@@ -108,6 +111,7 @@ public class XdocPublisher {
 
     /**
      * Do modification of an xdoc release notes in a local repo.
+     *
      * @throws IOException if problem with access to files appears.
      */
     private void changeLocalRepoXdoc() throws IOException {

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
@@ -48,6 +48,7 @@ import freemarker.template.TemplateExceptionHandler;
 
 /**
  * Util class to generate release notes output file with FreeMarker template engines.
+ *
  * @author Andrei Selkin
  */
 // -@cs[ClassDataAbstractionCoupling] No way to split this up right now.
@@ -62,6 +63,7 @@ public final class TemplateProcessor {
 
     /**
      * Generates output file with release notes using FreeMarker.
+     *
      * @param variables the map which represents template variables.
      * @param outputFile output file.
      * @param templateFileName the optional file name of the template.
@@ -91,6 +93,7 @@ public final class TemplateProcessor {
 
     /**
      * Loads a template file to a string, otherwise a resource template if the file isn't supplied.
+     *
      * @param fileName The path of the optional file to load.
      * @param defaultResource The path of the resource to load if there is no file.
      * @return The contents of the template.
@@ -117,6 +120,7 @@ public final class TemplateProcessor {
 
     /**
      * Returns the map which represents template variables.
+     *
      * @param releaseNotes release notes map.
      * @param remoteRepoPath remote repository path.
      * @param releaseNumber release number.


### PR DESCRIPTION
According to https://checkstyle.sourceforge.io/config_javadoc.html#JavadocParagraph
> There is one blank line between each of two paragraphs and one blank line before the at-clauses block if it is present.

Unfortunately, this check is not working yet in checkstyle, so many of these violations sneaked into the repository, but it's coming in https://github.com/checkstyle/checkstyle/pull/7932 .

I wrote a script to apply the missing newline violations from mvn verify. It is available here: https://github.com/josephmate/FixAtClauseError