### PR TITLE
Issue #431: add timestamp to diff.groovy main report

### DIFF
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -192,7 +192,8 @@ def generateCheckstyleReport(cfg) {
     return new CheckstyleReportInfo(
         cfg.branch,
         getLastCommitSha(cfg.localGitRepo, cfg.branch),
-        getLastCommitMsg(cfg.localGitRepo, cfg.branch)
+        getLastCommitMsg(cfg.localGitRepo, cfg.branch),
+        getLastCommitTime(cfg.localGitRepo, cfg.branch)
     )
 }
 
@@ -204,6 +205,11 @@ def getLastCommitSha(gitRepo, branch) {
 def getLastCommitMsg(gitRepo, branch) {
     executeCmd("git checkout $branch", gitRepo)
     return 'git log -1 --pretty=%B'.execute(null, gitRepo).text.trim()
+}
+
+def getLastCommitTime(gitRepo, branch) {
+    executeCmd("git checkout $branch", gitRepo)
+    return 'git log -1 --format=%cd'.execute(null, gitRepo).text.trim()
 }
 
 def generateDiffReport(cfg) {
@@ -335,6 +341,8 @@ def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstyl
         summaryIndexHtml << ('<br />')
         summaryIndexHtml << "Base branch last commit message: \"$checkstyleBaseReportInfo.commitMsg\""
         summaryIndexHtml << ('<br />')
+        summaryIndexHtml << "Base branch last commit timestamp: \"$checkstyleBaseReportInfo.commitTime\""
+        summaryIndexHtml << ('<br />')
         summaryIndexHtml << ('<br />')
     }
     summaryIndexHtml << "Patch branch: $checkstylePatchReportInfo.branch"
@@ -342,6 +350,8 @@ def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstyl
     summaryIndexHtml << "Patch branch last commit SHA: $checkstylePatchReportInfo.commitSha"
     summaryIndexHtml << ('<br />')
     summaryIndexHtml << "Patch branch last commit message: \"$checkstylePatchReportInfo.commitMsg\""
+    summaryIndexHtml << ('<br />')
+    summaryIndexHtml << "Patch branch last commit timestamp: \"$checkstylePatchReportInfo.commitTime\""
     summaryIndexHtml << ('<br />')
     summaryIndexHtml << ('<br />')
     summaryIndexHtml << "Tested projects: ${projectsStatistic.size()}"
@@ -519,10 +529,12 @@ class CheckstyleReportInfo {
     def branch
     def commitSha
     def commitMsg
+    def commitTime
 
-    CheckstyleReportInfo(branch, commitSha, commitMsg) {
+    CheckstyleReportInfo(branch, commitSha, commitMsg, commitTime) {
         this.branch = branch
         this.commitSha = commitSha
         this.commitMsg = commitMsg
+        this.commitTime = commitTime
     }
 }


### PR DESCRIPTION
Issue #431: add timestamp to diff.groovy main report
Instead of adding timestamp next to SHA,  I made a new line.  This will make the timestamp easier to read, and since I thought the time zone was a relevant addition, the line would have been too long if printed next to SHA.

Example report:
![image](https://user-images.githubusercontent.com/31252532/86140205-a1d70f80-babe-11ea-95c5-f7ea4b496152.png)

