### PR TITLE
minor: add report generation time to diff.groovy (#431)

### DIFF
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -327,6 +327,7 @@ def getFilenameWithoutExtension(filename) {
 }
 
 def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstylePatchReportInfo, projectsStatistic) {
+    def date = new Date();
     summaryIndexHtml << ('<h6>')
     if (checkstyleBaseReportInfo) {
         summaryIndexHtml << "Base branch: $checkstyleBaseReportInfo.branch"
@@ -347,6 +348,8 @@ def printReportInfoSection(summaryIndexHtml, checkstyleBaseReportInfo, checkstyl
     summaryIndexHtml << "Tested projects: ${projectsStatistic.size()}"
     summaryIndexHtml << ('<br />')
     summaryIndexHtml << "&#177; differences found: ${projectsStatistic.values().sum()[0]}"
+    summaryIndexHtml << ('<br />')
+    summaryIndexHtml << "Time of report generation: $date"
     summaryIndexHtml << ('</h6>')
 }
 


### PR DESCRIPTION
Missed in #488, we needed to add report generation time to index.html