### PR TITLE
minor: fix violations from JavadocMethod

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/XdocPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/XdocPublisher.java
@@ -113,6 +113,7 @@ public class XdocPublisher {
      * Do modification of an xdoc release notes in a local repo.
      *
      * @throws IOException if problem with access to files appears.
+     * @throws IllegalStateException if the placeholder for a new section could not be found.
      */
     private void changeLocalRepoXdoc() throws IOException {
         final Path pathToXdoc = Paths.get(localRepoPath + PATH_TO_XDOC_IN_REPO);

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/templates/TemplateProcessor.java
@@ -98,6 +98,7 @@ public final class TemplateProcessor {
      * @param defaultResource The path of the resource to load if there is no file.
      * @return The contents of the template.
      * @throws FileNotFoundException if the supplied file can't be found.
+     * @throws IllegalStateException if the resource can't be found.
      */
     private static String loadTemplate(String fileName, String defaultResource)
             throws FileNotFoundException {


### PR DESCRIPTION
Similar to https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/816, this is a PR to fix failing CI in checkstyle/checkstyle#8213.

These are Checkstyle violations that were previously not detected due to issue checkstyle/checkstyle#8117.