### PR TITLE
minor: add openjdk14 testing files list

### DIFF
--- a/misc/jdk14-test-files.list
+++ b/misc/jdk14-test-files.list
@@ -1,0 +1,3666 @@
+lib/combo/tools/javac/combo/CompilationTestCase.java                                                             Passed. Execution successful
+lib/combo/tools/javac/combo/Diagnostics.java                                                                     Passed. Execution successful
+lib/combo/tools/javac/combo/JavacTemplateTestBase.java                                                           Passed. Execution successful
+lib/combo/tools/javac/combo/Template.java                                                                        Passed. Execution successful
+lib/combo/tools/javac/combo/TemplateTest.java                                                                    Passed. Execution successful
+tools/all/RunCodingRules.java                                                                                    Passed. Execution successful
+tools/doclint/AccessTest.java                                                                                    Passed. Execution successful
+tools/doclint/AccessibilityTest.java                                                                             Passed. Execution successful
+tools/doclint/AnchorTest.java                                                                                    Passed. Execution successful
+tools/doclint/AnchorTest2.java                                                                                   Passed. Execution successful
+tools/doclint/BadPackageCommentTest.java                                                                         Passed. Execution successful
+tools/doclint/CoverageExtras.java                                                                                Passed. Execution successful
+tools/doclint/CustomTagTest.java                                                                                 Passed. Execution successful
+tools/doclint/DuplicateParamTest.java                                                                            Passed. Execution successful
+tools/doclint/DuplicateReturnTest.java                                                                           Passed. Execution successful
+tools/doclint/EmptyAuthorTest.java                                                                               Passed. Execution successful
+tools/doclint/EmptyExceptionTest.java                                                                            Passed. Execution successful
+tools/doclint/EmptyParamTest.java                                                                                Passed. Execution successful
+tools/doclint/EmptyPreTest.java                                                                                  Passed. Execution successful
+tools/doclint/EmptyReturnTest.java                                                                               Passed. Execution successful
+tools/doclint/EmptySerialDataTest.java                                                                           Passed. Execution successful
+tools/doclint/EmptySerialFieldTest.java                                                                          Passed. Execution successful
+tools/doclint/EmptySinceTest.java                                                                                Passed. Execution successful
+tools/doclint/EmptyVersionTest.java                                                                              Passed. Execution successful
+tools/doclint/EndTagsTest.java                                                                                   Passed. Execution successful
+tools/doclint/EndWithIdentifierTest.java                                                                         Passed. Execution successful
+tools/doclint/HtmlAttrsTest.java                                                                                 Passed. Execution successful
+tools/doclint/HtmlTagsTest.java                                                                                  Passed. Execution successful
+tools/doclint/HtmlVersionTest.java                                                                               Passed. Execution successful
+tools/doclint/LambdaTest.java                                                                                    Passed. Execution successful
+tools/doclint/LiteralTest.java                                                                                   Passed. Execution successful
+tools/doclint/MissingCommentTest.java                                                                            Passed. Execution successful
+tools/doclint/MissingParamsTest.java                                                                             Passed. Execution successful
+tools/doclint/MissingReturnTest.java                                                                             Passed. Execution successful
+tools/doclint/MissingThrowsTest.java                                                                             Passed. Execution successful
+tools/doclint/MultipleDocLintOptionsTest.java                                                                    Passed. Compilation failed as expected
+tools/doclint/OptionTest.java                                                                                    Passed. Execution successful
+tools/doclint/OverridesTest.java                                                                                 Passed. Execution successful
+tools/doclint/ParaTagTest.java                                                                                   Passed. Execution successful
+tools/doclint/ProvidesTest.java                                                                                  Passed. Execution successful
+tools/doclint/ReferenceTest.java                                                                                 Passed. Execution successful
+tools/doclint/ResourceTest.java                                                                                  Passed. Execution successful
+tools/doclint/RunTest.java                                                                                       Passed. Execution successful
+tools/doclint/SummaryTest.java                                                                                   Passed. Execution successful
+tools/doclint/SyntaxTest.java                                                                                    Passed. Execution successful
+tools/doclint/SyntheticTest.java                                                                                 Passed. Execution successful
+tools/doclint/UnfinishedInlineTagTest.java                                                                       Passed. Execution successful
+tools/doclint/UsesTest.java                                                                                      Passed. Execution successful
+tools/doclint/ValidTest.java                                                                                     Passed. Execution successful
+tools/doclint/ValueTest.java                                                                                     Passed. Execution successful
+tools/doclint/anchorTests/p/Test.java                                                                            Passed. Compilation failed as expected
+tools/doclint/anchorTests/p/package-info.java                                                                    Passed. Compilation failed as expected
+tools/doclint/html/BlockTagsTest.java                                                                            Passed. Execution successful
+tools/doclint/html/EntitiesTest.java                                                                             Passed. Execution successful
+tools/doclint/html/HtmlVersionTagsAttrsTest.java                                                                 Passed. Execution successful
+tools/doclint/html/InlineTagsTest.java                                                                           Passed. Execution successful
+tools/doclint/html/ListTagsTest.java                                                                             Passed. Execution successful
+tools/doclint/html/OtherTagsTest.java                                                                            Passed. Execution successful
+tools/doclint/html/TableTagsTest.java                                                                            Passed. Execution successful
+tools/doclint/html/TagNotAllowed.java                                                                            Passed. Execution successful
+tools/doclint/html/TextNotAllowed.java                                                                           Passed. Execution successful
+tools/doclint/moduleTests/bad/module-info.java                                                                   Passed. Compilation failed as expected
+tools/doclint/moduleTests/good/module-info.java                                                                  Passed. Compilation successful
+tools/doclint/multipackage/MultiPackage.java                                                                     Passed. Compilation failed as expected
+tools/doclint/packageTests/bad/Test.java                                                                         Passed. Compilation failed as expected
+tools/doclint/packageTests/bad/package-info.java                                                                 Passed. Compilation failed as expected
+tools/doclint/packageTests/good/Test.java                                                                        Passed. Compilation successful
+tools/doclint/packageTests/good/package-info.java                                                                Passed. Compilation successful
+tools/doclint/tidy/AnchorAlreadyDefined.java                                                                     Passed. Execution successful
+tools/doclint/tidy/BadEnd.java                                                                                   Passed. Execution successful
+tools/doclint/tidy/InsertImplicit.java                                                                           Passed. Execution successful
+tools/doclint/tidy/InvalidEntity.java                                                                            Passed. Execution successful
+tools/doclint/tidy/InvalidName.java                                                                              Passed. Execution successful
+tools/doclint/tidy/InvalidTag.java                                                                               Passed. Execution successful
+tools/doclint/tidy/InvalidURI.java                                                                               Passed. Execution successful
+tools/doclint/tidy/MissingGT.java                                                                                Passed. Execution successful
+tools/doclint/tidy/MissingTag.java                                                                               Passed. Execution successful
+tools/doclint/tidy/NestedTag.java                                                                                Passed. Execution successful
+tools/doclint/tidy/ParaInPre.java                                                                                Passed. Execution successful
+tools/doclint/tidy/RepeatedAttr.java                                                                             Passed. Execution successful
+tools/doclint/tidy/TextNotAllowed.java                                                                           Passed. Execution successful
+tools/doclint/tidy/TrimmingEmptyTag.java                                                                         Passed. Execution successful
+tools/doclint/tidy/UnescapedOrUnknownEntity.java                                                                 Passed. Execution successful
+tools/doclint/tool/HelpTest.java                                                                                 Passed. Execution successful
+tools/doclint/tool/MaxDiagsTest.java                                                                             Passed. Execution successful
+tools/doclint/tool/PathsTest.java                                                                                Passed. Execution successful
+tools/doclint/tool/RunTest.java                                                                                  Passed. Execution successful
+tools/doclint/tool/StatsTest.java                                                                                Passed. Execution successful
+tools/javac/4241573/T4241573.java                                                                                Passed. Execution successful
+tools/javac/4846262/CheckEBCDICLocaleTest.java                                                                   Passed. Execution successful
+tools/javac/4880220/T4880220.java                                                                                Passed. Compilation failed as expected
+tools/javac/4917091/Test255.java                                                                                 Passed. Execution successful
+tools/javac/4917091/Test256a.java                                                                                Passed. Compilation failed as expected
+tools/javac/4917091/Test256b.java                                                                                Passed. Compilation failed as expected
+tools/javac/4980495/static/Test.java                                                                             Passed. Compilation failed as expected
+tools/javac/4980495/std/NonStatic2StaticImportClash.java                                                         Passed. Compilation failed as expected
+tools/javac/4980495/std/Static2NonStaticImportClash.java                                                         Passed. Compilation failed as expected
+tools/javac/4980495/std/Test.java                                                                                Passed. Compilation failed as expected
+tools/javac/5017953/T5017953.java                                                                                Passed. Compilation failed as expected
+tools/javac/5045412/Bar.java                                                                                     Passed. Compilation successful
+tools/javac/5045412/Foo.java                                                                                     Passed. Compilation successful
+tools/javac/6199662/Tree.java                                                                                    Passed. Compilation successful
+tools/javac/6257443/T6257443.java                                                                                Passed. Execution successful
+tools/javac/6302184/HiddenOptionsShouldUseGivenEncodingTest.java                                                 Passed. Execution successful
+tools/javac/6304921/T6304921.java                                                                                Passed. Compilation failed as expected
+tools/javac/6304921/TestLog.java                                                                                 Passed. Execution successful
+tools/javac/6330920/T6330920.java                                                                                Passed. Compilation failed as expected
+tools/javac/6330997/T6330997.java                                                                                Passed. Execution successful
+tools/javac/6341866/T6341866.java                                                                                Passed. Execution successful
+tools/javac/6342411/T6342411.java                                                                                Passed. Execution successful
+tools/javac/6360970/T6360970.java                                                                                Passed. Compilation failed as expected
+tools/javac/6390045/T6390045a.java                                                                               Passed. Compilation successful
+tools/javac/6390045/T6390045b.java                                                                               Passed. Compilation successful
+tools/javac/6394683/T6394683.java                                                                                Passed. Execution successful
+tools/javac/6400383/T6400383.java                                                                                Passed. Execution successful
+tools/javac/6400872/T6400872.java                                                                                Passed. Execution successful
+tools/javac/6402516/CheckClass.java                                                                              Passed. Execution successful
+tools/javac/6402516/CheckIsAccessible.java                                                                       Passed. Execution successful
+tools/javac/6402516/CheckLocalElements.java                                                                      Passed. Execution successful
+tools/javac/6402516/CheckMethod.java                                                                             Passed. Execution successful
+tools/javac/6403424/T6403424.java                                                                                Passed. Execution successful
+tools/javac/6440583/T6440583.java                                                                                Passed. Execution successful
+tools/javac/6457284/T6457284.java                                                                                Passed. Execution successful
+tools/javac/6491592/T6491592.java                                                                                Passed. Compilation failed as expected
+tools/javac/6508981/TestInferBinaryName.java                                                                     Passed. Execution successful
+tools/javac/6520152/T6520152.java                                                                                Passed. Execution successful
+tools/javac/6521805/T6521805b.java                                                                               Passed. Compilation successful
+tools/javac/6521805/T6521805c.java                                                                               Passed. Compilation successful
+tools/javac/6521805/T6521805d.java                                                                               Passed. Compilation failed as expected
+tools/javac/6521805/T6521805e.java                                                                               Passed. Compilation failed as expected
+tools/javac/6547131/T.java                                                                                       Passed. Execution successful
+tools/javac/6558548/T6558548.java                                                                                Passed. Compilation failed as expected
+tools/javac/6563143/EqualsHashCodeWarningTest.java                                                               Passed. Compilation successful
+tools/javac/6567415/T6567415.java                                                                                Passed. Execution successful
+tools/javac/6589361/T6589361.java                                                                                Passed. Execution successful
+tools/javac/6627362/T6627362.java                                                                                Passed. Execution successful
+tools/javac/6668794/badClass/Test.java                                                                           Passed. Execution successful
+tools/javac/6668794/badSource/Test.java                                                                          Passed. Compilation failed as expected
+tools/javac/6717241/T6717241a.java                                                                               Passed. Compilation failed as expected
+tools/javac/6717241/T6717241b.java                                                                               Passed. Compilation failed as expected
+tools/javac/6734819/T6734819a.java                                                                               Passed. Compilation successful
+tools/javac/6734819/T6734819b.java                                                                               Passed. Compilation successful
+tools/javac/6734819/T6734819c.java                                                                               Passed. Compilation failed as expected
+tools/javac/6758789/T6758789a.java                                                                               Passed. Compilation failed as expected
+tools/javac/6758789/T6758789b.java                                                                               Passed. Compilation failed as expected
+tools/javac/6835430/T6835430.java                                                                                Passed. Compilation successful
+tools/javac/6840059/T6840059.java                                                                                Passed. Compilation failed as expected
+tools/javac/6857948/T6857948.java                                                                                Passed. Compilation failed as expected
+tools/javac/6863465/T6863465a.java                                                                               Passed. Compilation failed as expected
+tools/javac/6863465/T6863465b.java                                                                               Passed. Compilation failed as expected
+tools/javac/6863465/T6863465c.java                                                                               Passed. Compilation failed as expected
+tools/javac/6863465/T6863465d.java                                                                               Passed. Compilation failed as expected
+tools/javac/6863465/TestCircularClassfile.java                                                                   Passed. Execution successful
+tools/javac/6889255/T6889255.java                                                                                Passed. Execution successful
+tools/javac/6902720/Test.java                                                                                    Passed. Execution successful
+tools/javac/6917288/GraphicalInstallerTest.java                                                                  Passed. Execution successful
+tools/javac/6917288/T6917288.java                                                                                Passed. Execution successful
+tools/javac/6948381/T6948381.java                                                                                Passed. Compilation successful
+tools/javac/6979683/TestCast6979683_BAD34.java                                                                   Passed. Compilation failed as expected
+tools/javac/6979683/TestCast6979683_BAD35.java                                                                   Passed. Compilation failed as expected
+tools/javac/6979683/TestCast6979683_BAD36.java                                                                   Passed. Compilation failed as expected
+tools/javac/6979683/TestCast6979683_BAD37.java                                                                   Passed. Compilation failed as expected
+tools/javac/6979683/TestCast6979683_BAD38.java                                                                   Passed. Compilation failed as expected
+tools/javac/6979683/TestCast6979683_BAD39.java                                                                   Passed. Compilation failed as expected
+tools/javac/6979683/TestCast6979683_GOOD.java                                                                    Passed. Execution successful
+tools/javac/6996626/Main.java                                                                                    Passed. Compilation successful
+tools/javac/7003595/T7003595.java                                                                                Passed. Execution successful
+tools/javac/7003595/T7003595b.java                                                                               Passed. Execution successful
+tools/javac/7023703/T7023703neg.java                                                                             Passed. Compilation failed as expected
+tools/javac/7023703/T7023703pos.java                                                                             Passed. Compilation successful
+tools/javac/7024568/T7024568.java                                                                                Passed. Compilation failed as expected
+tools/javac/7079713/TestCircularClassfile.java                                                                   Passed. Execution successful
+tools/javac/7085024/T7085024.java                                                                                Passed. Compilation failed as expected
+tools/javac/7086595/T7086595.java                                                                                Passed. Compilation failed as expected
+tools/javac/7102515/T7102515.java                                                                                Passed. Compilation failed as expected
+tools/javac/7118412/ShadowingTest.java                                                                           Passed. Execution successful
+tools/javac/7129225/TestImportStar.java                                                                          Passed. Compilation failed as expected
+tools/javac/7132880/T7132880.java                                                                                Passed. Compilation failed as expected
+tools/javac/7142086/T7142086.java                                                                                Passed. Execution successful
+tools/javac/7144981/IgnoreIgnorableCharactersInInput.java                                                        Passed. Execution successful
+tools/javac/7153958/CPoolRefClassContainingInlinedCts.java                                                       Passed. Execution successful
+tools/javac/7166455/CheckACC_STRICTFlagOnclinitTest.java                                                         Passed. Execution successful
+tools/javac/7167125/DiffResultAfterSameOperationInnerClasses.java                                                Passed. Execution successful
+tools/javac/7182350/T7182350.java                                                                                Passed. Compilation successful
+tools/javac/7199823/InnerClassCannotBeVerified.java                                                              Passed. Execution successful
+tools/javac/8000518/DuplicateConstantPoolEntry.java                                                              Passed. Execution successful
+tools/javac/8002286/T8002286.java                                                                                Passed. Compilation failed as expected
+tools/javac/8005931/CheckACC_STRICTFlagOnPkgAccessClassTest.java                                                 Passed. Execution successful
+tools/javac/8009170/RedundantByteCodeInArrayTest.java                                                            Passed. Execution successful
+tools/javac/8052070/DuplicateTypeParameter.java                                                                  Passed. Compilation failed as expected
+tools/javac/8062359/UnresolvableClassNPEInAttrTest.java                                                          Passed. Compilation failed as expected
+tools/javac/8074306/TestSyntheticNullChecks.java                                                                 Passed. Execution successful
+tools/javac/8133247/T8133247.java                                                                                Passed. Execution successful
+tools/javac/8138840/T8138840.java                                                                                Passed. Compilation failed as expected
+tools/javac/8138840/T8139243.java                                                                                Passed. Compilation failed as expected
+tools/javac/8138840/T8139249.java                                                                                Passed. Compilation failed as expected
+tools/javac/8161985/T8161985a.java                                                                               Passed. Compilation failed as expected
+tools/javac/8161985/T8161985b.java                                                                               Passed. Compilation failed as expected
+tools/javac/8167000/T8167000.java                                                                                Passed. Compilation failed as expected
+tools/javac/8167000/T8167000b.java                                                                               Passed. Compilation failed as expected
+tools/javac/8167000/T8167000c.java                                                                               Passed. Compilation failed as expected
+tools/javac/8169345/T8169345a.java                                                                               Passed. Execution successful
+tools/javac/8169345/T8169345b.java                                                                               Passed. Execution successful
+tools/javac/8169345/T8169345c.java                                                                               Passed. Compilation successful
+tools/javac/8194932/T8194932.java                                                                                Passed. Compilation failed as expected
+tools/javac/8203436/T8203436a.java                                                                               Passed. Compilation failed as expected
+tools/javac/8203436/T8203436b.java                                                                               Passed. Compilation failed as expected
+tools/javac/AbstractOverride.java                                                                                Passed. Compilation successful
+tools/javac/AccessMethods/AccessMethodsLHS.java                                                                  Passed. Execution successful
+tools/javac/AccessMethods/BitwiseAssignment.java                                                                 Passed. Execution successful
+tools/javac/AccessMethods/ChainedAssignment.java                                                                 Passed. Execution successful
+tools/javac/AccessMethods/ConstructorAccess.java                                                                 Passed. Execution successful
+tools/javac/AccessMethods/InternalHandshake.java                                                                 Passed. Execution successful
+tools/javac/AccessMethods/LateAddition.java                                                                      Passed. Compilation successful
+tools/javac/AccessMethods/UplevelPrivateConstants.java                                                           Passed. Compilation successful
+tools/javac/AddReferenceThis.java                                                                                Passed. Compilation successful
+tools/javac/Ambig3.java                                                                                          Passed. Compilation failed as expected
+tools/javac/AnonClsInIntf.java                                                                                   Passed. Compilation successful
+tools/javac/AnonInnerException_1.java                                                                            Passed. Compilation successful
+tools/javac/AnonInnerException_2.java                                                                            Passed. Compilation successful
+tools/javac/AnonInnerException_3.java                                                                            Passed. Compilation failed as expected
+tools/javac/AnonStaticMember_1.java                                                                              Passed. Compilation failed as expected
+tools/javac/AnonStaticMember_2.java                                                                              Passed. Compilation failed as expected
+tools/javac/AnonStaticMember_3.java                                                                              Passed. Compilation successful
+tools/javac/AnonymousClass/AnonymousClassFlags.java                                                              Passed. Execution successful
+tools/javac/AnonymousClass/AnonymousCtorExceptionTest.java                                                       Passed. Execution successful
+tools/javac/AnonymousClass/AnonymousInSuperCallNegTest.java                                                      Passed. Compilation failed as expected
+tools/javac/AnonymousClass/AnonymousInSuperCallTest.java                                                         Passed. Execution successful
+tools/javac/AnonymousClass/CtorAccessBypassTest.java                                                             Passed. Execution successful
+tools/javac/AnonymousConstructorExceptions.java                                                                  Passed. Compilation successful
+tools/javac/AnonymousNull.java                                                                                   Passed. Compilation successful
+tools/javac/AnonymousProtect/AnonymousProtect.java                                                               Passed. Compilation successful
+tools/javac/AnonymousSubclassTest.java                                                                           Passed. Execution successful
+tools/javac/AnonymousType.java                                                                                   Passed. Compilation successful
+tools/javac/ArrayCast.java                                                                                       Passed. Compilation successful
+tools/javac/AvoidNPEAtClassReader/AvoidNPEAtClassReaderTest.java                                                 Passed. Compilation successful
+tools/javac/BadAnnotation.java                                                                                   Passed. Compilation failed as expected
+tools/javac/BadBreak.java                                                                                        Passed. Execution successful
+tools/javac/BadCovar.java                                                                                        Passed. Compilation failed as expected
+tools/javac/BadHexConstant.java                                                                                  Passed. Compilation failed as expected
+tools/javac/BadOptimization/DeadCode1.java                                                                       Passed. Execution successful
+tools/javac/BadOptimization/DeadCode2.java                                                                       Passed. Execution successful
+tools/javac/BadOptimization/DeadCode3.java                                                                       Passed. Execution successful
+tools/javac/BadOptimization/DeadCode4.java                                                                       Passed. Execution successful
+tools/javac/BadOptimization/DeadCode5.java                                                                       Passed. Execution successful
+tools/javac/BadOptimization/DeadCode6.java                                                                       Passed. Compilation successful
+tools/javac/BadOptimization/Switch1.java                                                                         Passed. Execution successful
+tools/javac/BadOptimization/Switch2.java                                                                         Passed. Execution successful
+tools/javac/BoolArray.java                                                                                       Passed. Compilation successful
+tools/javac/BoundClassError.java                                                                                 Passed. Compilation failed as expected
+tools/javac/BranchToFewerDefines.java                                                                            Passed. Execution successful
+tools/javac/BreakAcrossClass.java                                                                                Passed. Compilation failed as expected
+tools/javac/CaptureInSubtype.java                                                                                Passed. Compilation failed as expected
+tools/javac/CascadedInnerNewInstance.java                                                                        Passed. Compilation successful
+tools/javac/CastInterface2Array.java                                                                             Passed. Compilation successful
+tools/javac/CheckNoClassCastException.java                                                                       Passed. Execution successful
+tools/javac/ClassCycle/ClassCycle1a.java                                                                         Passed. Compilation failed as expected
+tools/javac/ClassCycle/ClassCycle2a.java                                                                         Passed. Compilation failed as expected
+tools/javac/ClassCycle/ClassCycle3a.java                                                                         Passed. Compilation failed as expected
+tools/javac/ClassFileModifiers/ClassModifiers.java                                                               Passed. Compilation successful
+tools/javac/ClassFileModifiers/MemberModifiers.java                                                              Passed. Compilation successful
+tools/javac/ClassIsAbstract.java                                                                                 Passed. Compilation failed as expected
+tools/javac/ClassLit.java                                                                                        Passed. Execution successful
+tools/javac/ClassLiterals/ClassLiteralHelperContext.java                                                         Passed. Execution successful
+tools/javac/ClassLiterals/InitializeOuter.java                                                                   Passed. Execution successful
+tools/javac/ClassLiterals/InitializeTarget.java                                                                  Passed. Execution successful
+tools/javac/ClassLiterals/evalinit/ClassLiteralEvalInit.java                                                     Passed. Compilation successful
+tools/javac/ClassModifiers/InterfaceAndInnerClsCtor.java                                                         Passed. Compilation successful
+tools/javac/ClassPathTest/ClassPathTest.java                                                                     Passed. Execution successful
+tools/javac/ClassToTypeParm.java                                                                                 Passed. Compilation failed as expected
+tools/javac/CloneableProblem.java                                                                                Passed. Compilation successful
+tools/javac/Closure1.java                                                                                        Passed. Execution successful
+tools/javac/Closure2.java                                                                                        Passed. Execution successful
+tools/javac/Closure3.java                                                                                        Passed. Execution successful
+tools/javac/Closure4.java                                                                                        Passed. Execution successful
+tools/javac/Closure5.java                                                                                        Passed. Execution successful
+tools/javac/Closure6.java                                                                                        Passed. Execution successful
+tools/javac/CompoundBox.java                                                                                     Passed. Compilation failed as expected
+tools/javac/ConditionalArgTypes_1.java                                                                           Passed. Compilation successful
+tools/javac/ConditionalArgTypes_2.java                                                                           Passed. Compilation successful
+tools/javac/ConditionalExpressionResolvePending.java                                                             Passed. Execution successful
+tools/javac/ConditionalInline.java                                                                               Passed. Compilation successful
+tools/javac/ConditionalWithVoid.java                                                                             Passed. Compilation failed as expected
+tools/javac/ConstBoolAppend.java                                                                                 Passed. Execution successful
+tools/javac/ConstCharAppend.java                                                                                 Passed. Execution successful
+tools/javac/ConstFoldTest.java                                                                                   Passed. Execution successful
+tools/javac/ConstantValues/ConstValInit.java                                                                     Passed. Execution successful
+tools/javac/ConstantValues/ConstValInlining.java                                                                 Passed. Execution successful
+tools/javac/CyclicInheritance.java                                                                               Passed. Compilation failed as expected
+tools/javac/CyclicInheritance2.java                                                                              Passed. Compilation successful
+tools/javac/CyclicInheritance4.java                                                                              Passed. Execution successful
+tools/javac/CyclicInheritance6/Main.java                                                                         Passed. Compilation successful
+tools/javac/CyclicScoping/CyclicScoping_1.java                                                                   Passed. Compilation failed as expected
+tools/javac/CyclicScoping/CyclicScoping_2.java                                                                   Passed. Compilation failed as expected
+tools/javac/DeadInnerClass.java                                                                                  Passed. Compilation successful
+tools/javac/DeclarationStatementInline.java                                                                      Passed. Compilation successful
+tools/javac/DeepStringConcat.java                                                                                Passed. Compilation successful
+tools/javac/DefiniteAssignment/7003744/T7003744a.java                                                            Passed. Compilation successful
+tools/javac/DefiniteAssignment/7003744/T7003744b.java                                                            Passed. Compilation successful
+tools/javac/DefiniteAssignment/8156180/T8156180.java                                                             Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DABlock.java                                                                      Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DALoop1.java                                                                      Passed. Compilation successful
+tools/javac/DefiniteAssignment/DASwitch.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DUAssert.java                                                                     Passed. Compilation successful
+tools/javac/DefiniteAssignment/DUBeforeDefined1.java                                                             Passed. Execution successful
+tools/javac/DefiniteAssignment/DUBeforeDefined2.java                                                             Passed. Execution successful
+tools/javac/DefiniteAssignment/DUParam1.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DUParam2.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DUSwitch.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DUSwitch2.java                                                                    Passed. Compilation successful
+tools/javac/DefiniteAssignment/DUTry.java                                                                        Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignAfterIf_1.java                                                           Passed. Compilation successful
+tools/javac/DefiniteAssignment/DefAssignAfterIf_2.java                                                           Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignAfterThis_1.java                                                         Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignAfterThis_2.java                                                         Passed. Compilation successful
+tools/javac/DefiniteAssignment/DefAssignAfterTry1.java                                                           Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignAfterTry2.java                                                           Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignAfterTry3.java                                                           Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_1.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_10.java                                         Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_11.java                                         Passed. Compilation successful
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_12.java                                         Passed. Compilation successful
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_13.java                                         Passed. Compilation successful
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_14.java                                         Passed. Compilation successful
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_2.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_3.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_4.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_5.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_6.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_7.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_8.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignBoolean_9.java                                          Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignCond.java                                               Passed. Execution successful
+tools/javac/DefiniteAssignment/DefAssignBoolean/DefAssignConstantBoolean.java                                    Passed. Compilation successful
+tools/javac/DefiniteAssignment/DefAssignNestedArg.java                                                           Passed. Compilation successful
+tools/javac/DefiniteAssignment/T4704365.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4717164.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4717165.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4718134.java                                                                     Passed. Compilation successful
+tools/javac/DefiniteAssignment/T4718142.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4718142a.java                                                                    Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4718708.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4720379.java                                                                     Passed. Compilation successful
+tools/javac/DefiniteAssignment/T4720751.java                                                                     Passed. Compilation successful
+tools/javac/DefiniteAssignment/T4721062a.java                                                                    Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4721062b.java                                                                    Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T4721076.java                                                                     Passed. Compilation successful
+tools/javac/DefiniteAssignment/T4721998.java                                                                     Passed. Compilation successful
+tools/javac/DefiniteAssignment/T4725725.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T7181578.java                                                                     Passed. Compilation successful
+tools/javac/DefiniteAssignment/T8039026.java                                                                     Passed. Compilation failed as expected
+tools/javac/DefiniteAssignment/T8204610.java                                                                     Passed. Execution successful
+tools/javac/DefiniteAssignment/ThrowBeforeTryFinally.java                                                        Passed. Compilation successful
+tools/javac/DefiniteAssignment/UncaughtException.java                                                            Passed. Compilation failed as expected
+tools/javac/DepParam.java                                                                                        Passed. Compilation successful
+tools/javac/Diagnostics/6722234/T6722234a.java                                                                   Passed. Compilation failed as expected
+tools/javac/Diagnostics/6722234/T6722234b.java                                                                   Passed. Compilation failed as expected
+tools/javac/Diagnostics/6722234/T6722234c.java                                                                   Passed. Compilation failed as expected
+tools/javac/Diagnostics/6722234/T6722234d.java                                                                   Passed. Compilation failed as expected
+tools/javac/Diagnostics/6769027/T6769027.java                                                                    Passed. Execution successful
+tools/javac/Diagnostics/6799605/T6799605.java                                                                    Passed. Compilation failed as expected
+tools/javac/Diagnostics/6860795/T6860795.java                                                                    Passed. Compilation failed as expected
+tools/javac/Diagnostics/6862608/T6862608a.java                                                                   Passed. Compilation failed as expected
+tools/javac/Diagnostics/6862608/T6862608b.java                                                                   Passed. Compilation failed as expected
+tools/javac/Diagnostics/6864382/T6864382.java                                                                    Passed. Compilation failed as expected
+tools/javac/Diagnostics/7010608/Test.java                                                                        Passed. Execution successful
+tools/javac/Diagnostics/7116676/T7116676.java                                                                    Passed. Execution successful
+tools/javac/Diagnostics/8010387/T8010387.java                                                                    Passed. Compilation failed as expected
+tools/javac/Diagnostics/compressed/8067883/T8067883.java                                                         Passed. Compilation failed as expected
+tools/javac/Diagnostics/compressed/T8012003a.java                                                                Passed. Compilation failed as expected
+tools/javac/Diagnostics/compressed/T8012003b.java                                                                Passed. Compilation failed as expected
+tools/javac/Diagnostics/compressed/T8012003c.java                                                                Passed. Compilation failed as expected
+tools/javac/Diagnostics/compressed/T8020286.java                                                                 Passed. Compilation failed as expected
+tools/javac/Digits.java                                                                                          Passed. Compilation failed as expected
+tools/javac/DivByZero.java                                                                                       Passed. Compilation successful
+tools/javac/DuplicateClass.java                                                                                  Passed. Compilation failed as expected
+tools/javac/DuplicateClass2.java                                                                                 Passed. Compilation successful
+tools/javac/DuplicateImport.java                                                                                 Passed. Compilation successful
+tools/javac/EOI.java                                                                                             Passed. Compilation failed as expected
+tools/javac/EarlyAssert.java                                                                                     Passed. Execution successful
+tools/javac/EmptyArray.java                                                                                      Passed. Compilation successful
+tools/javac/EmptyBreak.java                                                                                      Passed. Compilation successful
+tools/javac/EmptyDocComments.java                                                                                Passed. Compilation successful
+tools/javac/EmptySwitch.java                                                                                     Passed. Execution successful
+tools/javac/EnclosingAccessCheck.java                                                                            Passed. Compilation failed as expected
+tools/javac/Enum1.java                                                                                           Passed. Execution successful
+tools/javac/ExceptionalFinally.java                                                                              Passed. Compilation successful
+tools/javac/ExceptionalFinally2.java                                                                             Passed. Compilation failed as expected
+tools/javac/ExprQualifiedType.java                                                                               Passed. Compilation failed as expected
+tools/javac/ExtDirs/ExtDirTest.java                                                                              Passed. Execution successful
+tools/javac/ExtendArray.java                                                                                     Passed. Compilation failed as expected
+tools/javac/ExtendsAccess/ExtendsAccess.java                                                                     Passed. Compilation failed as expected
+tools/javac/ExtendsScope.java                                                                                    Passed. Compilation failed as expected
+tools/javac/ExtraneousEquals.java                                                                                Passed. Compilation failed as expected
+tools/javac/FaultySignature.java                                                                                 Passed. Execution successful
+tools/javac/FinalInitializer.java                                                                                Passed. Compilation successful
+tools/javac/FinalInitializer_2.java                                                                              Passed. Compilation successful
+tools/javac/FinalIntConcatenation.java                                                                           Passed. Execution successful
+tools/javac/FinalThisReference.java                                                                              Passed. Compilation successful
+tools/javac/FinallyWarn.java                                                                                     Passed. Compilation successful
+tools/javac/FlatnameClash.java                                                                                   Passed. Compilation failed as expected
+tools/javac/FlatnameClash2.java                                                                                  Passed. Compilation failed as expected
+tools/javac/FloatingPointChanges/BadConstructorModifiers.java                                                    Passed. Compilation failed as expected
+tools/javac/FloatingPointChanges/Test.java                                                                       Passed. Execution successful
+tools/javac/FoldConditional.java                                                                                 Passed. Execution successful
+tools/javac/ForwardReference/ForwardReference_2.java                                                             Passed. Compilation failed as expected
+tools/javac/ForwardReference/ForwardReference_4.java                                                             Passed. Compilation failed as expected
+tools/javac/ForwardReference/ForwardReference_5.java                                                             Passed. Compilation successful
+tools/javac/ForwardReference/T6676362a.java                                                                      Passed. Compilation successful
+tools/javac/ForwardReference/T6676362b.java                                                                      Passed. Compilation successful
+tools/javac/ForwardReference/UseBeforeDeclaration.java                                                           Passed. Compilation successful
+tools/javac/GoodCovar.java                                                                                       Passed. Compilation successful
+tools/javac/HexFloatLiterals.java                                                                                Passed. Execution successful
+tools/javac/HexThree.java                                                                                        Passed. Execution successful
+tools/javac/HiddenAbstractMethod/Test.java                                                                       Passed. Compilation failed as expected
+tools/javac/IllDefinedOrderOfInit.java                                                                           Passed. Execution successful
+tools/javac/IllegalAnnotation.java                                                                               Passed. Compilation failed as expected
+tools/javac/IllegallyOptimizedException.java                                                                     Passed. Execution successful
+tools/javac/ImplicitToString.java                                                                                Passed. Execution successful
+tools/javac/ImportCycle/Dummy.java                                                                               Passed. Compilation successful
+tools/javac/ImportPackagePrivateInner/Dummy.java                                                                 Passed. Compilation successful
+tools/javac/ImportUnnamed/Dummy.java                                                                             Passed. Compilation failed as expected
+tools/javac/InconsistentInheritedSignature.java                                                                  Passed. Compilation failed as expected
+tools/javac/InconsistentStack.java                                                                               Passed. Execution successful
+tools/javac/IncorrectInheritance/IncorrectInheritanceTest.java                                                   Passed. Execution successful
+tools/javac/Increment.java                                                                                       Passed. Compilation successful
+tools/javac/InheritedPrivateImpl.java                                                                            Passed. Compilation successful
+tools/javac/InitializerCompletion_1.java                                                                         Passed. Compilation failed as expected
+tools/javac/InitializerCompletion_2.java                                                                         Passed. Compilation successful
+tools/javac/InitializerCompletion_3.java                                                                         Passed. Compilation failed as expected
+tools/javac/InitializerCompletion_4.java                                                                         Passed. Compilation successful
+tools/javac/InnerClassesAttribute/Test.java                                                                      Passed. Compilation successful
+tools/javac/InnerMemberRegression.java                                                                           Passed. Compilation successful
+tools/javac/InnerMethSig.java                                                                                    Passed. Compilation successful
+tools/javac/InnerNamedConstant_1.java                                                                            Passed. Execution successful
+tools/javac/InnerNamedConstant_2.java                                                                            Passed. Compilation failed as expected
+tools/javac/InnerTruth.java                                                                                      Passed. Execution successful
+tools/javac/InstanceInitException_1.java                                                                         Passed. Compilation successful
+tools/javac/InstanceInitException_2.java                                                                         Passed. Compilation failed as expected
+tools/javac/InterfaceAssert.java                                                                                 Passed. Execution successful
+tools/javac/InterfaceFieldParsing_1.java                                                                         Passed. Compilation failed as expected
+tools/javac/InterfaceInInner.java                                                                                Passed. Compilation failed as expected
+tools/javac/InterfaceMemberClassModifiers.java                                                                   Passed. Compilation failed as expected
+tools/javac/InterfaceObjectIncompatibility.java                                                                  Passed. Compilation failed as expected
+tools/javac/InterfaceObjectInheritance.java                                                                      Passed. Compilation failed as expected
+tools/javac/InterfaceOverrideCheck.java                                                                          Passed. Compilation failed as expected
+tools/javac/InterfaceOverrideFinal.java                                                                          Passed. Compilation failed as expected
+tools/javac/InterfaceOverrideObject.java                                                                         Passed. Compilation successful
+tools/javac/InvalidIntfCast.java                                                                                 Passed. Compilation successful
+tools/javac/JsrRet.java                                                                                          Passed. Compilation successful
+tools/javac/LabelHiding_1.java                                                                                   Passed. Compilation successful
+tools/javac/LabeledDeclaration.java                                                                              Passed. Compilation failed as expected
+tools/javac/LocalClasses_1.java                                                                                  Passed. Compilation successful
+tools/javac/LocalClasses_2.java                                                                                  Passed. Compilation failed as expected
+tools/javac/ManyMembers2.java                                                                                    Passed. Compilation successful
+tools/javac/MemberTypeInheritance.java                                                                           Passed. Compilation successful
+tools/javac/MethodParameters/AnnotationTest.java                                                                 Passed. Execution successful
+tools/javac/MethodParameters/AnonymousClass.java                                                                 Passed. Execution successful
+tools/javac/MethodParameters/CaptureTest.java                                                                    Passed. Execution successful
+tools/javac/MethodParameters/ClassReaderTest/ClassReaderTest.java                                                Passed. Compilation successful
+tools/javac/MethodParameters/Constructors.java                                                                   Passed. Execution successful
+tools/javac/MethodParameters/DefaultParamNames.java                                                              Passed. Execution successful
+tools/javac/MethodParameters/EnumTest.java                                                                       Passed. Execution successful
+tools/javac/MethodParameters/InstanceMethods.java                                                                Passed. Execution successful
+tools/javac/MethodParameters/LambdaTest.java                                                                     Passed. Execution successful
+tools/javac/MethodParameters/LegacyOutputTest/LegacyOutputTest.java                                              Passed. Execution successful
+tools/javac/MethodParameters/LocalClassTest.java                                                                 Passed. Execution successful
+tools/javac/MethodParameters/MemberClassTest.java                                                                Passed. Execution successful
+tools/javac/MethodParameters/StaticMethods.java                                                                  Passed. Execution successful
+tools/javac/MethodParameters/UncommonParamNames.java                                                             Passed. Execution successful
+tools/javac/MethodParametersTest.java                                                                            Passed. Execution successful
+tools/javac/MissingInclude/MissingIncludeTest.java                                                               Passed. Execution successful
+tools/javac/NameClash/NameClashTest.java                                                                         Passed. Compilation successful
+tools/javac/NameClash/One.java                                                                                   Passed. Compilation successful
+tools/javac/NameCollision.java                                                                                   Passed. Compilation failed as expected
+tools/javac/NameCollision2.java                                                                                  Passed. Execution successful
+tools/javac/NestedDuplicateLabels.java                                                                           Passed. Compilation failed as expected
+tools/javac/NestedFinallyReturn.java                                                                             Passed. Compilation successful
+tools/javac/NestedInnerClassNames.java                                                                           Passed. Compilation failed as expected
+tools/javac/NewGeneric.java                                                                                      Passed. Compilation failed as expected
+tools/javac/NoStringToLower.java                                                                                 Passed. Execution successful
+tools/javac/NonAmbiguousField/Test.java                                                                          Passed. Compilation failed as expected
+tools/javac/NonStaticFieldExpr1.java                                                                             Passed. Compilation failed as expected
+tools/javac/NonStaticFieldExpr2.java                                                                             Passed. Compilation failed as expected
+tools/javac/NonStaticFieldExpr3.java                                                                             Passed. Compilation failed as expected
+tools/javac/NonStaticFieldExpr4c.java                                                                            Passed. Compilation successful
+tools/javac/NonStaticFinalVar.java                                                                               Passed. Compilation successful
+tools/javac/Null2DArray.java                                                                                     Passed. Execution successful
+tools/javac/NullQualifiedNew.java                                                                                Passed. Execution failed as expected
+tools/javac/NullQualifiedNew2.java                                                                               Passed. Execution successful
+tools/javac/NullQualifiedSuper1.java                                                                             Passed. Compilation failed as expected
+tools/javac/NullQualifiedSuper2.java                                                                             Passed. Execution failed as expected
+tools/javac/NullStaticQualifier.java                                                                             Passed. Execution successful
+tools/javac/ObjectIncompatibleInterface.java                                                                     Passed. Compilation successful
+tools/javac/ObjectMethodRefFromInterface.java                                                                    Passed. Execution successful
+tools/javac/OuterParameter_1.java                                                                                Passed. Execution successful
+tools/javac/OverrideChecks/6199153/T6199153.java                                                                 Passed. Compilation failed as expected
+tools/javac/OverrideChecks/6400189/T6400189a.java                                                                Passed. Compilation failed as expected
+tools/javac/OverrideChecks/6400189/T6400189b.java                                                                Passed. Compilation failed as expected
+tools/javac/OverrideChecks/6400189/T6400189c.java                                                                Passed. Compilation successful
+tools/javac/OverrideChecks/6400189/T6400189d.java                                                                Passed. Compilation successful
+tools/javac/OverrideChecks/6738538/T6738538a.java                                                                Passed. Compilation successful
+tools/javac/OverrideChecks/6738538/T6738538b.java                                                                Passed. Compilation successful
+tools/javac/OverrideChecks/IncompleteMessageOverride.java                                                        Passed. Compilation failed as expected
+tools/javac/OverrideChecks/InconsistentReturn.java                                                               Passed. Compilation failed as expected
+tools/javac/OverrideChecks/InterfaceImplements.java                                                              Passed. Compilation successful
+tools/javac/OverrideChecks/InterfaceOverride.java                                                                Passed. Compilation successful
+tools/javac/OverrideChecks/Private.java                                                                          Passed. Compilation failed as expected
+tools/javac/OverrideChecks/StaticOverride.java                                                                   Passed. Compilation failed as expected
+tools/javac/OverrideChecks/T4720356a.java                                                                        Passed. Compilation failed as expected
+tools/javac/OverrideChecks/T4720359a.java                                                                        Passed. Compilation failed as expected
+tools/javac/OverrideChecks/T4721069.java                                                                         Passed. Compilation failed as expected
+tools/javac/OverrideChecks/T6326485.java                                                                         Passed. Compilation successful
+tools/javac/OverrideChecks/T6399361.java                                                                         Passed. Compilation successful
+tools/javac/OverrideChecks/T8139255.java                                                                         Passed. Compilation failed as expected
+tools/javac/OverrideChecks/ThrowsConflict.java                                                                   Passed. Compilation failed as expected
+tools/javac/OverridePosition.java                                                                                Passed. Compilation failed as expected
+tools/javac/PackageClassAmbiguity/Bad.java                                                                       Passed. Compilation failed as expected
+tools/javac/PackageClassAmbiguity/util.java                                                                      Passed. Compilation failed as expected
+tools/javac/Parens1.java                                                                                         Passed. Compilation failed as expected
+tools/javac/Parens2.java                                                                                         Passed. Compilation failed as expected
+tools/javac/Parens3.java                                                                                         Passed. Compilation failed as expected
+tools/javac/Parens4.java                                                                                         Passed. Compilation failed as expected
+tools/javac/ParseConditional.java                                                                                Passed. Compilation failed as expected
+tools/javac/Paths/6638501/JarFromManifestFailure.java                                                            Passed. Execution successful
+tools/javac/Paths/Class-Path.sh                                                                                  Passed. Execution successful
+tools/javac/Paths/Class-Path2.sh                                                                                 Passed. Execution successful
+tools/javac/Paths/Diagnostics.sh                                                                                 Passed. Execution successful
+tools/javac/Paths/Help.sh                                                                                        Passed. Execution successful
+tools/javac/Paths/MineField.sh                                                                                   Passed. Execution successful
+tools/javac/Paths/TestCompileJARInClassPath.java                                                                 Passed. Execution successful
+tools/javac/Paths/wcMineField.sh                                                                                 Passed. Execution successful
+tools/javac/PrivateLocalConstructor.java                                                                         Passed. Execution successful
+tools/javac/PrivateUplevelConstant.java                                                                          Passed. Compilation successful
+tools/javac/ProtectedInnerClass/ProtectedInnerClassesTest.java                                                   Passed. Execution successful
+tools/javac/QualifiedAccess/QualifiedAccess_1.java                                                               Passed. Compilation failed as expected
+tools/javac/QualifiedAccess/QualifiedAccess_2.java                                                               Passed. Compilation failed as expected
+tools/javac/QualifiedAccess/QualifiedAccess_3.java                                                               Passed. Compilation failed as expected
+tools/javac/QualifiedAccess/QualifiedAccess_4.java                                                               Passed. Compilation failed as expected
+tools/javac/QualifiedConstant.java                                                                               Passed. Compilation failed as expected
+tools/javac/QualifiedNew.java                                                                                    Passed. Compilation failed as expected
+tools/javac/QualifiedNewScope.java                                                                               Passed. Compilation successful
+tools/javac/QualifiedOuterThis.java                                                                              Passed. Execution successful
+tools/javac/QualifiedOuterThis2.java                                                                             Passed. Compilation successful
+tools/javac/QualifiedThisAndSuper_1.java                                                                         Passed. Execution successful
+tools/javac/QualifiedThisAndSuper_2.java                                                                         Passed. Execution successful
+tools/javac/QualifiedThisAndSuper_3.java                                                                         Passed. Execution successful
+tools/javac/QualifiedThisExactMatch.java                                                                         Passed. Execution successful
+tools/javac/RawCrash.java                                                                                        Passed. Compilation successful
+tools/javac/ReturnAfterIfThenElse.java                                                                           Passed. Compilation failed as expected
+tools/javac/ShiftExpressionTest.java                                                                             Passed. Execution successful
+tools/javac/StandaloneQualifiedSuper.java                                                                        Passed. Compilation failed as expected
+tools/javac/StaticBlockScope.java                                                                                Passed. Compilation successful
+tools/javac/StdoutCloseTest.java                                                                                 Passed. Execution successful
+tools/javac/StoreClass.java                                                                                      Passed. Compilation failed as expected
+tools/javac/StrictAbstract.java                                                                                  Passed. Execution successful
+tools/javac/StringAppendAccessMethodOnLHS.java                                                                   Passed. Execution successful
+tools/javac/StringConcat/TestIndyStringConcat.java                                                               Passed. Execution successful
+tools/javac/StringConcat/access/Test.java                                                                        Passed. Execution successful
+tools/javac/StringConversion.java                                                                                Passed. Execution successful
+tools/javac/StringConversion2.java                                                                               Passed. Execution successful
+tools/javac/StringsInSwitch/7181320/BinOpInCaseLabel.java                                                        Passed. Compilation successful
+tools/javac/StringsInSwitch/7181320/CastInCaseLabel.java                                                         Passed. Compilation successful
+tools/javac/StringsInSwitch/7181320/CondExprInCaseLabel.java                                                     Passed. Compilation successful
+tools/javac/StringsInSwitch/7181320/CondExprInCaseLabel1.java                                                    Passed. Compilation successful
+tools/javac/StringsInSwitch/7181320/CondExprInCaseLabel2.java                                                    Passed. Compilation successful
+tools/javac/StringsInSwitch/BadlyTypedLabel1.java                                                                Passed. Compilation failed as expected
+tools/javac/StringsInSwitch/BadlyTypedLabel2.java                                                                Passed. Compilation failed as expected
+tools/javac/StringsInSwitch/NonConstantLabel.java                                                                Passed. Compilation failed as expected
+tools/javac/StringsInSwitch/OneCaseSwitches.java                                                                 Passed. Execution successful
+tools/javac/StringsInSwitch/RepeatedStringCaseLabels1.java                                                       Passed. Compilation failed as expected
+tools/javac/StringsInSwitch/RepeatedStringCaseLabels2.java                                                       Passed. Compilation failed as expected
+tools/javac/StringsInSwitch/StringSwitches.java                                                                  Passed. Execution successful
+tools/javac/SuperField.java                                                                                      Passed. Execution successful
+tools/javac/SuperMeth.java                                                                                       Passed. Execution successful
+tools/javac/SuperMethodResolve.java                                                                              Passed. Compilation successful
+tools/javac/SuperNew.java                                                                                        Passed. Compilation successful
+tools/javac/SuperNew2.java                                                                                       Passed. Execution successful
+tools/javac/SuperNew3.java                                                                                       Passed. Compilation successful
+tools/javac/SuperNew4.java                                                                                       Passed. Compilation successful
+tools/javac/SuperclassConstructorException.java                                                                  Passed. Compilation successful
+tools/javac/SwitchExitStateTest.java                                                                             Passed. Execution successful
+tools/javac/SwitchFence.java                                                                                     Passed. Execution successful
+tools/javac/SwitchScope.java                                                                                     Passed. Compilation failed as expected
+tools/javac/SynchronizedClass.java                                                                               Passed. Compilation failed as expected
+tools/javac/SynthName1.java                                                                                      Passed. Execution successful
+tools/javac/SynthName2.java                                                                                      Passed. Compilation failed as expected
+tools/javac/T4093617/T4093617.java                                                                               Passed. Compilation failed as expected
+tools/javac/T4848619/T4848619a.java                                                                              Passed. Compilation failed as expected
+tools/javac/T4848619/T4848619b.java                                                                              Passed. Compilation failed as expected
+tools/javac/T4881267.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T4906100.java                                                                                        Passed. Compilation successful
+tools/javac/T4965689/ClassLiteralWastesByteTest.java                                                             Passed. Execution successful
+tools/javac/T4994049/DeprecatedNOT.java                                                                          Passed. Compilation successful
+tools/javac/T4994049/DeprecatedYES.java                                                                          Passed. Compilation failed as expected
+tools/javac/T4994049/T4994049.java                                                                               Passed. Compilation failed as expected
+tools/javac/T5003235/T5003235a.java                                                                              Passed. Compilation failed as expected
+tools/javac/T5003235/T5003235b.java                                                                              Passed. Compilation failed as expected
+tools/javac/T5003235/T5003235c.java                                                                              Passed. Compilation failed as expected
+tools/javac/T5024091/T5024091.java                                                                               Passed. Compilation failed as expected
+tools/javac/T5048776.java                                                                                        Passed. Compilation successful
+tools/javac/T5053846/MethodRefDupInConstantPoolTest.java                                                         Passed. Execution successful
+tools/javac/T5092545.java                                                                                        Passed. Execution successful
+tools/javac/T5105890.java                                                                                        Passed. Execution successful
+tools/javac/T6180021/AbstractSub.java                                                                            Passed. Compilation successful
+tools/javac/T6180021/Sub.java                                                                                    Passed. Compilation successful
+tools/javac/T6181889/EmptyFinallyTest.java                                                                       Passed. Execution successful
+tools/javac/T6214885.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6224167.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6227617.java                                                                                        Passed. Compilation successful
+tools/javac/T6230128.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6231246/T6231246.java                                                                               Passed. Compilation successful
+tools/javac/T6231847.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6232928.java                                                                                        Passed. Execution successful
+tools/javac/T6234077.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6238612.java                                                                                        Passed. Execution successful
+tools/javac/T6241723.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6245591.java                                                                                        Passed. Compilation successful
+tools/javac/T6247324.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6265400.java                                                                                        Passed. Execution successful
+tools/javac/T6266772.java                                                                                        Passed. Execution successful
+tools/javac/T6294589.java                                                                                        Passed. Compilation successful
+tools/javac/T6304128.java                                                                                        Passed. Compilation successful
+tools/javac/T6306967.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6326693/FinalVariableAssignedToInCatchBlockTest.java                                                Passed. Compilation failed as expected
+tools/javac/T6326754.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6340549.java                                                                                        Passed. Execution successful
+tools/javac/T6351767.java                                                                                        Passed. Execution successful
+tools/javac/T6356217/T6356217.java                                                                               Passed. Compilation successful
+tools/javac/T6356530/SerializableAbstractClassTest.java                                                          Passed. Compilation failed as expected
+tools/javac/T6358024.java                                                                                        Passed. Execution successful
+tools/javac/T6358166.java                                                                                        Passed. Execution successful
+tools/javac/T6358168.java                                                                                        Passed. Execution successful
+tools/javac/T6361619.java                                                                                        Passed. Execution successful
+tools/javac/T6366196.java                                                                                        Passed. Execution successful
+tools/javac/T6370653.java                                                                                        Passed. Execution successful
+tools/javac/T6379327.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6394563.java                                                                                        Passed. Compilation successful
+tools/javac/T6395974.java                                                                                        Passed. Execution successful
+tools/javac/T6397044.java                                                                                        Passed. Execution successful
+tools/javac/T6397286.java                                                                                        Passed. Execution successful
+tools/javac/T6403466.java                                                                                        Passed. Execution successful
+tools/javac/T6404756.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6405099.java                                                                                        Passed. Execution successful
+tools/javac/T6406771.java                                                                                        Passed. Execution successful
+tools/javac/T6407066.java                                                                                        Passed. Execution successful
+tools/javac/T6407257.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6410706.java                                                                                        Passed. Execution successful
+tools/javac/T6411379.java                                                                                        Passed. Compilation successful
+tools/javac/T6423583.java                                                                                        Passed. Compilation successful
+tools/javac/T6435291/T6435291.java                                                                               Passed. Execution successful
+tools/javac/T6458749.java                                                                                        Passed. Compilation successful
+tools/javac/T6458823/T6458823.java                                                                               Passed. Execution successful
+tools/javac/T6472751.java                                                                                        Passed. Execution successful
+tools/javac/T6534287.java                                                                                        Passed. Execution successful
+tools/javac/T6554097.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6558476.java                                                                                        Passed. Execution successful
+tools/javac/T6567414.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6587674.java                                                                                        Passed. Execution successful
+tools/javac/T6595666.java                                                                                        Passed. Execution successful
+tools/javac/T6625520.java                                                                                        Passed. Execution successful
+tools/javac/T6654037.java                                                                                        Passed. Execution successful
+tools/javac/T6663588.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6665791.java                                                                                        Passed. Execution successful
+tools/javac/T6668802.java                                                                                        Passed. Execution successful
+tools/javac/T6695379/AnnotationsAreNotCopiedToBridgeMethodsTest.java                                             Passed. Execution successful
+tools/javac/T6725036.java                                                                                        Passed. Execution successful
+tools/javac/T6759996.java                                                                                        Passed. Execution successful
+tools/javac/T6794959.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6855236.java                                                                                        Passed. Compilation successful
+tools/javac/T6873849.java                                                                                        Passed. Execution successful
+tools/javac/T6881645.java                                                                                        Passed. Compilation successful
+tools/javac/T6882235.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T6900149.java                                                                                        Passed. Execution successful
+tools/javac/T6942649.java                                                                                        Passed. Execution successful
+tools/javac/T6956462/T6956462.java                                                                               Passed. Execution successful
+tools/javac/T6956638.java                                                                                        Passed. Execution successful
+tools/javac/T6970173/DebugPointerAtBadPositionTest.java                                                          Passed. Execution successful
+tools/javac/T6972327.java                                                                                        Passed. Execution successful
+tools/javac/T6977800.java                                                                                        Passed. Compilation successful
+tools/javac/T6985181.java                                                                                        Passed. Execution successful
+tools/javac/T6993301.java                                                                                        Passed. Execution successful
+tools/javac/T6999210.java                                                                                        Passed. Execution successful
+tools/javac/T7008643/InlinedFinallyConfuseDebuggersTest.java                                                     Passed. Execution successful
+tools/javac/T7040104.java                                                                                        Passed. Execution successful
+tools/javac/T7040592/CoerceNullToMoreSpecificTypeTest.java                                                       Passed. Execution successful
+tools/javac/T7040592/T7040592.java                                                                               Passed. Execution successful
+tools/javac/T7042623.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T7053059/DoubleCastTest.java                                                                         Passed. Execution successful
+tools/javac/T7053059/VerifyErrorWithDoubleAssignmentTest.java                                                    Passed. Execution successful
+tools/javac/T7090499.java                                                                                        Passed. Compilation successful
+tools/javac/T7093325.java                                                                                        Passed. Execution successful
+tools/javac/T7120266.java                                                                                        Passed. Compilation successful
+tools/javac/T7120463.java                                                                                        Passed. Compilation failed as expected
+tools/javac/T7126754.java                                                                                        Passed. Compilation successful
+tools/javac/T7142672/Bug.java                                                                                    Passed. Execution successful
+tools/javac/T7159016.java                                                                                        Passed. Execution successful
+tools/javac/T7165659/InnerClassAttrMustNotHaveStrictFPFlagTest.java                                              Passed. Execution successful
+tools/javac/T7179353/GenericsAndTWRCompileErrorTest.java                                                         Passed. Compilation successful
+tools/javac/T8000316/T8000316.java                                                                               Passed. Execution successful
+tools/javac/T8003967/DetectMutableStaticFields.java                                                              Passed. Execution successful
+tools/javac/T8004969.java                                                                                        Passed. Execution successful
+tools/javac/T8010659/CompilerCrashWhenMixingBinariesAndSourcesTest.java                                          Passed. Execution successful
+tools/javac/T8010737/ParameterNamesAreNotCopiedToAnonymousInitTest.java                                          Passed. Execution successful
+tools/javac/T8011181/EmptyUTF8ForInnerClassNameTest.java                                                         Passed. Execution successful
+tools/javac/T8013394/CompileErrorWithIteratorTest.java                                                           Passed. Execution successful
+tools/javac/T8016099/UncheckedWarningRegressionTest.java                                                         Passed. Compilation failed as expected
+tools/javac/T8019486/WrongLNTForLambdaTest.java                                                                  Passed. Execution successful
+tools/javac/T8020997/CannotCompileRepeatedAnnoTest.java                                                          Passed. Compilation successful
+tools/javac/T8022053/UnverifiableInitForNestedLocalClassTest.java                                                Passed. Execution successful
+tools/javac/T8022162/IncorrectSignatureDeterminationForInnerClassesTest.java                                     Passed. Execution successful
+tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java                                                       Passed. Execution successful
+tools/javac/T8022316/CompilerErrorGenericThrowPlusMethodRefTest.java                                             Passed. Compilation failed as expected
+tools/javac/T8023112/SkipLazyConstantCreationForMethodRefTest.java                                               Passed. Compilation successful
+tools/javac/T8023545/MisleadingErrorMsgDiamondPlusPrivateCtorTest.java                                           Passed. Compilation failed as expected
+tools/javac/T8024039/NoDeadCodeGenerationOnTrySmtTest.java                                                       Passed. Execution successful
+tools/javac/T8024207/FlowCrashTest.java                                                                          Passed. Compilation failed as expected
+tools/javac/T8024398/NPETryTest.java                                                                             Passed. Compilation successful
+tools/javac/T8024437/ExceptionInferenceFromClassFileTest.java                                                    Passed. Execution successful
+tools/javac/T8026963/TypeAnnotationsCrashWithErroneousTreeTest.java                                              Passed. Compilation failed as expected
+tools/javac/T8028504/DontGenerateLVTForGNoneOpTest.java                                                          Passed. Execution successful
+tools/javac/T8029002/MultipleUpperBoundsIncorporationTest.java                                                   Passed. Compilation successful
+tools/javac/T8029102/WarnSerializableElementTest.java                                                            Passed. Compilation failed as expected
+tools/javac/T8029102/WarnSerializableLambdaTestb.java                                                            Passed. Compilation failed as expected
+tools/javac/T8029102/WarnSerializableLambdaTestc.java                                                            Passed. Compilation successful
+tools/javac/T8029179/CompileErrorForValidBooleanExpTest.java                                                     Passed. Compilation successful
+tools/javac/T8029569/VarargsAmbiguityCrashTest.java                                                              Passed. Compilation failed as expected
+tools/javac/T8030816/CrashLambdaExpressionWithNonAccessibleIdTest.java                                           Passed. Compilation failed as expected
+tools/javac/T8034044.java                                                                                        Passed. Execution successful
+tools/javac/T8037947/CCEForFunctionalInterExtedingRawSuperInterTest.java                                         Passed. Compilation successful
+tools/javac/T8038975/AccessTest.java                                                                             Passed. Compilation successful
+tools/javac/T8047338/FilterNonMembersToObtainFunctionDescriptorTest.java                                         Passed. Compilation successful
+tools/javac/T8048543/InferenceVariableInstantiatedUnexpectedlyTest.java                                          Passed. Compilation successful
+tools/javac/T8050386/WrongStackframeGenerationTest1.java                                                         Passed. Execution successful
+tools/javac/T8050386/WrongStackframeGenerationTest2.java                                                         Passed. Execution successful
+tools/javac/T8058244/MissingErrorInDefaultSuperCallTest.java                                                     Passed. Compilation failed as expected
+tools/javac/T8059921/ForbidAccessToFieldUsingSuperTest.java                                                      Passed. Compilation failed as expected
+tools/javac/T8068460/PrettyPrintingForLoopsTest.java                                                             Passed. Execution successful
+tools/javac/T8071847/T8071847.java                                                                               Passed. Execution successful
+tools/javac/T8132562/ClassPathWithDoubleQuotesTest.java                                                          Passed. Execution successful
+tools/javac/T8139474/DashRelease7DashVerboseTest.java                                                            Passed. Compilation successful
+tools/javac/T8148354/IntersectionFunctionalButComponentsNotTest.java                                             Passed. Compilation successful
+tools/javac/T8148354/IntersectionTypeBugTest.java                                                                Passed. Compilation successful
+tools/javac/T8151191/ErrorRunningJavadocOnInnerClasses.java                                                      Passed. Compilation successful
+tools/javac/T8152616.java                                                                                        Passed. Execution successful
+tools/javac/T8159970/TypeEqualityInInferenceTest.java                                                            Passed. Execution successful
+tools/javac/T8160156/LetExpressionsAreUnnecessarilyGeneratedTest.java                                            Passed. Execution successful
+tools/javac/T8161277/IsSameTypeWildcardTest.java                                                                 Passed. Execution successful
+tools/javac/T8161383/LookingForOperatorSymbolsAtWrongPlaceTest.java                                              Passed. Compilation successful
+tools/javac/T8170667/ParameterProcessor.java                                                                     Passed. Compilation successful
+tools/javac/T8171325/NPEClearingLocalClassNameIndexesTest.java                                                   Passed. Compilation failed as expected
+tools/javac/T8171332/Processor.java                                                                              Passed. Compilation failed as expected
+tools/javac/T8171528/DuplicatedAnnotatedPackagesTest.java                                                        Passed. Compilation failed as expected
+tools/javac/T8173955/MessageForClassTest.java                                                                    Passed. Compilation failed as expected
+tools/javac/T8173955/MessageForEnumTest.java                                                                     Passed. Compilation failed as expected
+tools/javac/T8173955/MessageForInterfaceTest.java                                                                Passed. Compilation failed as expected
+tools/javac/T8175198/AnnotationsAndFormalParamsTest.java                                                         Passed. Compilation failed as expected
+tools/javac/T8175235/InferenceRegressionTest01.java                                                              Passed. Compilation successful
+tools/javac/T8175235/InferenceRegressionTest02.java                                                              Passed. Execution successful
+tools/javac/T8175790/NPEDueToErroneousLambdaTest.java                                                            Passed. Compilation failed as expected
+tools/javac/T8175794/MissingReturnConstraintTest.java                                                            Passed. Compilation successful
+tools/javac/T8176714/FieldOverloadKindNotAssignedTest.java                                                       Passed. Execution successful
+tools/javac/T8176714/TimingOfMReferenceCheckingTest01.java                                                       Passed. Compilation successful
+tools/javac/T8176714/TimingOfMReferenceCheckingTest02.java                                                       Passed. Compilation successful
+tools/javac/T8177068/NoCompletionFailureSkipOnSpeculativeAttribution.java                                        Passed. Execution successful
+tools/javac/T8180141/MissingLNTEntryForBreakContinueTest.java                                                    Passed. Execution successful
+tools/javac/T8180660/MissingLNTEntryForFinalizerTest.java                                                        Passed. Execution successful
+tools/javac/T8181464/LambdaInAnnotationsCausesNPETest1.java                                                      Passed. Compilation failed as expected
+tools/javac/T8181464/LambdaInAnnotationsCausesNPETest2.java                                                      Passed. Compilation failed as expected
+tools/javac/T8181464/LambdaInAnnotationsCausesNPETest3.java                                                      Passed. Compilation failed as expected
+tools/javac/T8182047/CorrectGenerationOfExConstraintsTest.java                                                   Passed. Compilation successful
+tools/javac/T8182649/AddCheckForPartiallyInferredTypesTest.java                                                  Passed. Compilation successful
+tools/javac/T8182747/BadAnnotationRegressionTest.java                                                            Passed. Compilation failed as expected
+tools/javac/T8185451/MisleadingVarArgsErrorMsgTest.java                                                          Passed. Compilation failed as expected
+tools/javac/T8185983/RejectTypeArgsOnSelectTest.java                                                             Passed. Compilation failed as expected
+tools/javac/T8187487/CrashWithDuplicateClassNamesTest.java                                                       Passed. Compilation failed as expected
+tools/javac/T8187805/BogusRTTAForUnusedVarTest.java                                                              Passed. Execution successful
+tools/javac/T8187978/FilterOutCandidatesForDiagnosticsTest.java                                                  Passed. Compilation failed as expected
+tools/javac/T8194998/BrokenErrorMessageTest.java                                                                 Passed. Compilation failed as expected
+tools/javac/T8196048/ThrownTypeVarsAsRootsTest.java                                                              Passed. Compilation successful
+tools/javac/T8198502.java                                                                                        Passed. Execution successful
+tools/javac/T8199744/IncorrectMsgQualifiedReceiverTest.java                                                      Passed. Compilation failed as expected
+tools/javac/T8199910.java                                                                                        Passed. Compilation successful
+tools/javac/T8201281/NullInErrorMessageTest.java                                                                 Passed. Compilation failed as expected
+tools/javac/T8202597/NotionalInterfaceNotBeingInducedTest.java                                                   Passed. Compilation successful
+tools/javac/T8203277/PreflowShouldVisitLambdaOrDiamondInsideLambdaTest.java                                      Passed. Compilation successful
+tools/javac/T8203338/CheckWellFormednessIntersectionTypesTest.java                                               Passed. Compilation failed as expected
+tools/javac/T8203486/SkipInferenceForNonFunctionalInterfTest.java                                                Passed. Compilation successful
+tools/javac/T8203813/WrongReceiverTest.java                                                                      Passed. Compilation failed as expected
+tools/javac/T8203892/CheckTargetIsNotAddedAsMarkerInterfaceTest.java                                             Passed. Execution successful
+tools/javac/T8207320/IntersectionOrderTest.java                                                                  Passed. Execution successful
+tools/javac/T8207320/IntersectionOrderTest2.java                                                                 Passed. Execution successful
+tools/javac/T8209173/CodeCompletionExceptTest.java                                                               Passed. Execution successful
+tools/javac/T8210197/DiamondWithAnonymousInnerClassTest.java                                                     Passed. Execution successful
+tools/javac/T8210435/NoLocalsMustBeReservedForDCEedVarsTest.java                                                 Passed. Execution successful
+tools/javac/T8211450/ThrownTypeVarTest.java                                                                      Passed. Compilation successful
+tools/javac/T8215470/BadEnclosingMethodAttrTest.java                                                             Passed. Execution successful
+tools/javac/T8215482/NPETypeVarWithOuterBoundTest.java                                                           Passed. Compilation successful
+tools/javac/T8222035/MinContextOpTest.java                                                                       Passed. Compilation failed as expected
+tools/javac/T8222251/PreflowNotVisitingLambdaExpTest.java                                                        Passed. Compilation successful
+tools/javac/T8222795/ConditionalAndPostfixOperator.java                                                          Passed. Execution successful
+tools/javac/T8222949/TestConstantDynamic.java                                                                    Passed. Execution successful
+tools/javac/T8223942/ClientCodeWrappersShouldOverrideAllMethodsTest.java                                         Passed. Execution successful
+tools/javac/TestPkgInfo.java                                                                                     Passed. Execution successful
+tools/javac/TextBlockAPI.java                                                                                    Passed. Execution successful
+tools/javac/TextBlockIllegalEscape.java                                                                          Passed. Compilation failed as expected
+tools/javac/TextBlockLang.java                                                                                   Passed. Execution successful
+tools/javac/ThrowNull.java                                                                                       Passed. Compilation successful
+tools/javac/ThrowsIntersection_1.java                                                                            Passed. Compilation successful
+tools/javac/ThrowsIntersection_2.java                                                                            Passed. Compilation successful
+tools/javac/ThrowsIntersection_3.java                                                                            Passed. Compilation failed as expected
+tools/javac/ThrowsIntersection_4.java                                                                            Passed. Compilation failed as expected
+tools/javac/TryInInstanceInit.java                                                                               Passed. Compilation successful
+tools/javac/TryWithResources/BadTwr.java                                                                         Passed. Compilation failed as expected
+tools/javac/TryWithResources/BadTwrSyntax.java                                                                   Passed. Compilation failed as expected
+tools/javac/TryWithResources/DuplicateResource.java                                                              Passed. Execution successful
+tools/javac/TryWithResources/DuplicateResourceDecl.java                                                          Passed. Compilation failed as expected
+tools/javac/TryWithResources/ExplicitFinal.java                                                                  Passed. Execution successful
+tools/javac/TryWithResources/ImplicitFinal.java                                                                  Passed. Compilation failed as expected
+tools/javac/TryWithResources/InterruptedExceptionTest.java                                                       Passed. Execution successful
+tools/javac/TryWithResources/PlainTry.java                                                                       Passed. Compilation failed as expected
+tools/javac/TryWithResources/ResDeclOutsideTry.java                                                              Passed. Compilation failed as expected
+tools/javac/TryWithResources/ResInNestedExpr.java                                                                Passed. Execution successful
+tools/javac/TryWithResources/ResourceInterface.java                                                              Passed. Compilation failed as expected
+tools/javac/TryWithResources/ResourceNameConflict.java                                                           Passed. Compilation failed as expected
+tools/javac/TryWithResources/ResourceOutsideTry.java                                                             Passed. Compilation failed as expected
+tools/javac/TryWithResources/ResourceRedecl.java                                                                 Passed. Compilation failed as expected
+tools/javac/TryWithResources/ResourceShadow.java                                                                 Passed. Execution successful
+tools/javac/TryWithResources/ResourceTypeVar.java                                                                Passed. Compilation successful
+tools/javac/TryWithResources/T7022711.java                                                                       Passed. Compilation failed as expected
+tools/javac/TryWithResources/T7032633.java                                                                       Passed. Compilation successful
+tools/javac/TryWithResources/T7164542.java                                                                       Passed. Compilation successful
+tools/javac/TryWithResources/T7178324.java                                                                       Passed. Compilation successful
+tools/javac/TryWithResources/TestTwr09.java                                                                      Passed. Execution successful
+tools/javac/TryWithResources/TwrAndLambda.java                                                                   Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrAndTypeVariables.java                                                            Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrAndTypeVariables2Test.java                                                       Passed. Compilation successful
+tools/javac/TryWithResources/TwrAvoidNullCheck.java                                                              Passed. Execution successful
+tools/javac/TryWithResources/TwrClose.java                                                                       Passed. Execution successful
+tools/javac/TryWithResources/TwrFlow.java                                                                        Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrForVariable1.java                                                                Passed. Execution successful
+tools/javac/TryWithResources/TwrForVariable2.java                                                                Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrForVariable3.java                                                                Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrForVariable4.java                                                                Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrLint.java                                                                        Passed. Compilation successful
+tools/javac/TryWithResources/TwrMultiCatch.java                                                                  Passed. Execution successful
+tools/javac/TryWithResources/TwrNullTests.java                                                                   Passed. Execution successful
+tools/javac/TryWithResources/TwrOnNonResource.java                                                               Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrSimpleClose.java                                                                 Passed. Execution successful
+tools/javac/TryWithResources/TwrSuppression.java                                                                 Passed. Execution successful
+tools/javac/TryWithResources/TwrTests.java                                                                       Passed. Execution successful
+tools/javac/TryWithResources/TwrVarKinds.java                                                                    Passed. Compilation failed as expected
+tools/javac/TryWithResources/TwrVarRedeclaration.java                                                            Passed. Compilation failed as expected
+tools/javac/TryWithResources/UnusedResourcesTest.java                                                            Passed. Execution successful
+tools/javac/TryWithResources/WeirdTwr.java                                                                       Passed. Execution successful
+tools/javac/TypeVarShadow.java                                                                                   Passed. Compilation successful
+tools/javac/UncaughtOverflow.java                                                                                Passed. Compilation failed as expected
+tools/javac/UnreachableLoopCond.java                                                                             Passed. Compilation successful
+tools/javac/UnreachableVar.java                                                                                  Passed. Execution successful
+tools/javac/UnterminatedLineComment.java                                                                         Passed. Compilation successful
+tools/javac/UplevelFromAnonInSuperCall.java                                                                      Passed. Compilation successful
+tools/javac/UseEnum.java                                                                                         Passed. Compilation failed as expected
+tools/javac/VarDeclarationWithAssignment.java                                                                    Passed. Execution successful
+tools/javac/Verify.java                                                                                          Passed. Execution successful
+tools/javac/VerifyDA.java                                                                                        Passed. Execution successful
+tools/javac/VersionOpt.java                                                                                      Passed. Execution successful
+tools/javac/VoidArray.java                                                                                       Passed. Compilation failed as expected
+tools/javac/abstract/T1.java                                                                                     Passed. Compilation successful
+tools/javac/abstract/T4717181a.java                                                                              Passed. Compilation successful
+tools/javac/abstract/T4717181b.java                                                                              Passed. Compilation successful
+tools/javac/abstract/U1.java                                                                                     Passed. Compilation successful
+tools/javac/accessVirtualInner/Main.java                                                                         Passed. Execution successful
+tools/javac/analyzer/AnalyzerMandatoryWarnings.java                                                              Passed. Compilation successful
+tools/javac/analyzer/AnalyzerNotQuiteSpeculative.java                                                            Passed. Compilation successful
+tools/javac/analyzer/AnalyzersCheckSourceLevel.java                                                              Passed. Compilation successful
+tools/javac/analyzer/AnonymousInAnonymous.java                                                                   Passed. Compilation successful
+tools/javac/analyzer/DoNoRunAnalyzersWhenException.java                                                          Passed. Execution successful
+tools/javac/analyzer/LambdaWithMethod.java                                                                       Passed. Compilation failed as expected
+tools/javac/analyzer/StuckLambdas.java                                                                           Passed. Compilation successful
+tools/javac/analyzer/T8211102.java                                                                               Passed. Compilation successful
+tools/javac/annotations/6214965/T6214965.java                                                                    Passed. Compilation successful
+tools/javac/annotations/6359949/T6359949.java                                                                    Passed. Compilation successful
+tools/javac/annotations/6359949/T6359949a.java                                                                   Passed. Compilation failed as expected
+tools/javac/annotations/6365854/T6365854.java                                                                    Passed. Execution successful
+tools/javac/annotations/6550655/T6550655.java                                                                    Passed. Execution successful
+tools/javac/annotations/6881115/T6881115.java                                                                    Passed. Compilation failed as expected
+tools/javac/annotations/8145489/T8145489.java                                                                    Passed. Compilation successful
+tools/javac/annotations/8218152/MalformedAnnotationProcessorTests.java                                           Passed. Execution successful
+tools/javac/annotations/AnnotationTypeElementModifiers.java                                                      Passed. Compilation failed as expected
+tools/javac/annotations/AtNonAnnotationTypeTest.java                                                             Passed. Compilation failed as expected
+tools/javac/annotations/FinalReceiverTest.java                                                                   Passed. Compilation failed as expected
+tools/javac/annotations/FinalStringInNested.java                                                                 Passed. Compilation successful
+tools/javac/annotations/LocalInnerReceiverTest.java                                                              Passed. Compilation successful
+tools/javac/annotations/SyntheticParameters.java                                                                 Passed. Execution successful
+tools/javac/annotations/T7043371.java                                                                            Passed. Compilation successful
+tools/javac/annotations/T7073477.java                                                                            Passed. Compilation successful
+tools/javac/annotations/T8154270/EraseClassInfoAnnotationValueTest.java                                          Passed. Execution successful
+tools/javac/annotations/TestAnnotationPackageInfo.java                                                           Passed. Execution successful
+tools/javac/annotations/clinit/AnnoWithClinit1.java                                                              Passed. Compilation successful
+tools/javac/annotations/clinit/AnnoWithClinitFail.java                                                           Passed. Compilation failed as expected
+tools/javac/annotations/default/A.java                                                                           Passed. Compilation failed as expected
+tools/javac/annotations/neg/8022765/ErroneousAnnotations.java                                                    Passed. Compilation failed as expected
+tools/javac/annotations/neg/8022765/T8022765.java                                                                Passed. Compilation failed as expected
+tools/javac/annotations/neg/8022765/VerifyErroneousAnnotationsAttributed.java                                    Passed. Execution successful
+tools/javac/annotations/neg/8171322/TypeVariableAsAnnotationTest.java                                            Passed. Compilation failed as expected
+tools/javac/annotations/neg/AnnComma.java                                                                        Passed. Compilation failed as expected
+tools/javac/annotations/neg/AnonSubclass.java                                                                    Passed. Compilation failed as expected
+tools/javac/annotations/neg/ArrayLit.java                                                                        Passed. Compilation failed as expected
+tools/javac/annotations/neg/Constant.java                                                                        Passed. Compilation failed as expected
+tools/javac/annotations/neg/Cycle1.java                                                                          Passed. Compilation failed as expected
+tools/javac/annotations/neg/Cycle2.java                                                                          Passed. Compilation failed as expected
+tools/javac/annotations/neg/Cycle3.java                                                                          Passed. Compilation failed as expected
+tools/javac/annotations/neg/Dep.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/DeprecatedAnnotationTest/package-info.java                                           Passed. Compilation failed as expected
+tools/javac/annotations/neg/Dup.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/DupTarget.java                                                                       Passed. Compilation failed as expected
+tools/javac/annotations/neg/InvalidPackageAnno.java                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/MemberOver.java                                                                      Passed. Compilation failed as expected
+tools/javac/annotations/neg/NoAnnotationMethods.java                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/NoClone.java                                                                         Passed. Compilation failed as expected
+tools/javac/annotations/neg/NoDefault.java                                                                       Passed. Compilation failed as expected
+tools/javac/annotations/neg/NoDefaultAbstract.java                                                               Passed. Compilation failed as expected
+tools/javac/annotations/neg/NoObjectMethods.java                                                                 Passed. Compilation failed as expected
+tools/javac/annotations/neg/NoStatic.java                                                                        Passed. Compilation failed as expected
+tools/javac/annotations/neg/NoStaticAbstract.java                                                                Passed. Compilation failed as expected
+tools/javac/annotations/neg/ObjectMembers.java                                                                   Passed. Compilation failed as expected
+tools/javac/annotations/neg/OverrideNo.java                                                                      Passed. Compilation failed as expected
+tools/javac/annotations/neg/Package.java                                                                         Passed. Compilation failed as expected
+tools/javac/annotations/neg/Recovery.java                                                                        Passed. Compilation failed as expected
+tools/javac/annotations/neg/Recovery1.java                                                                       Passed. Compilation failed as expected
+tools/javac/annotations/neg/Scope.java                                                                           Passed. Compilation failed as expected
+tools/javac/annotations/neg/Syntax1.java                                                                         Passed. Compilation failed as expected
+tools/javac/annotations/neg/WrongTarget.java                                                                     Passed. Compilation failed as expected
+tools/javac/annotations/neg/WrongTarget2.java                                                                    Passed. Compilation failed as expected
+tools/javac/annotations/neg/WrongValue.java                                                                      Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z1.java                                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z10.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z11.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z12.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z13.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z14.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z15.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z16.java                                                                             Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z2.java                                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z3.java                                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z4.java                                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z5.java                                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z8.java                                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/Z9.java                                                                              Passed. Compilation failed as expected
+tools/javac/annotations/neg/pkg/package-info.java                                                                Passed. Compilation failed as expected
+tools/javac/annotations/pos/AnnotationMethods.java                                                               Passed. Compilation successful
+tools/javac/annotations/pos/AnnoteElideBraces.java                                                               Passed. Compilation successful
+tools/javac/annotations/pos/ClassA.java                                                                          Passed. Compilation successful
+tools/javac/annotations/pos/Dep.java                                                                             Passed. Compilation successful
+tools/javac/annotations/pos/Enum1.java                                                                           Passed. Compilation successful
+tools/javac/annotations/pos/Local.java                                                                           Passed. Compilation successful
+tools/javac/annotations/pos/Members.java                                                                         Passed. Compilation successful
+tools/javac/annotations/pos/NType.java                                                                           Passed. Compilation successful
+tools/javac/annotations/pos/OverrideCheck.java                                                                   Passed. Compilation successful
+tools/javac/annotations/pos/OverrideOK.java                                                                      Passed. Compilation successful
+tools/javac/annotations/pos/Parameter.java                                                                       Passed. Compilation successful
+tools/javac/annotations/pos/Primitives.java                                                                      Passed. Execution successful
+tools/javac/annotations/pos/RightTarget.java                                                                     Passed. Compilation successful
+tools/javac/annotations/pos/TrailingComma.java                                                                   Passed. Compilation successful
+tools/javac/annotations/pos/Z1.java                                                                              Passed. Compilation successful
+tools/javac/annotations/pos/Z2.java                                                                              Passed. Compilation successful
+tools/javac/annotations/pos/Z3.java                                                                              Passed. Compilation successful
+tools/javac/annotations/pos/Z4.java                                                                              Passed. Compilation successful
+tools/javac/annotations/pos/package-info.java                                                                    Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/8029017/TypeUseTarget.java                                          Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/8029017/TypeUseTargetNeg.java                                       Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/BaseAnnoAsContainerAnno.java                                        Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/BasicRepeatingAnnotations.java                                      Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/CheckTargets.java                                                   Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/ClassReaderDefault.java                                             Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/ContainerHasRepeatedContained.java                                  Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/CyclicAnnotation.java                                               Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/DefaultCasePresent.java                                             Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/DefaultTarget.java                                                  Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeParameter.java                                     Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeUse.java                                           Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/DelayRepeatedContainer.java                                         Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/DocumentedContainerAnno.java                                        Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/DuplicateErrors.java                                                Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/InheritedContainerAnno.java                                         Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/InvalidClsTypeParamTarget.java                                      Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/InvalidMethodTypeParamTarget.java                                   Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/InvalidMethodTypeUse.java                                           Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/InvalidRepAnnoOnCast.java                                           Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/InvalidTarget.java                                                  Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/MissingContainer.java                                               Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/MissingDefaultCase1.java                                            Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/MissingDefaultCase2.java                                            Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/MissingValueMethod.java                                             Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/MultiLevelRepeatableAnno.java                                       Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/MultipleAnnoMixedOrder.java                                         Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/NestedContainers.java                                               Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/NoRepeatableAnno.java                                               Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer.java                                            Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer2.java                                           Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/RepMemberAnno.java                                                  Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/RepSelfMemberAnno.java                                              Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/RepeatingAndContainerPresent.java                                   Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/RepeatingTargetNotAllowed.java                                      Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/SelfRepeatingAnnotations.java                                       Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/SingleRepeatingAndContainer.java                                    Passed. Compilation successful
+tools/javac/annotations/repeatingAnnotations/UseWrongRepeatable.java                                             Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/WrongReturnTypeForValue.java                                        Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/WrongVersion.java                                                   Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/brokenTypeAnnoContainer/BrokenTypeAnnoContainer.java                Passed. Compilation failed as expected
+tools/javac/annotations/repeatingAnnotations/combo/BasicSyntaxCombo.java                                         Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/combo/DeprecatedAnnoCombo.java                                      Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/combo/DocumentedAnnoCombo.java                                      Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/combo/InheritedAnnoCombo.java                                       Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/combo/ReflectionTest.java                                           Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/combo/RetentionAnnoCombo.java                                       Passed. Execution successful
+tools/javac/annotations/repeatingAnnotations/generatedInRepeating/GeneratedInRepeating.java                      Passed. Compilation successful
+tools/javac/annotations/testCrashNestedAnnos/TestCrashNestedAnnos.java                                           Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/6967002/T6967002.java                                                    Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/8013180/QualifiedName.java                                               Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/8047024/T8047024.java                                                    Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/DeclVsUseErrorMessage.java                                               Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/ErasureTest.java                                                         Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/InnerClass.java                                                          Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/MultipleTargets.java                                                     Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/RichFormatterWithAnnotationsTest.java                                    Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/TargetTypes.java                                                         Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/TestAnonInnerInstance1.java                                              Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/TypeParameterTarget.java                                                 Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/TypeProcOnly.java                                                        Passed. Execution successful
+tools/javac/annotations/typeAnnotations/TypeUseTarget.java                                                       Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/api/AnnotatedArrayOrder.java                                             Passed. Execution successful
+tools/javac/annotations/typeAnnotations/api/ArrayCreationTree.java                                               Passed. Execution successful
+tools/javac/annotations/typeAnnotations/api/ArrayPositionConsistency.java                                        Passed. Execution successful
+tools/javac/annotations/typeAnnotations/attribution/Scopes.java                                                  Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/classfile/AnnotatedExtendsTest.java                                      Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/AnonymousClassTest.java                                        Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/AnonymousExtendsTest.java                                      Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/BridgeShouldHaveNoInteriorAnnotationsTest.java                 Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/CombinationsTargetTest1.java                                   Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/CombinationsTargetTest2.java                                   Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/CombinationsTargetTest3.java                                   Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/DeadCode.java                                                  Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/InstanceInitializer.java                                       Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/NestedLambdasCastedTest.java                                   Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/NewTypeArguments.java                                          Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/NoTargetAnnotations.java                                       Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/Patterns.java                                                  Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/Scopes.java                                                    Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/StaticInitializer.java                                         Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/SyntheticParameters.java                                       Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/T8008762.java                                                  Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/T8008769.java                                                  Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/T8010015.java                                                  Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/TestAnonInnerClasses.java                                      Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/TestNewCastArray.java                                          Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/TypeAnnotationPropagationTest.java                             Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/TypeCasts.java                                                 Passed. Execution successful
+tools/javac/annotations/typeAnnotations/classfile/Wildcards.java                                                 Passed. Execution successful
+tools/javac/annotations/typeAnnotations/failures/AnnotatedClassExpr.java                                         Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/AnnotatedImport.java                                            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest.java                                Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest2.java                               Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest3.java                               Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/AnnotatedPackage1.java                                          Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/AnnotatedPackage2.java                                          Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/AnnotationVersion.java                                          Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/BadCast.java                                                    Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/CantAnnotateStaticClass.java                                    Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/CheckErrorsForSource7.java                                      Passed. Execution successful
+tools/javac/annotations/typeAnnotations/failures/CheckForDeclAnnoNPE.java                                        Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/IncompleteArray.java                                            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/IndexArray.java                                                 Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/LazyConstantValue.java                                          Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/LintCast.java                                                   Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/OldArray.java                                                   Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/Scopes.java                                                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/StaticFields.java                                               Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/T8008751.java                                                   Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/T8009360.java                                                   Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/T8011722.java                                                   Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/T8020715.java                                                   Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/TypeAndField.java                                               Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/TypeOnAnonClass.java                                            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/TypeVariable.java                                               Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/TypeVariableCycleTest.java                                      Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/TypeVariableMissingTA.java                                      Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/VoidGenericMethod.java                                          Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/arrays/DeclarationAnnotation.java                        Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/arrays/DuplicateAnnotationValue.java                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/arrays/DuplicateTypeAnnotation.java                      Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/arrays/InvalidLocation.java                              Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/arrays/MissingAnnotationValue.java                       Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/innertypeparams/DuplicateAnnotationValue.java            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/innertypeparams/DuplicateTypeAnnotation.java             Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/innertypeparams/InvalidLocation.java                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/innertypeparams/MissingAnnotationValue.java              Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/newarray/DuplicateAnnotationValue.java                   Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/newarray/DuplicateTypeAnnotation.java                    Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/newarray/InvalidLocation.java                            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/newarray/MissingAnnotationValue.java                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/parambounds/BrokenAnnotation.java                        Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/parambounds/DuplicateAnnotationValue.java                Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/parambounds/DuplicateTypeAnnotation.java                 Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/parambounds/InvalidLocation.java                         Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/parambounds/MissingAnnotationValue.java                  Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/receiver/DeclarationAnnotation.java                      Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/receiver/DuplicateAnnotationValue.java                   Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/receiver/DuplicateTypeAnnotation.java                    Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/receiver/InvalidLocation.java                            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/receiver/MissingAnnotationValue.java                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/receiver/Nesting.java                                    Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/failures/common/receiver/StaticThings.java                               Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/receiver/WrongType.java                                  Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/rest/DuplicateAnnotationValue.java                       Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/rest/DuplicateTypeAnnotation.java                        Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/rest/InvalidLocation.java                                Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/rest/MissingAnnotationValue.java                         Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeArgs/DuplicateAnnotationValue.java                   Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeArgs/DuplicateTypeAnnotation.java                    Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeArgs/InvalidLocation.java                            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeArgs/MissingAnnotationValue.java                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeparams/DuplicateAnnotationValue.java                 Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeparams/DuplicateTypeAnnotation.java                  Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeparams/InvalidLocation.java                          Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/typeparams/MissingAnnotationValue.java                   Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/wildcards/DeclarationAnnotation.java                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/wildcards/DuplicateAnnotationValue.java                  Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/wildcards/DuplicateTypeAnnotation.java                   Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/wildcards/InvalidLocation.java                           Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/common/wildcards/MissingAnnotationValue.java                    Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/target/Constructor.java                                         Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/target/DotClass.java                                            Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/target/IncompleteArray.java                                     Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/target/NotTypeParameter.java                                    Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/target/NotTypeUse.java                                          Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/failures/target/VoidMethod.java                                          Passed. Compilation failed as expected
+tools/javac/annotations/typeAnnotations/newlocations/AfterMethodTypeParams.java                                  Passed. Execution successful
+tools/javac/annotations/typeAnnotations/newlocations/AllLocations.java                                           Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/AnonymousClass.java                                         Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/BasicTest.java                                              Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/ClassExtends.java                                           Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/ClassParameters.java                                        Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/ConstructorTypeArgs.java                                    Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/ExceptionParameters.java                                    Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Expressions.java                                            Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Fields.java                                                 Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Lambda.java                                                 Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/LocalVariables.java                                         Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/MethodReturnType.java                                       Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/MethodTypeArgs.java                                         Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/MethodTypeParameters.java                                   Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/MultiCatch.java                                             Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/NestedTypes.java                                            Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Parameters.java                                             Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Receivers.java                                              Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/ResourceVariables.java                                      Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Throws.java                                                 Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/TopLevelBlocks.java                                         Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/TypeCasts.java                                              Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/TypeParameters.java                                         Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Varargs.java                                                Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/newlocations/Wildcards.java                                              Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/packageanno/PackageProcessor.java                                        Passed. Compilation successful
+tools/javac/annotations/typeAnnotations/referenceinfos/ClassExtends.java                                         Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/ClassTypeParam.java                                       Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/ConstructorInvocationTypeArgument.java                    Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/Constructors.java                                         Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/ExceptionParameters.java                                  Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/Fields.java                                               Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/FromSpecification.java                                    Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/Initializers.java                                         Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/MethodInvocationTypeArgument.java                         Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/MethodParameters.java                                     Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/MethodReceivers.java                                      Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/MethodReturns.java                                        Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/MethodThrows.java                                         Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/MethodTypeParam.java                                      Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/MultiCatch.java                                           Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/NewObjects.java                                           Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/RepeatingTypeAnnotations.java                             Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/ResourceVariable.java                                     Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/TypeCasts.java                                            Passed. Execution successful
+tools/javac/annotations/typeAnnotations/referenceinfos/TypeTests.java                                            Passed. Execution successful
+tools/javac/api/6400303/T6400303.java                                                                            Passed. Execution successful
+tools/javac/api/6406133/T6406133.java                                                                            Passed. Execution successful
+tools/javac/api/6410643/T6410643.java                                                                            Passed. Execution successful
+tools/javac/api/6411310/T6411310.java                                                                            Passed. Execution successful
+tools/javac/api/6411333/T6411333.java                                                                            Passed. Execution successful
+tools/javac/api/6412656/T6412656.java                                                                            Passed. Execution successful
+tools/javac/api/6415780/T6415780.java                                                                            Passed. Execution successful
+tools/javac/api/6418694/T6418694.java                                                                            Passed. Execution successful
+tools/javac/api/6420409/T6420409.java                                                                            Passed. Execution successful
+tools/javac/api/6420464/T6420464.java                                                                            Passed. Execution successful
+tools/javac/api/6421111/T6421111.java                                                                            Passed. Execution successful
+tools/javac/api/6421756/T6421756.java                                                                            Passed. Execution successful
+tools/javac/api/6422215/T6422215.java                                                                            Passed. Execution successful
+tools/javac/api/6422327/T6422327.java                                                                            Passed. Execution successful
+tools/javac/api/6423003/T6423003.java                                                                            Passed. Execution successful
+tools/javac/api/6431257/T6431257.java                                                                            Passed. Execution successful
+tools/javac/api/6431435/T6431435.java                                                                            Passed. Execution successful
+tools/javac/api/6437349/T6437349.java                                                                            Passed. Execution successful
+tools/javac/api/6437999/T6437999.java                                                                            Passed. Execution successful
+tools/javac/api/6440333/T6440333.java                                                                            Passed. Execution successful
+tools/javac/api/6440528/T6440528.java                                                                            Passed. Execution successful
+tools/javac/api/6452876/T6452876.java                                                                            Passed. Execution successful
+tools/javac/api/6468404/T6468404.java                                                                            Passed. Execution successful
+tools/javac/api/6471599/Main.java                                                                                Passed. Execution successful
+tools/javac/api/6557752/T6557752.java                                                                            Passed. Execution successful
+tools/javac/api/6598108/T6598108.java                                                                            Passed. Execution successful
+tools/javac/api/6608214/T6608214.java                                                                            Passed. Execution successful
+tools/javac/api/6731573/T6731573.java                                                                            Passed. Execution successful
+tools/javac/api/6733837/T6733837.java                                                                            Passed. Execution successful
+tools/javac/api/6852595/T6852595.java                                                                            Passed. Execution successful
+tools/javac/api/7086261/T7086261.java                                                                            Passed. Execution successful
+tools/javac/api/8007344/Test.java                                                                                Passed. Execution successful
+tools/javac/api/CrashReport.java                                                                                 Passed. Execution successful
+tools/javac/api/EndPositions.java                                                                                Passed. Execution successful
+tools/javac/api/Sibling.java                                                                                     Passed. Execution successful
+tools/javac/api/T6257235.java                                                                                    Passed. Execution successful
+tools/javac/api/T6258271.java                                                                                    Passed. Execution successful
+tools/javac/api/T6265137.java                                                                                    Passed. Execution successful
+tools/javac/api/T6306137.java                                                                                    Passed. Execution successful
+tools/javac/api/T6345974.java                                                                                    Passed. Execution successful
+tools/javac/api/T6357331.java                                                                                    Passed. Execution successful
+tools/javac/api/T6358786.java                                                                                    Passed. Execution successful
+tools/javac/api/T6358955.java                                                                                    Passed. Execution successful
+tools/javac/api/T6392782.java                                                                                    Passed. Execution successful
+tools/javac/api/T6395981.java                                                                                    Passed. Execution successful
+tools/javac/api/T6397104.java                                                                                    Passed. Execution successful
+tools/javac/api/T6400205.java                                                                                    Passed. Execution successful
+tools/javac/api/T6400207.java                                                                                    Passed. Execution successful
+tools/javac/api/T6407011.java                                                                                    Passed. Execution successful
+tools/javac/api/T6412669.java                                                                                    Passed. Execution successful
+tools/javac/api/T6419926.java                                                                                    Passed. Execution successful
+tools/javac/api/T6431879.java                                                                                    Passed. Execution successful
+tools/javac/api/T6437138.java                                                                                    Passed. Execution successful
+tools/javac/api/T6483788.java                                                                                    Passed. Execution successful
+tools/javac/api/T6501502.java                                                                                    Passed. Execution successful
+tools/javac/api/T6838467.java                                                                                    Passed. Execution successful
+tools/javac/api/T6877206.java                                                                                    Passed. Execution successful
+tools/javac/api/TestClientCodeWrapper.java                                                                       Passed. Execution successful
+tools/javac/api/TestContainTypes.java                                                                            Passed. Execution successful
+tools/javac/api/TestDocComments.java                                                                             Passed. Execution successful
+tools/javac/api/TestEvalExpression.java                                                                          Passed. Execution successful
+tools/javac/api/TestGetElement.java                                                                              Passed. Execution successful
+tools/javac/api/TestGetElementReference.java                                                                     Passed. Execution successful
+tools/javac/api/TestGetScope.java                                                                                Passed. Execution successful
+tools/javac/api/TestGetScopeBinaryNames.java                                                                     Passed. Execution successful
+tools/javac/api/TestGetScopeErrors.java                                                                          Passed. Execution successful
+tools/javac/api/TestGetScopeResult.java                                                                          Passed. Execution successful
+tools/javac/api/TestGetTree.java                                                                                 Passed. Compilation successful
+tools/javac/api/TestJavacTask.java                                                                               Passed. Execution successful
+tools/javac/api/TestJavacTaskScanner.java                                                                        Passed. Execution successful
+tools/javac/api/TestJavacTask_Lock.java                                                                          Passed. Execution successful
+tools/javac/api/TestJavacTask_Multiple.java                                                                      Passed. Execution successful
+tools/javac/api/TestJavacTask_ParseAttrGen.java                                                                  Passed. Execution successful
+tools/javac/api/TestModuleUnnamedPackage.java                                                                    Passed. Execution successful
+tools/javac/api/TestName.java                                                                                    Passed. Execution successful
+tools/javac/api/TestOperators.java                                                                               Passed. Compilation successful
+tools/javac/api/TestResolveError.java                                                                            Passed. Execution successful
+tools/javac/api/TestResolveIdent.java                                                                            Passed. Execution successful
+tools/javac/api/TestSearchPaths.java                                                                             Passed. Execution successful
+tools/javac/api/TestTreePath.java                                                                                Passed. Execution successful
+tools/javac/api/TestTrees.java                                                                                   Passed. Execution successful
+tools/javac/api/ToolProvider/HelloWorldTest.java                                                                 Passed. Execution successful
+tools/javac/api/ToolProvider/ToolProviderTest.java                                                               Passed. Execution successful
+tools/javac/api/ToolProvider/ToolProviderTest1.java                                                              Passed. Execution successful
+tools/javac/api/ToolProvider/ToolProviderTest2.java                                                              Passed. Execution successful
+tools/javac/api/file/SJFM_AsPath.java                                                                            Passed. Execution successful
+tools/javac/api/file/SJFM_GetFileObjects.java                                                                    Passed. Execution successful
+tools/javac/api/file/SJFM_IsSameFile.java                                                                        Passed. Execution successful
+tools/javac/api/file/SJFM_Locations.java                                                                         Passed. Execution successful
+tools/javac/api/guide/Test.java                                                                                  Passed. Execution successful
+tools/javac/api/lazy/LoadParameterNamesLazily.java                                                               Passed. Execution successful
+tools/javac/api/taskListeners/CompileEvent.java                                                                  Passed. Execution successful
+tools/javac/api/taskListeners/EventsBalancedTest.java                                                            Passed. Execution successful
+tools/javac/api/taskListeners/TestSimpleAddRemove.java                                                           Passed. Execution successful
+tools/javac/assert/Attach.java                                                                                   Passed. Execution successful
+tools/javac/assert/DU1.java                                                                                      Passed. Compilation failed as expected
+tools/javac/assert/DU2.java                                                                                      Passed. Compilation failed as expected
+tools/javac/assert/Position.java                                                                                 Passed. Execution successful
+tools/javac/binaryCompat/T1.java                                                                                 Passed. Execution successful
+tools/javac/boxing/BoxedForeach.java                                                                             Passed. Execution successful
+tools/javac/boxing/Boxing1.java                                                                                  Passed. Execution successful
+tools/javac/boxing/Boxing2.java                                                                                  Passed. Compilation failed as expected
+tools/javac/boxing/Boxing4.java                                                                                  Passed. Execution successful
+tools/javac/boxing/BoxingCaching.java                                                                            Passed. Execution successful
+tools/javac/boxing/IncrementBoxedAndAccess.java                                                                  Passed. Execution successful
+tools/javac/boxing/QualBoxedPostOp.java                                                                          Passed. Execution successful
+tools/javac/boxing/QualBoxedPostOp2.java                                                                         Passed. Execution successful
+tools/javac/boxing/QualBoxedPostOp3.java                                                                         Passed. Execution successful
+tools/javac/boxing/T5082929.java                                                                                 Passed. Compilation failed as expected
+tools/javac/boxing/T6348760.java                                                                                 Passed. Execution successful
+tools/javac/boxing/T6369051.java                                                                                 Passed. Compilation successful
+tools/javac/boxing/T6614974.java                                                                                 Passed. Execution successful
+tools/javac/boxing/T6816548.java                                                                                 Passed. Execution successful
+tools/javac/capture/Capture1.java                                                                                Passed. Compilation successful
+tools/javac/capture/Capture2.java                                                                                Passed. Compilation failed as expected
+tools/javac/capture/Capture3.java                                                                                Passed. Compilation successful
+tools/javac/capture/Capture5.java                                                                                Passed. Compilation successful
+tools/javac/capture/Martin.java                                                                                  Passed. Compilation failed as expected
+tools/javac/capture/T6594284.java                                                                                Passed. Compilation failed as expected
+tools/javac/cast/4916620/T4916620.java                                                                           Passed. Compilation successful
+tools/javac/cast/5034609/T5034609.java                                                                           Passed. Compilation successful
+tools/javac/cast/5043020/T5043020.java                                                                           Passed. Compilation successful
+tools/javac/cast/5064736/T5064736.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/5065215/T5065215.java                                                                           Passed. Compilation successful
+tools/javac/cast/6211853/T6211853.java                                                                           Passed. Compilation successful
+tools/javac/cast/6219964/T6219964.java                                                                           Passed. Compilation successful
+tools/javac/cast/6256789/T6256789.java                                                                           Passed. Compilation successful
+tools/javac/cast/6270087/T6270087.java                                                                           Passed. Compilation successful
+tools/javac/cast/6270087/T6270087neg.java                                                                        Passed. Compilation failed as expected
+tools/javac/cast/6286112/T6286112.java                                                                           Passed. Compilation successful
+tools/javac/cast/6295056/T6295056.java                                                                           Passed. Compilation successful
+tools/javac/cast/6302214/T6302214.java                                                                           Passed. Compilation successful
+tools/javac/cast/6302214/T6302214a.java                                                                          Passed. Compilation successful
+tools/javac/cast/6302956/T6302956.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/6358534/T6358534.java                                                                           Passed. Compilation successful
+tools/javac/cast/6467183/T6467183a.java                                                                          Passed. Compilation failed as expected
+tools/javac/cast/6467183/T6467183b.java                                                                          Passed. Compilation successful
+tools/javac/cast/6507317/T6507317.java                                                                           Passed. Compilation successful
+tools/javac/cast/6548436/T6548436a.java                                                                          Passed. Compilation successful
+tools/javac/cast/6548436/T6548436b.java                                                                          Passed. Compilation successful
+tools/javac/cast/6548436/T6548436c.java                                                                          Passed. Compilation successful
+tools/javac/cast/6548436/T6548436d.java                                                                          Passed. Compilation failed as expected
+tools/javac/cast/6557182/T6557182.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/6558559/T6558559a.java                                                                          Passed. Compilation successful
+tools/javac/cast/6558559/T6558559b.java                                                                          Passed. Compilation successful
+tools/javac/cast/6569057/T6569057.java                                                                           Passed. Compilation successful
+tools/javac/cast/6586091/T6586091.java                                                                           Passed. Compilation successful
+tools/javac/cast/6665356/T6665356.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/6714835/T6714835.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/6795580/T6795580.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/6932571/T6932571a.java                                                                          Passed. Compilation successful
+tools/javac/cast/6932571/T6932571b.java                                                                          Passed. Compilation successful
+tools/javac/cast/6932571/T6932571neg.java                                                                        Passed. Compilation failed as expected
+tools/javac/cast/7005095/T7005095neg.java                                                                        Passed. Compilation failed as expected
+tools/javac/cast/7005095/T7005095pos.java                                                                        Passed. Compilation successful
+tools/javac/cast/7005671/T7005671.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/7123100/T7123100a.java                                                                          Passed. Compilation failed as expected
+tools/javac/cast/7123100/T7123100b.java                                                                          Passed. Compilation failed as expected
+tools/javac/cast/7123100/T7123100c.java                                                                          Passed. Compilation failed as expected
+tools/javac/cast/7123100/T7123100d.java                                                                          Passed. Compilation failed as expected
+tools/javac/cast/7126754/T7126754.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/8141343/T8141343.java                                                                           Passed. Compilation failed as expected
+tools/javac/cast/BoxedArray.java                                                                                 Passed. Compilation failed as expected
+tools/javac/cast/forum/T654170.java                                                                              Passed. Compilation successful
+tools/javac/cast/intersection/IntersectionTypeCastTest.java                                                      Passed. Execution successful
+tools/javac/cast/intersection/IntersectionTypeParserTest.java                                                    Passed. Execution successful
+tools/javac/cast/intersection/model/Model01.java                                                                 Passed. Compilation successful
+tools/javac/classfiles/ClassVersionChecker.java                                                                  Passed. Execution successful
+tools/javac/classfiles/InnerClasses/SyntheticClasses.java                                                        Passed. Execution successful
+tools/javac/classfiles/InnerClasses/T8068517.java                                                                Passed. Execution successful
+tools/javac/classfiles/attributes/AnnotationDefault/AnnotationDefaultTest.java                                   Passed. Execution successful
+tools/javac/classfiles/attributes/ConstantValue/BrokenConstantValue.java                                         Passed. Compilation failed as expected
+tools/javac/classfiles/attributes/EnclosingMethod/EnclosingMethodTest.java                                       Passed. Execution successful
+tools/javac/classfiles/attributes/LineNumberTable/LineNumberTest.java                                            Passed. Execution successful
+tools/javac/classfiles/attributes/LineNumberTable/T8050993.java                                                  Passed. Execution successful
+tools/javac/classfiles/attributes/LocalVariableTable/LocalVariableTableTest.java                                 Passed. Execution successful
+tools/javac/classfiles/attributes/LocalVariableTable/LocalVariableTypeTableTest.java                             Passed. Execution successful
+tools/javac/classfiles/attributes/LocalVariableTable/T8136453/T8136453.java                                      Passed. Execution successful
+tools/javac/classfiles/attributes/Module/ModuleFlagTest.java                                                     Passed. Execution successful
+tools/javac/classfiles/attributes/Module/ModuleTest.java                                                         Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/ConstructorTest.java                                                 Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/EnumTest.java                                                        Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/ExceptionTest.java                                                   Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/FieldTest.java                                                       Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/InnerClassTest.java                                                  Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/MethodParameterTest.java                                             Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/MethodTypeBoundTest.java                                             Passed. Execution successful
+tools/javac/classfiles/attributes/Signature/ReturnTypeTest.java                                                  Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/AnonymousClassTest.java                                             Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/InnerClassTest.java                                                 Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/LocalClassTest.java                                                 Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/MixTest.java                                                        Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/ModuleInfoTest.java                                                 Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/NoSourceFileAttribute.java                                          Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/SyntheticClassTest.java                                             Passed. Execution successful
+tools/javac/classfiles/attributes/SourceFile/TopLevelClassesOneFileTest.java                                     Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassConstructorsTest.java                       Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassMembersTest.java                            Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/AccessToPrivateSiblingsTest.java                                     Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/AssertFieldTest.java                                                 Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/BridgeMethodForGenericMethodTest.java                                Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTest.java                                      Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/EnumTest.java                                                        Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/PackageInfoTest.java                                                 Passed. Execution successful
+tools/javac/classfiles/attributes/Synthetic/ThisFieldTest.java                                                   Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeAnnotationsForGenericMethodTest.java                        Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeAnnotationsForInnerAnnotationTest.java                      Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeAnnotationsForInnerClassTest.java                           Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeAnnotationsForInnerEnumTest.java                            Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeAnnotationsForInnerInterfaceTest.java                       Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeAnnotationsForTopLevelClassTest.java                        Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeParameterAnnotationsForGenericMethodTest.java               Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeParameterAnnotationsForLambdaTest.java                      Passed. Execution successful
+tools/javac/classfiles/attributes/annotations/RuntimeParameterAnnotationsTest.java                               Passed. Execution successful
+tools/javac/classfiles/attributes/deprecated/DeprecatedPackageTest.java                                          Passed. Execution successful
+tools/javac/classfiles/attributes/deprecated/DeprecatedTest.java                                                 Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerAnnotationTest.java                        Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerClassTest.java                             Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerEnumTest.java                              Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerInterfaceTest.java                         Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesHierarchyTest.java                                    Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesInAnonymousClassTest.java                             Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerAnnotationTest.java                            Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerClassTest.java                                 Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerEnumTest.java                                  Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerInterfaceTest.java                             Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesInLocalClassTest.java                                 Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesIndexTest.java                                        Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerClassesTest.java                                             Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerAnnotationTest.java                               Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerEnumTest.java                                     Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerInterfaceTest.java                                Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerEnumsInInnerClassTest.java                                   Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerAnnotationTest.java                         Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerClassTest.java                              Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerEnumTest.java                               Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerInterfaceTest.java                          Passed. Execution successful
+tools/javac/classfiles/attributes/innerclasses/NoInnerClassesTest.java                                           Passed. Execution successful
+tools/javac/classreader/8171132/BadConstantValue.java                                                            Passed. Execution successful
+tools/javac/classreader/8215407/BrokenEnclosingClass.java                                                        Passed. Compilation successful
+tools/javac/classreader/BadClass.java                                                                            Passed. Execution successful
+tools/javac/classreader/FileSystemClosedTest.java                                                                Passed. Execution successful
+tools/javac/classreader/T7031108.java                                                                            Passed. Execution successful
+tools/javac/classwriter/ExtraAttributes.java                                                                     Passed. Execution successful
+tools/javac/code/ArrayClone.java                                                                                 Passed. Execution successful
+tools/javac/completionDeps/DepsAndAnno.java                                                                      Passed. Execution successful
+tools/javac/completionDeps/DepsAndDocLint.java                                                                   Passed. Compilation successful
+tools/javac/conditional/6500343/T6500343a.java                                                                   Passed. Execution successful
+tools/javac/conditional/6500343/T6500343b.java                                                                   Passed. Execution successful
+tools/javac/conditional/8064464/T8064464.java                                                                    Passed. Compilation failed as expected
+tools/javac/conditional/Conditional.java                                                                         Passed. Compilation failed as expected
+tools/javac/conditional/ConditionalWithFinalStrings.java                                                         Passed. Execution successful
+tools/javac/conditional/T8016702.java                                                                            Passed. Execution successful
+tools/javac/constDebug/ConstDebugTest.java                                                                       Passed. Execution successful
+tools/javac/crossPackageImpl/CrossPackageImplA.java                                                              Passed. Compilation successful
+tools/javac/cycle/T8193561.java                                                                                  Passed. Compilation failed as expected
+tools/javac/danglingDep/DepX.java                                                                                Passed. Compilation successful
+tools/javac/danglingDep/NoDepX.java                                                                              Passed. Compilation successful
+tools/javac/danglingDep/Test1.java                                                                               Passed. Compilation successful
+tools/javac/declaration/method/MethodVoidParameter.java                                                          Passed. Compilation failed as expected
+tools/javac/defaultMethods/AssertionsTest.java                                                                   Passed. Execution successful
+tools/javac/defaultMethods/BadClassfile.java                                                                     Passed. Execution successful
+tools/javac/defaultMethods/CannotChangeAssertionsStateAfterInitialized.java                                      Passed. Execution successful
+tools/javac/defaultMethods/CheckACC_STRICTFlagOnDefaultMethodTest.java                                           Passed. Execution successful
+tools/javac/defaultMethods/ClassReaderTest/ClassReaderTest.java                                                  Passed. Compilation successful
+tools/javac/defaultMethods/DefaultMethodFlags.java                                                               Passed. Execution successful
+tools/javac/defaultMethods/Neg01.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg02.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg03.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg04.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg05.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg06.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg07.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg08.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg09.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg10.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg11.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg12.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg13.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg14.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg15.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Neg16.java                                                                            Passed. Compilation failed as expected
+tools/javac/defaultMethods/Pos01.java                                                                            Passed. Execution successful
+tools/javac/defaultMethods/Pos02.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos04.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos05.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos06.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos07.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos08.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos10.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos11.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos12.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos13.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos14.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos15.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/Pos16.java                                                                            Passed. Compilation successful
+tools/javac/defaultMethods/TestDefaultBody.java                                                                  Passed. Execution successful
+tools/javac/defaultMethods/TestNoBridgeOnDefaults.java                                                           Passed. Execution successful
+tools/javac/defaultMethods/crossCompile/CrossCompile.java                                                        Passed. Compilation successful
+tools/javac/defaultMethods/private/Private01.java                                                                Passed. Execution successful
+tools/javac/defaultMethods/private/Private02.java                                                                Passed. Compilation failed as expected
+tools/javac/defaultMethods/private/Private03.java                                                                Passed. Compilation failed as expected
+tools/javac/defaultMethods/private/Private04.java                                                                Passed. Execution successful
+tools/javac/defaultMethods/private/Private05.java                                                                Passed. Execution successful
+tools/javac/defaultMethods/private/Private06.java                                                                Passed. Compilation failed as expected
+tools/javac/defaultMethods/private/Private07.java                                                                Passed. Compilation failed as expected
+tools/javac/defaultMethods/private/Private08.java                                                                Passed. Compilation failed as expected
+tools/javac/defaultMethods/private/Private09.java                                                                Passed. Compilation failed as expected
+tools/javac/defaultMethods/private/Private10.java                                                                Passed. Compilation failed as expected
+tools/javac/defaultMethods/private/PrivateGenerics.java                                                          Passed. Execution successful
+tools/javac/defaultMethods/private/PrivateInterfaceMethodProcessorTest.java                                      Passed. Compilation successful
+tools/javac/defaultMethods/separate/Separate.java                                                                Passed. Compilation successful
+tools/javac/defaultMethods/static/Static01.java                                                                  Passed. Compilation successful
+tools/javac/defaultMethods/static/Static02.java                                                                  Passed. Compilation failed as expected
+tools/javac/defaultMethods/static/StaticInvokeQualified.java                                                     Passed. Compilation failed as expected
+tools/javac/defaultMethods/static/StaticInvokeSimple.java                                                        Passed. Compilation failed as expected
+tools/javac/defaultMethods/static/hiding/InterfaceMethodHidingTest.java                                          Passed. Execution successful
+tools/javac/defaultMethods/static/import/StaticImport1.java                                                      Passed. Compilation successful
+tools/javac/defaultMethods/static/import/StaticImport2.java                                                      Passed. Compilation failed as expected
+tools/javac/defaultMethods/static/import/StaticImport3.java                                                      Passed. Compilation failed as expected
+tools/javac/defaultMethods/super/TestDefaultSuperCall.java                                                       Passed. Execution successful
+tools/javac/defaultMethods/super/TestDirectSuperInterfaceInvoke.java                                             Passed. Execution successful
+tools/javac/defaultMethods/syntax/TestDefaultMethodsSyntax.java                                                  Passed. Execution successful
+tools/javac/defaultMethodsVisibility/DefaultMethodsNotVisibleForSourceLessThan8Test.java                         Passed. Execution successful
+tools/javac/depDocComment/DeprecatedDocComment.java                                                              Passed. Compilation failed as expected
+tools/javac/depDocComment/DeprecatedDocComment3.java                                                             Passed. Compilation successful
+tools/javac/depDocComment/DeprecatedDocComment4.java                                                             Passed. Compilation failed as expected
+tools/javac/depDocComment/SuppressDepAnnWithSwitchTest.java                                                      Passed. Compilation successful
+tools/javac/depDocComment/SuppressDeprecation.java                                                               Passed. Compilation successful
+tools/javac/depOverrides/annotation/Test1.java                                                                   Passed. Compilation successful
+tools/javac/depOverrides/annotation/Test2.java                                                                   Passed. Compilation successful
+tools/javac/depOverrides/annotation/Test3.java                                                                   Passed. Compilation successful
+tools/javac/depOverrides/doccomment/Test1.java                                                                   Passed. Compilation successful
+tools/javac/depOverrides/doccomment/Test2.java                                                                   Passed. Compilation successful
+tools/javac/depOverrides/doccomment/Test3.java                                                                   Passed. Compilation successful
+tools/javac/desugar/BoxingAndSuper.java                                                                          Passed. Execution successful
+tools/javac/diags/CheckExamples.java                                                                             Passed. Execution successful
+tools/javac/diags/CheckResourceKeys.java                                                                         Passed. Execution successful
+tools/javac/diags/CompletionFailureInDiags.java                                                                  Passed. Execution successful
+tools/javac/diags/DiagnosticRewriterTest.java                                                                    Passed. Compilation failed as expected
+tools/javac/diags/DiagnosticRewriterTest2.java                                                                   Passed. Compilation failed as expected
+tools/javac/diags/EagerInitCheck.java                                                                            Passed. Compilation failed as expected
+tools/javac/diags/MessageInfo.java                                                                               Passed. Execution successful
+tools/javac/diags/RunExamples.java                                                                               Passed. Execution successful
+tools/javac/doclint/DocLintFormatTest.java                                                                       Passed. Execution successful
+tools/javac/doclint/DocLintTest.java                                                                             Passed. Execution successful
+tools/javac/doclint/ImplicitHeadingsTest.java                                                                    Passed. Compilation successful
+tools/javac/doclint/IncludePackagesTest.java                                                                     Passed. Execution successful
+tools/javac/doclint/NPEDuplicateClassNamesTest.java                                                              Passed. Execution successful
+tools/javac/doclint/implicitSource/ImplicitSourceTest.java                                                       Passed. Compilation successful
+tools/javac/doctree/AttrTest.java                                                                                Passed. Execution successful
+tools/javac/doctree/AuthorTest.java                                                                              Passed. Execution successful
+tools/javac/doctree/BadTest.java                                                                                 Passed. Execution successful
+tools/javac/doctree/CodeTest.java                                                                                Passed. Execution successful
+tools/javac/doctree/DeprecatedTest.java                                                                          Passed. Execution successful
+tools/javac/doctree/DocRootTest.java                                                                             Passed. Execution successful
+tools/javac/doctree/DocTreePathScannerTest.java                                                                  Passed. Execution successful
+tools/javac/doctree/ElementTest.java                                                                             Passed. Execution successful
+tools/javac/doctree/EntityTest.java                                                                              Passed. Execution successful
+tools/javac/doctree/ExceptionTest.java                                                                           Passed. Execution successful
+tools/javac/doctree/FirstSentenceTest.java                                                                       Passed. Execution successful
+tools/javac/doctree/HiddenTest.java                                                                              Passed. Execution successful
+tools/javac/doctree/InPreTest.java                                                                               Passed. Execution successful
+tools/javac/doctree/IndexTest.java                                                                               Passed. Execution successful
+tools/javac/doctree/InheritDocTest.java                                                                          Passed. Execution successful
+tools/javac/doctree/LinkPlainTest.java                                                                           Passed. Execution successful
+tools/javac/doctree/LinkTest.java                                                                                Passed. Execution successful
+tools/javac/doctree/LiteralTest.java                                                                             Passed. Execution successful
+tools/javac/doctree/ParamTest.java                                                                               Passed. Execution successful
+tools/javac/doctree/ProvidesTest.java                                                                            Passed. Execution successful
+tools/javac/doctree/ReferenceTest.java                                                                           Passed. Compilation successful
+tools/javac/doctree/ReturnTest.java                                                                              Passed. Execution successful
+tools/javac/doctree/SeeTest.java                                                                                 Passed. Execution successful
+tools/javac/doctree/SerialDataTest.java                                                                          Passed. Execution successful
+tools/javac/doctree/SerialFieldTest.java                                                                         Passed. Execution successful
+tools/javac/doctree/SerialTest.java                                                                              Passed. Execution successful
+tools/javac/doctree/SimpleDocTreeVisitorTest.java                                                                Passed. Execution successful
+tools/javac/doctree/SinceTest.java                                                                               Passed. Execution successful
+tools/javac/doctree/SummaryTest.java                                                                             Passed. Execution successful
+tools/javac/doctree/SystemPropertyTest.java                                                                      Passed. Execution successful
+tools/javac/doctree/TagTest.java                                                                                 Passed. Execution successful
+tools/javac/doctree/ThrowableTest.java                                                                           Passed. Execution successful
+tools/javac/doctree/UsesTest.java                                                                                Passed. Execution successful
+tools/javac/doctree/ValueTest.java                                                                               Passed. Execution successful
+tools/javac/doctree/VersionTest.java                                                                             Passed. Execution successful
+tools/javac/doctree/dcapi/DocCommentTreeApiTester.java                                                           Passed. Execution successful
+tools/javac/doctree/positions/TestPosition.java                                                                  Passed. Compilation successful
+tools/javac/enum/6350057/T6350057.java                                                                           Passed. Compilation successful
+tools/javac/enum/6424358/T6424358.java                                                                           Passed. Compilation successful
+tools/javac/enum/7160084/T7160084a.java                                                                          Passed. Execution successful
+tools/javac/enum/7160084/T7160084b.java                                                                          Passed. Execution successful
+tools/javac/enum/AbstractEmptyEnum.java                                                                          Passed. Compilation failed as expected
+tools/javac/enum/AbstractEnum1.java                                                                              Passed. Execution successful
+tools/javac/enum/DA1.java                                                                                        Passed. Compilation failed as expected
+tools/javac/enum/DA2.java                                                                                        Passed. Compilation failed as expected
+tools/javac/enum/DA3.java                                                                                        Passed. Compilation failed as expected
+tools/javac/enum/Def.java                                                                                        Passed. Compilation successful
+tools/javac/enum/Enum1.java                                                                                      Passed. Execution successful
+tools/javac/enum/Enum2.java                                                                                      Passed. Compilation failed as expected
+tools/javac/enum/Enum3.java                                                                                      Passed. Execution successful
+tools/javac/enum/EnumAsIdentifier.java                                                                           Passed. Compilation failed as expected
+tools/javac/enum/EnumImplicitPrivateConstructor.java                                                             Passed. Execution successful
+tools/javac/enum/EnumInit.java                                                                                   Passed. Compilation successful
+tools/javac/enum/EnumMembersOrder.java                                                                           Passed. Compilation failed as expected
+tools/javac/enum/EnumPrivateConstructor.java                                                                     Passed. Compilation successful
+tools/javac/enum/EnumProtectedConstructor.java                                                                   Passed. Compilation failed as expected
+tools/javac/enum/EnumPublicConstructor.java                                                                      Passed. Compilation failed as expected
+tools/javac/enum/EnumSwitch1.java                                                                                Passed. Compilation successful
+tools/javac/enum/EnumSwitch2.java                                                                                Passed. Compilation failed as expected
+tools/javac/enum/EnumSwitch3.java                                                                                Passed. Compilation successful
+tools/javac/enum/EnumSwitch4.java                                                                                Passed. Execution successful
+tools/javac/enum/ExplicitlyAbstractEnum1.java                                                                    Passed. Compilation failed as expected
+tools/javac/enum/ExplicitlyAbstractEnum2.java                                                                    Passed. Compilation failed as expected
+tools/javac/enum/ExplicitlyFinalEnum1.java                                                                       Passed. Compilation failed as expected
+tools/javac/enum/ExplicitlyFinalEnum2.java                                                                       Passed. Compilation failed as expected
+tools/javac/enum/FauxEnum1.java                                                                                  Passed. Compilation failed as expected
+tools/javac/enum/FauxEnum3.java                                                                                  Passed. Compilation failed as expected
+tools/javac/enum/FauxSpecialEnum1.java                                                                           Passed. Compilation failed as expected
+tools/javac/enum/FauxSpecialEnum2.java                                                                           Passed. Compilation failed as expected
+tools/javac/enum/LocalEnum.java                                                                                  Passed. Compilation failed as expected
+tools/javac/enum/NestedEnum.java                                                                                 Passed. Compilation failed as expected
+tools/javac/enum/NoFinal.java                                                                                    Passed. Compilation failed as expected
+tools/javac/enum/NoFinal2.java                                                                                   Passed. Compilation failed as expected
+tools/javac/enum/NoFinal3.java                                                                                   Passed. Compilation failed as expected
+tools/javac/enum/NoFinal4.java                                                                                   Passed. Compilation failed as expected
+tools/javac/enum/NoFinal5.java                                                                                   Passed. Compilation failed as expected
+tools/javac/enum/OkFinal.java                                                                                    Passed. Execution successful
+tools/javac/enum/SynthValues.java                                                                                Passed. Execution successful
+tools/javac/enum/T5075242.java                                                                                   Passed. Compilation successful
+tools/javac/enum/T5081785.java                                                                                   Passed. Compilation failed as expected
+tools/javac/enum/T6509042.java                                                                                   Passed. Compilation successful
+tools/javac/enum/T6675483.java                                                                                   Passed. Compilation successful
+tools/javac/enum/T6724345.java                                                                                   Passed. Compilation successful
+tools/javac/enum/TrailingComma.java                                                                              Passed. Compilation successful
+tools/javac/enum/UserValue.java                                                                                  Passed. Compilation successful
+tools/javac/enum/ValueOf.java                                                                                    Passed. Execution successful
+tools/javac/enum/enumSwitch/EnumSwitch.java                                                                      Passed. Execution successful
+tools/javac/enum/forwardRef/T6425594.java                                                                        Passed. Compilation failed as expected
+tools/javac/enum/forwardRef/TestEnum1.java                                                                       Passed. Compilation failed as expected
+tools/javac/enum/forwardRef/TestEnum2.java                                                                       Passed. Compilation failed as expected
+tools/javac/enum/forwardRef/TestEnum3.java                                                                       Passed. Compilation failed as expected
+tools/javac/enum/forwardRef/TestEnum4.java                                                                       Passed. Compilation failed as expected
+tools/javac/enum/forwardRef/TestEnum5.java                                                                       Passed. Compilation failed as expected
+tools/javac/enum/forwardRef/TestEnum6.java                                                                       Passed. Compilation failed as expected
+tools/javac/expression/BinopVoidTest.java                                                                        Passed. Compilation failed as expected
+tools/javac/expression/DeeplyChainedNonPolyExpressionTest.java                                                   Passed. Execution successful
+tools/javac/expression/IllegalParenthesis.java                                                                   Passed. Compilation failed as expected
+tools/javac/expression/NullAppend.java                                                                           Passed. Compilation failed as expected
+tools/javac/expression/NullAppend2.java                                                                          Passed. Compilation failed as expected
+tools/javac/expression/_super/NonDirectSuper/NonDirectSuper.java                                                 Passed. Execution successful
+tools/javac/expswitch/ExpSwitchNestingTest.java                                                                  Passed. Execution successful
+tools/javac/failover/CheckAttributedTree.java                                                                    Passed. Execution successful
+tools/javac/failover/FailOver01.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver02.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver03.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver04.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver05.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver06.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver07.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver08.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver09.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver10.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver11.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver12.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver13.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver14.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/FailOver15.java                                                                             Passed. Compilation failed as expected
+tools/javac/failover/PostAttrConstructor.java                                                                    Passed. Execution successful
+tools/javac/falseCycle/FalseCycle.java                                                                           Passed. Compilation successful
+tools/javac/fatalErrors/NoJavaLangTest.java                                                                      Passed. Execution successful
+tools/javac/file/ExplodedImage.java                                                                              Passed. Execution successful
+tools/javac/file/FSInfoTest.java                                                                                 Passed. Execution successful
+tools/javac/file/LimitedImage.java                                                                               Passed. Execution successful
+tools/javac/file/ModuleAndPackageLocations.java                                                                  Passed. Execution successful
+tools/javac/file/MultiReleaseJar/MultiReleaseJarAwareSJFM.java                                                   Passed. Execution successful
+tools/javac/file/MultiReleaseJar/MultiReleaseJarTest.java                                                        Passed. Execution successful
+tools/javac/file/MultiReleaseJar/MutliReleaseModuleInfoTest.java                                                 Passed. Execution successful
+tools/javac/file/SetLocationForModule.java                                                                       Passed. Execution successful
+tools/javac/file/SymLinkArchiveTest.java                                                                         Passed. Execution successful
+tools/javac/file/SymLinkShortNameTest.java                                                                       Passed. Execution successful
+tools/javac/file/SymLinkTest.java                                                                                Passed. Execution successful
+tools/javac/file/T7018098.java                                                                                   Passed. Execution successful
+tools/javac/file/T7068437.java                                                                                   Passed. Execution successful
+tools/javac/file/T7068451.java                                                                                   Passed. Execution successful
+tools/javac/file/T8132857.java                                                                                   Passed. Execution successful
+tools/javac/file/T8143268.java                                                                                   Passed. Execution successful
+tools/javac/file/T8150475.java                                                                                   Passed. Compilation successful
+tools/javac/file/zip/T6836682.java                                                                               Passed. Execution successful
+tools/javac/file/zip/T6865530.java                                                                               Passed. Execution successful
+tools/javac/file/zip/T8076104.java                                                                               Passed. Execution successful
+tools/javac/flags/FlagsTest.java                                                                                 Passed. Execution successful
+tools/javac/flow/LVTHarness.java                                                                                 Passed. Execution successful
+tools/javac/flow/T8030218/CompileTimeErrorForNonAssignedStaticFieldTest.java                                     Passed. Compilation failed as expected
+tools/javac/flow/T8042741/LambdaArgumentsTest.java                                                               Passed. Compilation successful
+tools/javac/flow/T8042741/PositionTest.java                                                                      Passed. Compilation successful
+tools/javac/flow/T8062747.java                                                                                   Passed. Compilation successful
+tools/javac/foreach/7139681/T7139681neg.java                                                                     Passed. Compilation failed as expected
+tools/javac/foreach/7139681/T7139681pos.java                                                                     Passed. Compilation successful
+tools/javac/foreach/Foreach.java                                                                                 Passed. Execution successful
+tools/javac/foreach/GenericIterator.java                                                                         Passed. Compilation successful
+tools/javac/foreach/IntersectIterator.java                                                                       Passed. Execution successful
+tools/javac/foreach/ListOfListTest.java                                                                          Passed. Execution successful
+tools/javac/foreach/SpecIterable.java                                                                            Passed. Execution successful
+tools/javac/foreach/StaticBlock.java                                                                             Passed. Compilation successful
+tools/javac/foreach/SuperfluousAbstract.java                                                                     Passed. Execution successful
+tools/javac/foreach/T6500701.java                                                                                Passed. Execution successful
+tools/javac/generics/4453032/InterfaceCast1.java                                                                 Passed. Compilation successful
+tools/javac/generics/5009937/T5009937.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/5066774/T5066774.java                                                                       Passed. Compilation successful
+tools/javac/generics/5086027/T5086027.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/5086027/T5086027pos.java                                                                    Passed. Compilation successful
+tools/javac/generics/6182950/T6182950a.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6182950/T6182950b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6182950/T6182950c.java                                                                      Passed. Compilation successful
+tools/javac/generics/6192945/Method.java                                                                         Passed. Compilation successful
+tools/javac/generics/6192945/T6192945.java                                                                       Passed. Compilation successful
+tools/javac/generics/6207386/T6207386.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/6207386/Test.java                                                                           Passed. Compilation successful
+tools/javac/generics/6213818/T6213818.java                                                                       Passed. Compilation successful
+tools/javac/generics/6218229/T6218229.java                                                                       Passed. Compilation successful
+tools/javac/generics/6227936/Orig.java                                                                           Passed. Compilation failed as expected
+tools/javac/generics/6227936/T6227936.java                                                                       Passed. Compilation successful
+tools/javac/generics/6245699/T6245699.java                                                                       Passed. Execution successful
+tools/javac/generics/6245699/T6245699a.java                                                                      Passed. Execution successful
+tools/javac/generics/6245699/T6245699b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6245699/T6245699c.java                                                                      Passed. Execution successful
+tools/javac/generics/6268476/T6268476.java                                                                       Passed. Compilation successful
+tools/javac/generics/6292765/T6292765.java                                                                       Passed. Compilation successful
+tools/javac/generics/6294779/T6294779a.java                                                                      Passed. Compilation successful
+tools/javac/generics/6294779/T6294779b.java                                                                      Passed. Compilation successful
+tools/javac/generics/6294779/T6294779c.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6332204/T6332204.java                                                                       Passed. Compilation successful
+tools/javac/generics/6332204/T6346876.java                                                                       Passed. Compilation successful
+tools/javac/generics/6356636/T6356636.java                                                                       Passed. Compilation successful
+tools/javac/generics/6359951/T6359951.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/6372782/T6372782.java                                                                       Passed. Compilation successful
+tools/javac/generics/6413682/T6413682.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/6413682/TestPos.java                                                                        Passed. Execution successful
+tools/javac/generics/6476118/T6476118a.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6476118/T6476118b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6476118/T6476118c.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6476118/T6476118d.java                                                                      Passed. Compilation successful
+tools/javac/generics/6487370/T6487370.java                                                                       Passed. Execution successful
+tools/javac/generics/6495506/T6495506.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/6531075/T6531075.java                                                                       Passed. Execution successful
+tools/javac/generics/6531090/T6531090a.java                                                                      Passed. Execution successful
+tools/javac/generics/6531090/T6531090b.java                                                                      Passed. Execution successful
+tools/javac/generics/6677785/T6677785.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/6711619/T6711619a.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6711619/T6711619b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6723444/T6723444.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/6729401/T6729401.java                                                                       Passed. Compilation successful
+tools/javac/generics/6910550/T6910550a.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6910550/T6910550b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6910550/T6910550c.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6910550/T6910550d.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6910550/T6910550e.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6946618/T6946618a.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6946618/T6946618b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6946618/T6946618c.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6956758/T6956758neg.java                                                                    Passed. Compilation failed as expected
+tools/javac/generics/6956758/T6956758pos.java                                                                    Passed. Compilation successful
+tools/javac/generics/6969184/T6969184.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719a.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719c.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719d.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719e.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719f.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719g.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6985719/T6985719h.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/6987475/T6987475neg.java                                                                    Passed. Compilation failed as expected
+tools/javac/generics/6987475/T6987475pos.java                                                                    Passed. Compilation successful
+tools/javac/generics/7007615/T7007615.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/7007615/acc1/AccessibilityCheck01.java                                                      Passed. Compilation successful
+tools/javac/generics/7007615/acc2/AccessibilityCheck02.java                                                      Passed. Compilation failed as expected
+tools/javac/generics/7015430/T7015430.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/7020657/T7020657neg.java                                                                    Passed. Compilation failed as expected
+tools/javac/generics/7020657/T7020657pos.java                                                                    Passed. Compilation successful
+tools/javac/generics/7022054/T7022054neg1.java                                                                   Passed. Compilation failed as expected
+tools/javac/generics/7022054/T7022054neg2.java                                                                   Passed. Compilation failed as expected
+tools/javac/generics/7022054/T7022054pos1.java                                                                   Passed. Compilation failed as expected
+tools/javac/generics/7022054/T7022054pos2.java                                                                   Passed. Compilation failed as expected
+tools/javac/generics/7034019/T7034019a.java                                                                      Passed. Compilation successful
+tools/javac/generics/7034019/T7034019b.java                                                                      Passed. Compilation successful
+tools/javac/generics/7034019/T7034019c.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/7034019/T7034019d.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/7034511/T7034511a.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/7034511/T7034511b.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/7034511/T7041019.java                                                                       Passed. Compilation successful
+tools/javac/generics/7151070/T7151070.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/7151802/T7151802.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/8004094/T8004094.java                                                                       Passed. Compilation successful
+tools/javac/generics/8016640/T8016640.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/8064803/T8064803.java                                                                       Passed. Execution successful
+tools/javac/generics/ArrayClone.java                                                                             Passed. Execution successful
+tools/javac/generics/ArrayTypearg.java                                                                           Passed. Compilation successful
+tools/javac/generics/BridgeClash.java                                                                            Passed. Compilation successful
+tools/javac/generics/BridgeOrder.java                                                                            Passed. Execution successful
+tools/javac/generics/CastCrash.java                                                                              Passed. Compilation failed as expected
+tools/javac/generics/Casting.java                                                                                Passed. Compilation successful
+tools/javac/generics/Casting2.java                                                                               Passed. Compilation successful
+tools/javac/generics/Casting3.java                                                                               Passed. Compilation successful
+tools/javac/generics/Casting4.java                                                                               Passed. Compilation successful
+tools/javac/generics/Casting5.java                                                                               Passed. Compilation successful
+tools/javac/generics/CatchTyparam.java                                                                           Passed. Compilation failed as expected
+tools/javac/generics/CheckNoDuplicateErrors.java                                                                 Passed. Compilation failed as expected
+tools/javac/generics/ClassBoundCheckingOverflow.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/Conditional.java                                                                            Passed. Compilation successful
+tools/javac/generics/Covar2.java                                                                                 Passed. Execution successful
+tools/javac/generics/Covar3.java                                                                                 Passed. Compilation failed as expected
+tools/javac/generics/Covar4.java                                                                                 Passed. Compilation failed as expected
+tools/javac/generics/Crash01.java                                                                                Passed. Compilation successful
+tools/javac/generics/Crash02.java                                                                                Passed. Compilation successful
+tools/javac/generics/CyclicInheritance3.java                                                                     Passed. Compilation successful
+tools/javac/generics/CyclicInheritance5.java                                                                     Passed. Compilation successful
+tools/javac/generics/ErasureClashCrash.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/ExtendedRaw1.java                                                                           Passed. Compilation successful
+tools/javac/generics/ExtendedRaw2.java                                                                           Passed. Compilation successful
+tools/javac/generics/ExtendedRaw3.java                                                                           Passed. Compilation successful
+tools/javac/generics/ExtendedRaw4.java                                                                           Passed. Compilation successful
+tools/javac/generics/FinalBridge.java                                                                            Passed. Execution successful
+tools/javac/generics/GenLit1.java                                                                                Passed. Compilation failed as expected
+tools/javac/generics/GenLit2.java                                                                                Passed. Compilation failed as expected
+tools/javac/generics/GenericAnonCtor.java                                                                        Passed. Execution successful
+tools/javac/generics/GenericMerge.java                                                                           Passed. Compilation successful
+tools/javac/generics/GenericOverride.java                                                                        Passed. Compilation successful
+tools/javac/generics/GenericThrowable.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/GetClass.java                                                                               Passed. Compilation failed as expected
+tools/javac/generics/GetClass2.java                                                                              Passed. Execution successful
+tools/javac/generics/InheritanceConflict.java                                                                    Passed. Compilation failed as expected
+tools/javac/generics/InheritanceConflict2.java                                                                   Passed. Compilation successful
+tools/javac/generics/InheritanceConflict3.java                                                                   Passed. Compilation failed as expected
+tools/javac/generics/InnerInterface1.java                                                                        Passed. Compilation successful
+tools/javac/generics/InnerInterface2.java                                                                        Passed. Compilation successful
+tools/javac/generics/InstanceOf1.java                                                                            Passed. Compilation successful
+tools/javac/generics/InstanceOf2.java                                                                            Passed. Compilation failed as expected
+tools/javac/generics/InstanceOf3.java                                                                            Passed. Compilation failed as expected
+tools/javac/generics/LoadOrder.java                                                                              Passed. Compilation successful
+tools/javac/generics/LowerBoundBottomTypeTest.java                                                               Passed. Compilation successful
+tools/javac/generics/MissingBridge.java                                                                          Passed. Execution successful
+tools/javac/generics/MissingCast.java                                                                            Passed. Execution successful
+tools/javac/generics/MissingCast2.java                                                                           Passed. Execution successful
+tools/javac/generics/Multibound1.java                                                                            Passed. Compilation failed as expected
+tools/javac/generics/MultipleInheritance.java                                                                    Passed. Compilation successful
+tools/javac/generics/NameOrder.java                                                                              Passed. Compilation successful
+tools/javac/generics/Nonlinear.java                                                                              Passed. Compilation failed as expected
+tools/javac/generics/ParametricException.java                                                                    Passed. Compilation successful
+tools/javac/generics/ParenVerify.java                                                                            Passed. Execution successful
+tools/javac/generics/PermuteBound.java                                                                           Passed. Compilation successful
+tools/javac/generics/PrimitiveClass.java                                                                         Passed. Compilation successful
+tools/javac/generics/PrimitiveVariant.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/RawClient.java                                                                              Passed. Compilation successful
+tools/javac/generics/RefEqual.java                                                                               Passed. Compilation failed as expected
+tools/javac/generics/RelaxedArrays.java                                                                          Passed. Execution successful
+tools/javac/generics/ReverseOrder.java                                                                           Passed. Compilation successful
+tools/javac/generics/SelfImplement.java                                                                          Passed. Compilation failed as expected
+tools/javac/generics/SilentUnchecked.java                                                                        Passed. Compilation successful
+tools/javac/generics/SuperTypeargs.java                                                                          Passed. Compilation successful
+tools/javac/generics/T4683314.java                                                                               Passed. Compilation successful
+tools/javac/generics/T4684378.java                                                                               Passed. Execution successful
+tools/javac/generics/T4695348.java                                                                               Passed. Compilation failed as expected
+tools/javac/generics/T4695415.java                                                                               Passed. Compilation successful
+tools/javac/generics/T4695847.java                                                                               Passed. Compilation successful
+tools/javac/generics/T4711570.java                                                                               Passed. Compilation successful
+tools/javac/generics/T4711572.java                                                                               Passed. Compilation successful
+tools/javac/generics/T4711694.java                                                                               Passed. Execution successful
+tools/javac/generics/T4738171.java                                                                               Passed. Compilation failed as expected
+tools/javac/generics/T4739399.java                                                                               Passed. Compilation failed as expected
+tools/javac/generics/T4757416.java                                                                               Passed. Compilation failed as expected
+tools/javac/generics/T4784207a.java                                                                              Passed. Compilation successful
+tools/javac/generics/T4784219.java                                                                               Passed. Compilation successful
+tools/javac/generics/T5011073.java                                                                               Passed. Compilation failed as expected
+tools/javac/generics/T5094318.java                                                                               Passed. Execution failed as expected
+tools/javac/generics/T6391995.java                                                                               Passed. Compilation successful
+tools/javac/generics/T6481655.java                                                                               Passed. Execution successful
+tools/javac/generics/T6507024.java                                                                               Passed. Compilation successful
+tools/javac/generics/T6557954.java                                                                               Passed. Compilation successful
+tools/javac/generics/T6657499.java                                                                               Passed. Execution successful
+tools/javac/generics/T6660289.java                                                                               Passed. Compilation successful
+tools/javac/generics/T6751514.java                                                                               Passed. Execution successful
+tools/javac/generics/T6869075.java                                                                               Passed. Execution successful
+tools/javac/generics/TyparamLit.java                                                                             Passed. Compilation failed as expected
+tools/javac/generics/TyparamStaticScope.java                                                                     Passed. Compilation successful
+tools/javac/generics/TyparamStaticScope2.java                                                                    Passed. Compilation failed as expected
+tools/javac/generics/UncheckedArray.java                                                                         Passed. Compilation failed as expected
+tools/javac/generics/UncheckedConstructor.java                                                                   Passed. Compilation failed as expected
+tools/javac/generics/UncheckedCovariance.java                                                                    Passed. Compilation failed as expected
+tools/javac/generics/UnsoundInference.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/Varargs.java                                                                                Passed. Compilation successful
+tools/javac/generics/Varargs2.java                                                                               Passed. Execution successful
+tools/javac/generics/WrongNew.java                                                                               Passed. Execution successful
+tools/javac/generics/abstract/T4717181c.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/bridge1/D.java                                                                              Passed. Execution successful
+tools/javac/generics/bridges/AnonymousSubtypeOfRawSupertype.java                                                 Passed. Execution successful
+tools/javac/generics/bridges/BridgeHarness.java                                                                  Passed. Execution successful
+tools/javac/generics/bridges/ReorderedBoundsTest.java                                                            Passed. Execution successful
+tools/javac/generics/bridges/VerifyNoBridgeLoopTest.java                                                         Passed. Execution successful
+tools/javac/generics/classreader/HArrayMethod.java                                                               Passed. Compilation successful
+tools/javac/generics/diamond/6939780/T6939780.java                                                               Passed. Compilation successful
+tools/javac/generics/diamond/6996914/T6996914a.java                                                              Passed. Execution successful
+tools/javac/generics/diamond/6996914/T6996914b.java                                                              Passed. Compilation successful
+tools/javac/generics/diamond/7002837/T7002837.java                                                               Passed. Compilation successful
+tools/javac/generics/diamond/7030150/GenericConstructorAndDiamondTest.java                                       Passed. Execution successful
+tools/javac/generics/diamond/7030687/ParserTest.java                                                             Passed. Execution successful
+tools/javac/generics/diamond/7030687/T7030687.java                                                               Passed. Compilation failed as expected
+tools/javac/generics/diamond/7046778/DiamondAndInnerClassTest.java                                               Passed. Execution successful
+tools/javac/generics/diamond/7057297/T7057297.java                                                               Passed. Compilation failed as expected
+tools/javac/generics/diamond/7188968/T7188968.java                                                               Passed. Compilation failed as expected
+tools/javac/generics/diamond/8065986/T8065986a.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/diamond/8065986/T8065986b.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/diamond/MultipleInferenceHooksTest.java                                                     Passed. Execution successful
+tools/javac/generics/diamond/T6951833.java                                                                       Passed. Compilation successful
+tools/javac/generics/diamond/T8041713/DiamondPlusUnexistingMethodRefCrashTest.java                               Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg01.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg02.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg03.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg04.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg05.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg06.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg07.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg08.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg09a.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg09b.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg09c.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg09d.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg10.java                                                                      Passed. Compilation successful
+tools/javac/generics/diamond/neg/Neg11.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg12.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg13.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg14.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg15.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg16.java                                                                      Passed. Compilation successful
+tools/javac/generics/diamond/neg/Neg17.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg18.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg19.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg20.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg21.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg22.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/Neg23.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/diamond/neg/T8078473.java                                                                   Passed. Compilation successful
+tools/javac/generics/diamond/neg/T8078473_2.java                                                                 Passed. Compilation successful
+tools/javac/generics/diamond/pos/NestedDiamondAllocationTest.java                                                Passed. Execution successful
+tools/javac/generics/diamond/pos/Pos01.java                                                                      Passed. Execution successful
+tools/javac/generics/diamond/pos/Pos02.java                                                                      Passed. Execution successful
+tools/javac/generics/diamond/pos/Pos03.java                                                                      Passed. Execution successful
+tools/javac/generics/diamond/pos/Pos04.java                                                                      Passed. Execution successful
+tools/javac/generics/diamond/pos/Pos05.java                                                                      Passed. Execution successful
+tools/javac/generics/diamond/pos/Pos06.java                                                                      Passed. Compilation successful
+tools/javac/generics/diamond/pos/Pos07.java                                                                      Passed. Compilation successful
+tools/javac/generics/diamond/pos/Pos08.java                                                                      Passed. Compilation successful
+tools/javac/generics/forwardSeparateBound/ForwardSeparateBound2.java                                             Passed. Compilation successful
+tools/javac/generics/genericAbstract/A.java                                                                      Passed. Compilation successful
+tools/javac/generics/inference/4941882/T4941882.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/4942040/T4942040.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/4954546/T4954546.java                                                             Passed. Execution successful
+tools/javac/generics/inference/4972073/T4972073.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/4972073/T4972073a.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/4972073/T4972073b.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/5003431/T5003431.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5021635/T5021635.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5021635/T6299211.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5034571/T5034571.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5042462/T5042462.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5044646/T5044646.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/5049523/T5049523.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5070671/T5070671.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5073060/GenericsAndPackages.java                                                  Passed. Compilation successful
+tools/javac/generics/inference/5073060/Neg.java                                                                  Passed. Compilation failed as expected
+tools/javac/generics/inference/5073060/T5073060.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5073060/T5073060a.java                                                            Passed. Execution successful
+tools/javac/generics/inference/5080917/T5080917.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/5081782/Neg.java                                                                  Passed. Compilation failed as expected
+tools/javac/generics/inference/5081782/Pos.java                                                                  Passed. Compilation successful
+tools/javac/generics/inference/6215213/T6215213.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6222762/T6222762.java                                                             Passed. Execution successful
+tools/javac/generics/inference/6240565/T6240565.java                                                             Passed. Execution successful
+tools/javac/generics/inference/6273455/T6273455.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6278587/T6278587.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6278587/T6278587Neg.java                                                          Passed. Compilation successful
+tools/javac/generics/inference/6302954/T6456971.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6302954/T6476073.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6302954/X.java                                                                    Passed. Compilation successful
+tools/javac/generics/inference/6315770/T6315770.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/6356673/T6365166.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6356673/Test.java                                                                 Passed. Compilation successful
+tools/javac/generics/inference/6359106/T6359106.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6365166/NewTest.java                                                              Passed. Compilation successful
+tools/javac/generics/inference/6369605/T6369605a.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6369605/T6369605b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6468384/T6468384.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6569789/T6569789.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6611449/T6611449.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/6638712/T6638712a.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/6638712/T6638712b.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/6638712/T6638712c.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/6638712/T6638712d.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/6638712/T6638712e.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/6650759/T6650759a.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759c.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759d.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759e.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759f.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759g.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759h.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759i.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759j.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759k.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759l.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6650759/T6650759m.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/6718364/T6718364.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/6838943/T6838943.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/6938454/T6938454a.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6938454/T6938454b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/6943278/T6943278.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/6995200/T6995200.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/7086586/T7086586.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/7086586/T7086586b.java                                                            Passed. Execution successful
+tools/javac/generics/inference/7086601/T7086601a.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/7086601/T7086601b.java                                                            Passed. Execution successful
+tools/javac/generics/inference/7154127/T7154127.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/7177306/T7177306a.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/7177306/T7177306b.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/7177306/T7177306c.java                                                            Passed. Execution successful
+tools/javac/generics/inference/7177306/T7177306d.java                                                            Passed. Execution successful
+tools/javac/generics/inference/7177306/T7177306e.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/8006692/T8006692.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8015505/T8015505.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8019824/T8019824.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/8020149/T8020149.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8043725/T8043725.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8043893/T8043893.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/8043926/T8043926.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8048838/T8048838.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8055963/T8055963.java                                                             Passed. Execution successful
+tools/javac/generics/inference/8058199/T8058199.java                                                             Passed. Execution successful
+tools/javac/generics/inference/8058511/T8058511a.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8058511/T8058511b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8058511/T8058511c.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8062977/T8062977.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/8067767/T8067767.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8077306/T8077306.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8078024/T8078024.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8130304/T8130304.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8141613/T8141613.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8147493/T8147493a.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8147493/T8147493b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8148213/T8148213.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/8152411/T8152411.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/8152832/T8152832.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8156954/T8156954.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8157149/T8157149a.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/8157149/T8157149b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8157149/T8157149c.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8158355/T8158355.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8159680/T8159680.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8164399/T8164399.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8164399/T8164399b.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/8168134/T8168134.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8170410/T8170410.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8174249/T8174249a.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8174249/T8174249b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8176534/T8176534.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/inference/8176534/TestUncheckedCalls.java                                                   Passed. Execution successful
+tools/javac/generics/inference/8177097/T8177097a.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8177097/T8177097b.java                                                            Passed. Compilation successful
+tools/javac/generics/inference/8178150/T8178150.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/8178427/T8178427.java                                                             Passed. Compilation successful
+tools/javac/generics/inference/CaptureGLB1.java                                                                  Passed. Compilation successful
+tools/javac/generics/inference/CaptureGLB2.java                                                                  Passed. Compilation successful
+tools/javac/generics/inference/CaptureInDeclaredBound.java                                                       Passed. Compilation successful
+tools/javac/generics/inference/CaptureLowerBound.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/inference/CaptureLowerBoundArray.java                                                       Passed. Compilation successful
+tools/javac/generics/inference/CaptureLowerBoundAssign.java                                                      Passed. Compilation successful
+tools/javac/generics/inference/CaptureLowerBoundDeref.java                                                       Passed. Compilation successful
+tools/javac/generics/inference/CaptureLowerBoundNeg.java                                                         Passed. Compilation successful
+tools/javac/generics/inference/CaptureUpperBoundDeref.java                                                       Passed. Compilation successful
+tools/javac/generics/inference/CheckNoTimeoutException.java                                                      Passed. Compilation successful
+tools/javac/generics/inference/EagerReturnTypeResolution/EagerReturnTypeResolutionTesta.java                     Passed. Compilation successful
+tools/javac/generics/inference/EagerReturnTypeResolution/EagerReturnTypeResolutionTestb.java                     Passed. Compilation failed as expected
+tools/javac/generics/inference/EagerReturnTypeResolution/PrimitiveTypeBoxingTest.java                            Passed. Compilation failed as expected
+tools/javac/generics/inference/IntersectThrownTypesTest.java                                                     Passed. Compilation failed as expected
+tools/javac/generics/inference/LowerBoundGLB.java                                                                Passed. Compilation successful
+tools/javac/generics/inference/NestedCapture.java                                                                Passed. Compilation successful
+tools/javac/generics/inference/NestedWildcards.java                                                              Passed. Compilation successful
+tools/javac/generics/inference/T6835428.java                                                                     Passed. Compilation successful
+tools/javac/generics/inference/T7015715.java                                                                     Passed. Compilation successful
+tools/javac/generics/inference/T8028503/PrimitiveTypeInBoundForMethodRefTest.java                                Passed. Compilation successful
+tools/javac/generics/inference/T8044546/CrashImplicitLambdaTest.java                                             Passed. Compilation successful
+tools/javac/generics/inference/T8044546/NestedInvocationsTest.java                                               Passed. Compilation successful
+tools/javac/generics/neg/OrderedIntersections.java                                                               Passed. Compilation failed as expected
+tools/javac/generics/odersky/BadTest.java                                                                        Passed. Compilation failed as expected
+tools/javac/generics/odersky/BadTest2.java                                                                       Passed. Compilation successful
+tools/javac/generics/odersky/BadTest3.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/odersky/BadTest4.java                                                                       Passed. Compilation successful
+tools/javac/generics/odersky/Test.java                                                                           Passed. Compilation successful
+tools/javac/generics/odersky/Test2.java                                                                          Passed. Compilation successful
+tools/javac/generics/odersky/Test3.java                                                                          Passed. Compilation successful
+tools/javac/generics/odersky/Test4.java                                                                          Passed. Compilation successful
+tools/javac/generics/parametricException/J.java                                                                  Passed. Compilation successful
+tools/javac/generics/rare/6665356/T6665356.java                                                                  Passed. Compilation failed as expected
+tools/javac/generics/rare/Rare1.java                                                                             Passed. Compilation successful
+tools/javac/generics/rare/Rare10.java                                                                            Passed. Compilation successful
+tools/javac/generics/rare/Rare11.java                                                                            Passed. Compilation successful
+tools/javac/generics/rare/Rare2.java                                                                             Passed. Compilation failed as expected
+tools/javac/generics/rare/Rare3.java                                                                             Passed. Compilation failed as expected
+tools/javac/generics/rare/Rare4.java                                                                             Passed. Compilation failed as expected
+tools/javac/generics/rare/Rare5.java                                                                             Passed. Compilation failed as expected
+tools/javac/generics/rare/Rare6.java                                                                             Passed. Compilation failed as expected
+tools/javac/generics/rare/Rare7.java                                                                             Passed. Compilation failed as expected
+tools/javac/generics/rare/Rare8.java                                                                             Passed. Compilation successful
+tools/javac/generics/rare/Rare9.java                                                                             Passed. Compilation successful
+tools/javac/generics/rawOverride/7062745/GenericOverrideTest.java                                                Passed. Execution successful
+tools/javac/generics/rawOverride/7062745/T7062745neg.java                                                        Passed. Compilation failed as expected
+tools/javac/generics/rawOverride/7062745/T7062745pos.java                                                        Passed. Compilation successful
+tools/javac/generics/rawOverride/7157798/Test1.java                                                              Passed. Compilation successful
+tools/javac/generics/rawOverride/7157798/Test2.java                                                              Passed. Compilation successful
+tools/javac/generics/rawOverride/7157798/Test3.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/rawOverride/7157798/Test4.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/rawOverride/AttributeSet.java                                                               Passed. Compilation successful
+tools/javac/generics/rawOverride/Fail1.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/rawOverride/T6178365.java                                                                   Passed. Execution successful
+tools/javac/generics/rawOverride/T6846972.java                                                                   Passed. Compilation successful
+tools/javac/generics/rawOverride/T7148556.java                                                                   Passed. Compilation successful
+tools/javac/generics/rawOverride/T8008627.java                                                                   Passed. Compilation successful
+tools/javac/generics/rawOverride/Warn1.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/rawOverride/Warn2.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/rawSeparate/RetroLexer.java                                                                 Passed. Compilation successful
+tools/javac/generics/syntax/6318240/Bar.java                                                                     Passed. Compilation successful
+tools/javac/generics/syntax/6318240/BarNeg1.java                                                                 Passed. Compilation failed as expected
+tools/javac/generics/syntax/6318240/BarNeg1a.java                                                                Passed. Compilation failed as expected
+tools/javac/generics/syntax/6318240/BarNeg2.java                                                                 Passed. Compilation failed as expected
+tools/javac/generics/syntax/6318240/BarNeg2a.java                                                                Passed. Compilation failed as expected
+tools/javac/generics/syntax/6318240/Foo.java                                                                     Passed. Compilation successful
+tools/javac/generics/typeargs/Basic.java                                                                         Passed. Compilation successful
+tools/javac/generics/typeargs/Metharg1.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/typeargs/Metharg2.java                                                                      Passed. Compilation failed as expected
+tools/javac/generics/typeargs/Newarg1.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/typeargs/Newarg2.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/typeargs/Superarg1.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/typeargs/Superarg2.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/typeargs/ThisArg.java                                                                       Passed. Compilation failed as expected
+tools/javac/generics/typevars/4856983/T4856983.java                                                              Passed. Compilation successful
+tools/javac/generics/typevars/4856983/T4856983a.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/typevars/4856983/T4856983b.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/typevars/5060485/Compatibility.java                                                         Passed. Compilation failed as expected
+tools/javac/generics/typevars/5060485/Compatibility02.java                                                       Passed. Compilation failed as expected
+tools/javac/generics/typevars/5060485/Method.java                                                                Passed. Compilation successful
+tools/javac/generics/typevars/5060485/Neg1.java                                                                  Passed. Compilation failed as expected
+tools/javac/generics/typevars/5060485/Neg2.java                                                                  Passed. Compilation failed as expected
+tools/javac/generics/typevars/5060485/Pos.java                                                                   Passed. Compilation successful
+tools/javac/generics/typevars/5060485/T5060485.java                                                              Passed. Compilation successful
+tools/javac/generics/typevars/5061359/T5061359.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/typevars/5061359/T5061359a.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/typevars/5061359/T5061359b.java                                                             Passed. Compilation successful
+tools/javac/generics/typevars/6182630/T6182630.java                                                              Passed. Compilation successful
+tools/javac/generics/typevars/6199146/T6199146.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/typevars/6486430/T6486430.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/typevars/6486430/T6486430a.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/typevars/6569404/T6569404a.java                                                             Passed. Execution successful
+tools/javac/generics/typevars/6569404/T6569404b.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/typevars/6569404/T6569404c.java                                                             Passed. Execution successful
+tools/javac/generics/typevars/6680106/T6680106.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/typevars/6804733/T6804733.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/typevars/6968793/T6968793.java                                                              Passed. Compilation failed as expected
+tools/javac/generics/typevars/8129214/T8129214.java                                                              Passed. Compilation successful
+tools/javac/generics/typevars/AnnoTypeVarBounds.java                                                             Passed. Compilation successful
+tools/javac/generics/typevars/IntersectionSubVar.java                                                            Passed. Compilation successful
+tools/javac/generics/typevars/T6880344.java                                                                      Passed. Compilation successful
+tools/javac/generics/typevars/T7040883.java                                                                      Passed. Compilation successful
+tools/javac/generics/typevars/T7148242.java                                                                      Passed. Compilation successful
+tools/javac/generics/wildcards/6320612/T6320612.java                                                             Passed. Compilation successful
+tools/javac/generics/wildcards/6330931/T6330931.java                                                             Passed. Compilation successful
+tools/javac/generics/wildcards/6437894/T6437894.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/wildcards/6651719/T6651719a.java                                                            Passed. Compilation successful
+tools/javac/generics/wildcards/6762569/T6762569a.java                                                            Passed. Compilation successful
+tools/javac/generics/wildcards/6762569/T6762569b.java                                                            Passed. Compilation failed as expected
+tools/javac/generics/wildcards/6886247/T6886247_1.java                                                           Passed. Compilation successful
+tools/javac/generics/wildcards/6886247/T6886247_2.java                                                           Passed. Compilation failed as expected
+tools/javac/generics/wildcards/7034495/T7034495.java                                                             Passed. Compilation failed as expected
+tools/javac/generics/wildcards/AssignmentDifferentTypes.java                                                     Passed. Compilation failed as expected
+tools/javac/generics/wildcards/AssignmentSameType.java                                                           Passed. Compilation failed as expected
+tools/javac/generics/wildcards/BoundBug.java                                                                     Passed. Compilation successful
+tools/javac/generics/wildcards/ContraArg.java                                                                    Passed. Compilation successful
+tools/javac/generics/wildcards/RefQueueBug.java                                                                  Passed. Compilation successful
+tools/javac/generics/wildcards/SubtypeCaptureLeak.java                                                           Passed. Compilation successful
+tools/javac/generics/wildcards/T5097548.java                                                                     Passed. Execution successful
+tools/javac/generics/wildcards/T5097548b.java                                                                    Passed. Compilation successful
+tools/javac/generics/wildcards/T6450290.java                                                                     Passed. Compilation failed as expected
+tools/javac/generics/wildcards/T6732484.java                                                                     Passed. Compilation successful
+tools/javac/generics/wildcards/T8015101.java                                                                     Passed. Compilation successful
+tools/javac/generics/wildcards/T8034147.java                                                                     Passed. Compilation successful
+tools/javac/generics/wildcards/UnboundArray.java                                                                 Passed. Compilation successful
+tools/javac/generics/wildcards/neg/AmbiguousCast.java                                                            Passed. Compilation successful
+tools/javac/generics/wildcards/neg/Capture.java                                                                  Passed. Compilation failed as expected
+tools/javac/generics/wildcards/neg/CastFail.java                                                                 Passed. Compilation failed as expected
+tools/javac/generics/wildcards/neg/CastTest.java                                                                 Passed. Compilation successful
+tools/javac/generics/wildcards/neg/CastWarn.java                                                                 Passed. Compilation successful
+tools/javac/generics/wildcards/neg/ParamCast.java                                                                Passed. Compilation failed as expected
+tools/javac/generics/wildcards/neg/Readonly.java                                                                 Passed. Compilation failed as expected
+tools/javac/generics/wildcards/neg/Unbounded.java                                                                Passed. Compilation failed as expected
+tools/javac/generics/wildcards/pos/AmbiguousCast2.java                                                           Passed. Compilation successful
+tools/javac/generics/wildcards/pos/BoundsCollision.java                                                          Passed. Compilation successful
+tools/javac/generics/wildcards/pos/Capture.java                                                                  Passed. Compilation successful
+tools/javac/generics/wildcards/pos/CastTest.java                                                                 Passed. Compilation successful
+tools/javac/generics/wildcards/pos/InstanceOf.java                                                               Passed. Compilation successful
+tools/javac/generics/wildcards/pos/ParamCast.java                                                                Passed. Compilation successful
+tools/javac/generics/wildcards/pos/RvalConversion.java                                                           Passed. Compilation successful
+tools/javac/generics/wildcards/pos/UncheckedCast1.java                                                           Passed. Compilation successful
+tools/javac/implicitCompile/SkipAttrFlowGenForImplicits.java                                                     Passed. Compilation successful
+tools/javac/implicitThis/6541876/T6541876a.java                                                                  Passed. Execution successful
+tools/javac/implicitThis/6541876/T6541876b.java                                                                  Passed. Execution successful
+tools/javac/implicitThis/NewBeforeOuterConstructed.java                                                          Passed. Compilation failed as expected
+tools/javac/implicitThis/NewBeforeOuterConstructed2.java                                                         Passed. Compilation failed as expected
+tools/javac/implicitThis/NewBeforeOuterConstructed3.java                                                         Passed. Execution successful
+tools/javac/implicitThis/WhichImplicitThis1.java                                                                 Passed. Execution successful
+tools/javac/implicitThis/WhichImplicitThis10.java                                                                Passed. Compilation successful
+tools/javac/implicitThis/WhichImplicitThis11.java                                                                Passed. Execution successful
+tools/javac/implicitThis/WhichImplicitThis2.java                                                                 Passed. Execution successful
+tools/javac/implicitThis/WhichImplicitThis3.java                                                                 Passed. Execution successful
+tools/javac/implicitThis/WhichImplicitThis4.java                                                                 Passed. Execution successful
+tools/javac/implicitThis/WhichImplicitThis5.java                                                                 Passed. Execution successful
+tools/javac/implicitThis/WhichImplicitThis6.java                                                                 Passed. Compilation successful
+tools/javac/implicitThis/WhichImplicitThis7.java                                                                 Passed. Compilation successful
+tools/javac/implicitThis/WhichImplicitThis9.java                                                                 Passed. Execution successful
+tools/javac/importChecks/ImportCanonical1.java                                                                   Passed. Compilation failed as expected
+tools/javac/importChecks/ImportCanonicalSameName/ImportCanonicalSameName.java                                    Passed. Compilation failed as expected
+tools/javac/importChecks/ImportIsFullyQualified.java                                                             Passed. Compilation failed as expected
+tools/javac/importChecks/ImportOfOwnClass.java                                                                   Passed. Compilation successful
+tools/javac/importChecks/ImportsObservable.java                                                                  Passed. Compilation failed as expected
+tools/javac/importChecks/InvalidImportsNoClasses.java                                                            Passed. Compilation failed as expected
+tools/javac/importChecks/NoImportedNoClasses.java                                                                Passed. Compilation failed as expected
+tools/javac/importContext/anonPackage/Foo.java                                                                   Passed. Compilation successful
+tools/javac/importContext/namedPackage/Dummy.java                                                                Passed. Compilation successful
+tools/javac/importOnDemand/ImportOnDemandConflicts.java                                                          Passed. Compilation failed as expected
+tools/javac/importscope/A.java                                                                                   Passed. Compilation successful
+tools/javac/importscope/BadClassFileDuringImport.java                                                            Passed. Execution successful
+tools/javac/importscope/CompletionFailureDuringImport.java                                                       Passed. Execution successful
+tools/javac/importscope/ImportDependenciesTest.java                                                              Passed. Execution successful
+tools/javac/importscope/ImportInaccessible.java                                                                  Passed. Compilation failed as expected
+tools/javac/importscope/ImportMembersTest.java                                                                   Passed. Execution successful
+tools/javac/importscope/ImportResolvedTooSoon.java                                                               Passed. Compilation successful
+tools/javac/importscope/NegativeCyclicDependencyTest.java                                                        Passed. Execution successful
+tools/javac/importscope/T7101822A.java                                                                           Passed. Compilation successful
+tools/javac/importscope/T8075274/Outer.java                                                                      Passed. Compilation successful
+tools/javac/importscope/T8133235/A.java                                                                          Passed. Compilation successful
+tools/javac/importscope/T8148131/A.java                                                                          Passed. Compilation successful
+tools/javac/importscope/TestDeepFinishClassStack.java                                                            Passed. Execution successful
+tools/javac/importscope/TestDuplicateImport.java                                                                 Passed. Execution successful
+tools/javac/importscope/TestLazyImportScope.java                                                                 Passed. Execution successful
+tools/javac/importscope/TypeParamCycle.java                                                                      Passed. Compilation successful
+tools/javac/importscope/TypeParamCycle2.java                                                                     Passed. Compilation successful
+tools/javac/importscope/TypeParamCycle3.java                                                                     Passed. Compilation successful
+tools/javac/importscope/dependencies/DependenciesTest.java                                                       Passed. Execution successful
+tools/javac/incompatibleNoninherited/A.java                                                                      Passed. Compilation successful
+tools/javac/incompleteStatements/T8000484.java                                                                   Passed. Compilation failed as expected
+tools/javac/inheritAccess/PvtMbrsNotInherit1.java                                                                Passed. Execution successful
+tools/javac/inheritedAccess/MethodReferenceQualification_1.java                                                  Passed. Execution successful
+tools/javac/innerClassFile/InnerClassFileTest.java                                                               Passed. Execution successful
+tools/javac/javazip/JavaZipTest.java                                                                             Passed. Execution successful
+tools/javac/jvm/6397652/T6397652.java                                                                            Passed. Compilation successful
+tools/javac/jvm/ClassRefDupInConstantPoolTest.java                                                               Passed. Execution successful
+tools/javac/jvm/T7024096.java                                                                                    Passed. Execution successful
+tools/javac/jvm/T8020689.java                                                                                    Passed. Execution successful
+tools/javac/jvm/VerboseClassPathTest.java                                                                        Passed. Execution successful
+tools/javac/jvm/VerboseOutTest.java                                                                              Passed. Execution successful
+tools/javac/lambda/8012557/PrivateLambdas.java                                                                   Passed. Execution successful
+tools/javac/lambda/8016081/T8016081.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8016177/T8016177a.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8016177/T8016177b.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8016177/T8016177c.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8016177/T8016177d.java                                                                        Passed. Compilation successful
+tools/javac/lambda/8016177/T8016177e.java                                                                        Passed. Compilation successful
+tools/javac/lambda/8016177/T8016177f.java                                                                        Passed. Compilation successful
+tools/javac/lambda/8016177/T8016177g.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8016320/IllegalBridgeModifier.java                                                            Passed. Execution successful
+tools/javac/lambda/8019480/T8019480.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8020147/T8020147.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8020804/T8020804.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8020843/T8020843a.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8020843/T8020843b.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8021567/T8021567.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8021567/T8021567b.java                                                                        Passed. Execution successful
+tools/javac/lambda/8023389/T8023389.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8023549/T8023549.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8023558/T8023558a.java                                                                        Passed. Execution successful
+tools/javac/lambda/8023558/T8023558b.java                                                                        Passed. Execution successful
+tools/javac/lambda/8023558/T8023558c.java                                                                        Passed. Execution successful
+tools/javac/lambda/8024497/CrashUsingReturningThisRefLambdaFromDefaultMetTest.java                               Passed. Compilation successful
+tools/javac/lambda/8051958/T8051958.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8063054/T8063054a.java                                                                        Passed. Compilation successful
+tools/javac/lambda/8063054/T8063054b.java                                                                        Passed. Compilation successful
+tools/javac/lambda/8066974/T8066974.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8067792/T8067792.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8068399/T8068399.java                                                                         Passed. Execution successful
+tools/javac/lambda/8068430/T8068430.java                                                                         Passed. Execution successful
+tools/javac/lambda/8071432/T8071432.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8073842/T8073842.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8074381/T8074381a.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8074381/T8074381b.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8131742/T8131742.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8134329/T8134329.java                                                                         Passed. Execution successful
+tools/javac/lambda/8142876/T8142876.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8148128/T8148128.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8153884/T8153884.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8168480/T8168480.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8168480/T8168480b.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/8169091/T8169091.java                                                                         Passed. Compilation successful
+tools/javac/lambda/8188144/T8188144.java                                                                         Passed. Execution successful
+tools/javac/lambda/8202372/T8202372.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/8210495/T8210495.java                                                                         Passed. Compilation successful
+tools/javac/lambda/AvoidInfiniteReattribution.java                                                               Passed. Execution successful
+tools/javac/lambda/BadAccess.java                                                                                Passed. Compilation failed as expected
+tools/javac/lambda/BadAccess02.java                                                                              Passed. Compilation failed as expected
+tools/javac/lambda/BadAccess03.java                                                                              Passed. Compilation failed as expected
+tools/javac/lambda/BadBreakContinue.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/BadConv03.java                                                                                Passed. Compilation failed as expected
+tools/javac/lambda/BadConv04.java                                                                                Passed. Compilation failed as expected
+tools/javac/lambda/BadExpressionLambda.java                                                                      Passed. Compilation failed as expected
+tools/javac/lambda/BadLambdaExpr.java                                                                            Passed. Execution successful
+tools/javac/lambda/BadLambdaPos.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/BadMethodCall.java                                                                            Passed. Compilation failed as expected
+tools/javac/lambda/BadMethodCall2.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/BadNestedLambda.java                                                                          Passed. Compilation failed as expected
+tools/javac/lambda/BadRecovery.java                                                                              Passed. Compilation failed as expected
+tools/javac/lambda/BadReturn.java                                                                                Passed. Compilation failed as expected
+tools/javac/lambda/BadStatementInLambda.java                                                                     Passed. Compilation failed as expected
+tools/javac/lambda/BadStatementInLambda02.java                                                                   Passed. Compilation failed as expected
+tools/javac/lambda/BadSwitchExpressionLambda.java                                                                Passed. Compilation failed as expected
+tools/javac/lambda/BadTargetType.java                                                                            Passed. Compilation failed as expected
+tools/javac/lambda/ByteCodeTest.java                                                                             Passed. Execution successful
+tools/javac/lambda/Conditional01.java                                                                            Passed. Compilation successful
+tools/javac/lambda/Conditional02.java                                                                            Passed. Compilation successful
+tools/javac/lambda/Conditional03.java                                                                            Passed. Compilation successful
+tools/javac/lambda/Conformance01.java                                                                            Passed. Compilation successful
+tools/javac/lambda/Defender01.java                                                                               Passed. Compilation successful
+tools/javac/lambda/DisjunctiveTypeTest.java                                                                      Passed. Compilation successful
+tools/javac/lambda/DoubleStaticImport.java                                                                       Passed. Compilation successful
+tools/javac/lambda/EffectivelyFinal01.java                                                                       Passed. Compilation failed as expected
+tools/javac/lambda/EffectivelyFinalTest.java                                                                     Passed. Compilation failed as expected
+tools/javac/lambda/EffectivelyFinalThrows.java                                                                   Passed. Compilation successful
+tools/javac/lambda/ErroneousArg.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/ExceptionsInLambda.java                                                                       Passed. Compilation failed as expected
+tools/javac/lambda/FunctionalInterfaceAnno.java                                                                  Passed. Compilation failed as expected
+tools/javac/lambda/FunctionalInterfaceAnno02.java                                                                Passed. Compilation successful
+tools/javac/lambda/FunctionalInterfaceConversionTest.java                                                        Passed. Execution successful
+tools/javac/lambda/GenericMethodRefImplClass.java                                                                Passed. Execution successful
+tools/javac/lambda/IdentifierTest.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/ImplicitEnclosingInstanceTest.java                                                            Passed. Execution successful
+tools/javac/lambda/InnerConstructor.java                                                                         Passed. Execution successful
+tools/javac/lambda/InnerInstanceCreationTest.java                                                                Passed. Execution successful
+tools/javac/lambda/Intersection01.java                                                                           Passed. Compilation successful
+tools/javac/lambda/Intersection02.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/Intersection03.java                                                                           Passed. Execution successful
+tools/javac/lambda/LambdaCapture01.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaCapture02.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaCapture03.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaCapture04.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaCapture05.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaCapture06.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaCapture07.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaConv01.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv03.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv05.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv06.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv08.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv09.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaConv10.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaConv11.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv12.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv13.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv16.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv17.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv18.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaConv19.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv20.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv21.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaConv22.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv23.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv24.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv25.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaConv26.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv27.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaConv28.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaConv29.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaEffectivelyFinalTest.java                                                               Passed. Compilation failed as expected
+tools/javac/lambda/LambdaExpr01.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr02.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr04.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaExpr05.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaExpr06.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr07.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr08.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaExpr09.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaExpr10.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaExpr11.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr12.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr13.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaExpr14.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr15.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr16.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr17.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr18.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExpr19.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/LambdaExpr20.java                                                                             Passed. Compilation successful
+tools/javac/lambda/LambdaExpr21.java                                                                             Passed. Execution successful
+tools/javac/lambda/LambdaExprLeadsToMissingClassFilesTest.java                                                   Passed. Execution successful
+tools/javac/lambda/LambdaExprNotVoid.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/LambdaInSuperCallCapturingOuterThis.java                                                      Passed. Execution successful
+tools/javac/lambda/LambdaInSuperCallCapturingOuterThis2.java                                                     Passed. Execution successful
+tools/javac/lambda/LambdaInSuperCallCapturingOuterThis3.java                                                     Passed. Execution successful
+tools/javac/lambda/LambdaInnerTypeVarArgs.java                                                                   Passed. Execution successful
+tools/javac/lambda/LambdaInnerTypeVarArgsSerialize.java                                                          Passed. Execution successful
+tools/javac/lambda/LambdaInnerTypeVarReflect.java                                                                Passed. Execution successful
+tools/javac/lambda/LambdaInnerTypeVarSerialize.java                                                              Passed. Execution successful
+tools/javac/lambda/LambdaInterfaceStaticField.java                                                               Passed. Compilation successful
+tools/javac/lambda/LambdaLambdaSerialized.java                                                                   Passed. Execution successful
+tools/javac/lambda/LambdaLocalTest.java                                                                          Passed. Execution successful
+tools/javac/lambda/LambdaMultiCatchTest.java                                                                     Passed. Execution successful
+tools/javac/lambda/LambdaNoFuncIntfFlow.java                                                                     Passed. Compilation failed as expected
+tools/javac/lambda/LambdaOuterLocalTest.java                                                                     Passed. Execution successful
+tools/javac/lambda/LambdaParameterNeedsNoInitTest.java                                                           Passed. Compilation successful
+tools/javac/lambda/LambdaParenGeneric.java                                                                       Passed. Execution successful
+tools/javac/lambda/LambdaParenGenericOrig.java                                                                   Passed. Execution successful
+tools/javac/lambda/LambdaParserTest.java                                                                         Passed. Execution successful
+tools/javac/lambda/LambdaReturnUnboxing.java                                                                     Passed. Execution successful
+tools/javac/lambda/LambdaScope01.java                                                                            Passed. Execution successful
+tools/javac/lambda/LambdaScope02.java                                                                            Passed. Execution successful
+tools/javac/lambda/LambdaScope03.java                                                                            Passed. Execution successful
+tools/javac/lambda/LambdaScope04.java                                                                            Passed. Compilation failed as expected
+tools/javac/lambda/LambdaScope05.java                                                                            Passed. Compilation failed as expected
+tools/javac/lambda/LambdaTestStrictFP.java                                                                       Passed. Execution successful
+tools/javac/lambda/LambdaTestStrictFPFlag.java                                                                   Passed. Execution successful
+tools/javac/lambda/LambdaTestStrictFPMethod.java                                                                 Passed. Execution successful
+tools/javac/lambda/LambdaWithInterfaceSuper.java                                                                 Passed. Compilation successful
+tools/javac/lambda/LocalBreakAndContinue.java                                                                    Passed. Compilation successful
+tools/javac/lambda/LocalVariableTable.java                                                                       Passed. Execution successful
+tools/javac/lambda/MethodHandleInvokeTest.java                                                                   Passed. Execution successful
+tools/javac/lambda/MethodReference01.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference02.java                                                                        Passed. Compilation successful
+tools/javac/lambda/MethodReference03.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference04.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference05.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference06.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference07.java                                                                        Passed. Compilation successful
+tools/javac/lambda/MethodReference08.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference09.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference10.java                                                                        Passed. Compilation successful
+tools/javac/lambda/MethodReference11.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference12.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference13.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference14.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference15.java                                                                        Passed. Compilation successful
+tools/javac/lambda/MethodReference16.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference17.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference18.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference19.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference20.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference21.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference22.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference23.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference24.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference25.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference26.java                                                                        Passed. Compilation successful
+tools/javac/lambda/MethodReference27.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference28.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference29.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference30.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference31.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference32.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference33.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference34.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference35.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference36.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference37.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference38.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference39.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference40.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference41.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference42.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference43.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference44.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference45.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference46.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference47.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference48.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference49.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference50.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference51.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference52.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference53.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference54.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference55.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference56.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference57.java                                                                        Passed. Compilation successful
+tools/javac/lambda/MethodReference58.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference59.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference60.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference61.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference62.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference63.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference64.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference65.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference66.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference67.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference68.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference69.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference70.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference71.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference72.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference73.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/MethodReference74.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReference75.java                                                                        Passed. Execution successful
+tools/javac/lambda/MethodReferenceArrayClone.java                                                                Passed. Execution successful
+tools/javac/lambda/MethodReferenceGenericTarget.java                                                             Passed. Execution successful
+tools/javac/lambda/MethodReferenceNoThisTest.java                                                                Passed. Compilation failed as expected
+tools/javac/lambda/MethodReferenceParserTest.java                                                                Passed. Execution successful
+tools/javac/lambda/MethodReferenceStaticNotAccessibleTest.java                                                   Passed. Compilation successful
+tools/javac/lambda/MethodReferenceVarargsTest.java                                                               Passed. Compilation successful
+tools/javac/lambda/MostSpecific01.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific02.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific03.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific04.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific05.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific06.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific07.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific08.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific09.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific10.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific11.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific12.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific13.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific14.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific15.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific16.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific17.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific18.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific19.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific20.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific21.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific22.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific23.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific24.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific25.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific26.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific27.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific28.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific29.java                                                                           Passed. Execution successful
+tools/javac/lambda/MostSpecific30.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific31.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/MostSpecific32.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/NakedThis.java                                                                                Passed. Compilation successful
+tools/javac/lambda/NestedCapture01.java                                                                          Passed. Compilation successful
+tools/javac/lambda/NestedCapture02.java                                                                          Passed. Compilation successful
+tools/javac/lambda/NestedCapture03.java                                                                          Passed. Compilation successful
+tools/javac/lambda/NestedCapture04.java                                                                          Passed. Execution successful
+tools/javac/lambda/NoTargetLambda.java                                                                           Passed. Compilation failed as expected
+tools/javac/lambda/NoWarnOnImplicitParams.java                                                                   Passed. Compilation failed as expected
+tools/javac/lambda/SE5AnnotationsOnLambdaParameters.java                                                         Passed. Execution successful
+tools/javac/lambda/SerializedLambdaInInit.java                                                                   Passed. Execution successful
+tools/javac/lambda/SingleLocalTest.java                                                                          Passed. Execution successful
+tools/javac/lambda/SourceLevelTest.java                                                                          Passed. Compilation failed as expected
+tools/javac/lambda/StaticMethodNegTest.java                                                                      Passed. Compilation failed as expected
+tools/javac/lambda/T8024947/PotentiallyAmbiguousWarningTest.java                                                 Passed. Compilation failed as expected
+tools/javac/lambda/T8025290/ExplicitVSImplicitLambdaTest.java                                                    Passed. Compilation successful
+tools/javac/lambda/T8025816/CrashMethodReferenceWithSiteTypeVarTest.java                                         Passed. Compilation successful
+tools/javac/lambda/T8031967.java                                                                                 Passed. Execution successful
+tools/javac/lambda/T8033483/IgnoreLambdaBodyDuringResolutionTest1.java                                           Passed. Compilation failed as expected
+tools/javac/lambda/T8033483/IgnoreLambdaBodyDuringResolutionTest2.java                                           Passed. Compilation failed as expected
+tools/javac/lambda/T8037935/LambdaWithBinOpConstRefToConstString.java                                            Passed. Execution successful
+tools/javac/lambda/T8038182/CrashFunctionDescriptorExceptionTest.java                                            Passed. Compilation failed as expected
+tools/javac/lambda/T8038420/LambdaIncrement.java                                                                 Passed. Execution successful
+tools/javac/lambda/T8041704/ErrorMessageTest.java                                                                Passed. Compilation failed as expected
+tools/javac/lambda/T8042759/ImplicitLambdaConsideredForApplicabilityTest.java                                    Passed. Compilation failed as expected
+tools/javac/lambda/T8056014.java                                                                                 Passed. Execution successful
+tools/javac/lambda/T8056984.java                                                                                 Passed. Compilation successful
+tools/javac/lambda/T8057794.java                                                                                 Passed. Compilation failed as expected
+tools/javac/lambda/T8057800/NPEMethodReferenceAndGenericsTest.java                                               Passed. Compilation successful
+tools/javac/lambda/T8077605.java                                                                                 Passed. Compilation successful
+tools/javac/lambda/T8129740/AllowEnclosingVarCaptureTest.java                                                    Passed. Execution successful
+tools/javac/lambda/T8129740/CaptureInCtorChainingTest.java                                                       Passed. Execution successful
+tools/javac/lambda/T8129740/QualifiedThisAccessTest.java                                                         Passed. Execution successful
+tools/javac/lambda/T8129740/SourceToSourceTranslationTest.java                                                   Passed. Execution successful
+tools/javac/lambda/T8145051.java                                                                                 Passed. Execution successful
+tools/javac/lambda/T8175317.java                                                                                 Passed. Compilation failed as expected
+tools/javac/lambda/T8195598.java                                                                                 Passed. Compilation successful
+tools/javac/lambda/T8209407/VerifierErrorInnerPlusLambda.java                                                    Passed. Execution successful
+tools/javac/lambda/T8213703/InvalidReceiverTypeTest.java                                                         Passed. Execution successful
+tools/javac/lambda/TargetType01.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType02.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType03.java                                                                             Passed. Execution successful
+tools/javac/lambda/TargetType04.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType05.java                                                                             Passed. Execution successful
+tools/javac/lambda/TargetType06.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType07.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType08.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType10.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType11.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType12.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType13.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType14.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType15.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType16.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType17.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType18.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType19.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType20.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType21.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType22.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType23.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType24.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType25.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType26.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType27.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType28.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType29.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType30.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType31.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType32.java                                                                             Passed. Execution successful
+tools/javac/lambda/TargetType33.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType34.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType35.java                                                                             Passed. Execution successful
+tools/javac/lambda/TargetType36.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType37.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType38.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType39.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType40.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType41.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType42.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType43.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType44.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType45.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType46.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType47.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType48.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType49.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType50.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType51.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType52.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType53.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType54.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType55.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType56.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType57.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType58.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType59.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType60.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType61.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType62.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType63.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType64.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType65.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType66.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType67.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType68.java                                                                             Passed. Compilation failed as expected
+tools/javac/lambda/TargetType69.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType70.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType71.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType72.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType73.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType74.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType75.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TargetType76.java                                                                             Passed. Compilation successful
+tools/javac/lambda/TestBootstrapMethodsCount.java                                                                Passed. Execution successful
+tools/javac/lambda/TestInvokeDynamic.java                                                                        Passed. Execution successful
+tools/javac/lambda/TestLambdaToMethodStats.java                                                                  Passed. Execution successful
+tools/javac/lambda/TestSelfRef.java                                                                              Passed. Execution successful
+tools/javac/lambda/UnderscoreAsIdent.java                                                                        Passed. Compilation failed as expected
+tools/javac/lambda/VoidCompatibility.java                                                                        Passed. Compilation successful
+tools/javac/lambda/VoidLambdaParameter.java                                                                      Passed. Compilation failed as expected
+tools/javac/lambda/XDdumpLambdaToMethodStats.java                                                                Passed. Compilation successful
+tools/javac/lambda/abort/Abort.java                                                                              Passed. Execution successful
+tools/javac/lambda/abort/CompletionFailure.java                                                                  Passed. Execution successful
+tools/javac/lambda/badMemberRefBytecode/TestBadMemberRefBytecode.java                                            Passed. Compilation successful
+tools/javac/lambda/bridge/TestMetafactoryBridges.java                                                            Passed. Execution successful
+tools/javac/lambda/bridge/template_tests/BridgeMethodTestCase.java                                               Passed. Execution successful
+tools/javac/lambda/bridge/template_tests/BridgeMethodsTemplateTest.java                                          Passed. Execution successful
+tools/javac/lambda/bytecode/TestLambdaBytecode.java                                                              Passed. Execution successful
+tools/javac/lambda/deduplication/ClassFieldDeduplication.java                                                    Passed. Execution successful
+tools/javac/lambda/deduplication/DeduplicationTest.java                                                          Passed. Execution successful
+tools/javac/lambda/funcInterfaces/LambdaTest1.java                                                               Passed. Execution successful
+tools/javac/lambda/funcInterfaces/LambdaTest1_neg1.java                                                          Passed. Compilation failed as expected
+tools/javac/lambda/funcInterfaces/LambdaTest1_neg2.java                                                          Passed. Compilation failed as expected
+tools/javac/lambda/funcInterfaces/LambdaTest1_neg3.java                                                          Passed. Compilation failed as expected
+tools/javac/lambda/funcInterfaces/LambdaTest2_SAM1.java                                                          Passed. Execution successful
+tools/javac/lambda/funcInterfaces/LambdaTest2_SAM2.java                                                          Passed. Execution successful
+tools/javac/lambda/funcInterfaces/LambdaTest2_SAM3.java                                                          Passed. Execution successful
+tools/javac/lambda/funcInterfaces/LambdaTest2_neg1.java                                                          Passed. Compilation failed as expected
+tools/javac/lambda/funcInterfaces/NonSAM1.java                                                                   Passed. Compilation failed as expected
+tools/javac/lambda/funcInterfaces/NonSAM2.java                                                                   Passed. Compilation failed as expected
+tools/javac/lambda/funcInterfaces/NonSAM3.java                                                                   Passed. Compilation failed as expected
+tools/javac/lambda/inaccessibleMref01/InaccessibleMref01.java                                                    Passed. Compilation failed as expected
+tools/javac/lambda/inaccessibleMref02/InaccessibleMref02.java                                                    Passed. Execution successful
+tools/javac/lambda/intersection/IntersectionTargetTypeTest.java                                                  Passed. Execution successful
+tools/javac/lambda/lambdaExecution/InInterface.java                                                              Passed. Execution successful
+tools/javac/lambda/lambdaExecution/InnerConstructor.java                                                         Passed. Execution successful
+tools/javac/lambda/lambdaExecution/LambdaTranslationTest1.java                                                   Passed. Execution successful
+tools/javac/lambda/lambdaExecution/LambdaTranslationTest2.java                                                   Passed. Execution successful
+tools/javac/lambda/lambdaExpression/AbstractClass_neg.java                                                       Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/AccessNonStatic_neg.java                                                     Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/EffectivelyFinal_neg.java                                                    Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/InvalidExpression1.java                                                      Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/InvalidExpression3.java                                                      Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/InvalidExpression4.java                                                      Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/InvalidExpression5.java                                                      Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/InvalidExpression6.java                                                      Passed. Compilation failed as expected
+tools/javac/lambda/lambdaExpression/LambdaTest1.java                                                             Passed. Execution successful
+tools/javac/lambda/lambdaExpression/LambdaTest2.java                                                             Passed. Execution successful
+tools/javac/lambda/lambdaExpression/LambdaTest3.java                                                             Passed. Execution successful
+tools/javac/lambda/lambdaExpression/LambdaTest4.java                                                             Passed. Execution successful
+tools/javac/lambda/lambdaExpression/LambdaTest5.java                                                             Passed. Execution successful
+tools/javac/lambda/lambdaExpression/LambdaTest6.java                                                             Passed. Execution successful
+tools/javac/lambda/lambdaExpression/SamConversion.java                                                           Passed. Execution successful
+tools/javac/lambda/lambdaExpression/SamConversionComboTest.java                                                  Passed. Execution successful
+tools/javac/lambda/lambdaNaming/TestNonSerializableLambdaNameStability.java                                      Passed. Execution successful
+tools/javac/lambda/lambdaNaming/TestSerializedLambdaNameStability.java                                           Passed. Execution successful
+tools/javac/lambda/methodReference/BridgeMethod.java                                                             Passed. Execution successful
+tools/javac/lambda/methodReference/ImplicitEnclosingInstanceTest.java                                            Passed. Execution successful
+tools/javac/lambda/methodReference/IntersectionTypeReceiverTest.java                                             Passed. Execution successful
+tools/javac/lambda/methodReference/IntersectionTypeReceiverTest2.java                                            Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef1.java                                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef2.java                                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef3.java                                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef4.java                                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef5.java                                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef6.java                                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef7.java                                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef8.java                                                               Passed. Compilation successful
+tools/javac/lambda/methodReference/MethodRefIntColonColonNewTest.java                                            Passed. Compilation failed as expected
+tools/javac/lambda/methodReference/MethodRefNewInnerBootstrap.java                                               Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefNewInnerInLambdaNPE1.java                                            Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefNewInnerInLambdaNPE2.java                                            Passed. Compilation successful
+tools/javac/lambda/methodReference/MethodRefNewInnerInLambdaVerify1.java                                         Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefNewInnerInLambdaVerify2.java                                         Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefNewInnerInLambdaVerify2simple.java                                   Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefQualifier1.java                                                      Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefSingleRefEvalBridge.java                                             Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefStuck.java                                                           Passed. Compilation failed as expected
+tools/javac/lambda/methodReference/MethodRefStuck2.java                                                          Passed. Compilation successful
+tools/javac/lambda/methodReference/MethodRefStuckParenthesized.java                                              Passed. Compilation failed as expected
+tools/javac/lambda/methodReference/MethodRefToInner.java                                                         Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRefToInnerWithoutOuter.java                                             Passed. Compilation failed as expected
+tools/javac/lambda/methodReference/MethodRefToLocalClassMethodTest.java                                          Passed. Execution successful
+tools/javac/lambda/methodReference/MethodRef_neg.java                                                            Passed. Compilation failed as expected
+tools/javac/lambda/methodReference/MethodReferenceComplexNullCheckTest.java                                      Passed. Execution successful
+tools/javac/lambda/methodReference/ProtectedInaccessibleMethodRefTest.java                                       Passed. Execution successful
+tools/javac/lambda/methodReference/ProtectedInaccessibleMethodRefTest2.java                                      Passed. Execution successful
+tools/javac/lambda/methodReference/SamConversion.java                                                            Passed. Execution successful
+tools/javac/lambda/methodReference/SamConversionComboTest.java                                                   Passed. Execution successful
+tools/javac/lambda/methodReference/TreeMakerParamsIsGoofy.java                                                   Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceIntersection1.java                                    Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceIntersection2.java                                    Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceIntersection3.java                                    Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceIntersectionInducedTest.java                          Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceNullCheckTest.java                                    Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferencePackagePrivateQualifier.java                          Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestFDCCE.java                                        Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestInnerDefault.java                                 Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestInnerInstance.java                                Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestInnerVarArgsThis.java                             Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestInstance.java                                     Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestKinds.java                                        Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestMethodHandle.java                                 Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestNew.java                                          Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestNewInner.java                                     Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestNewInnerImplicitArgs.java                         Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestSueCase1.java                                     Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestSueCase2.java                                     Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestSueCase4.java                                     Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestSuper.java                                        Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestSuperDefault.java                                 Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestTypeConversion.java                               Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestVarArgs.java                                      Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestVarArgsExt.java                                   Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestVarArgsSuper.java                                 Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestVarArgsSuperDefault.java                          Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceTestVarArgsThis.java                                  Passed. Execution successful
+tools/javac/lambda/methodReferenceExecution/MethodReferenceUnionTypeTest.java                                    Passed. Execution successful
+tools/javac/lambda/mostSpecific/StructuralMostSpecificTest.java                                                  Passed. Execution successful
+tools/javac/lambda/privateMethodReferences/MethodInvoker.java                                                    Passed. Execution successful
+tools/javac/lambda/privateMethodReferences/MethodSupplier.java                                                   Passed. Execution successful
+tools/javac/lambda/privateMethodReferences/ThirdClass.java                                                       Passed. Execution successful
+tools/javac/lambda/self_initializer/T8024809/SelfInitializerInLambdaTesta.java                                   Passed. Compilation failed as expected
+tools/javac/lambda/self_initializer/T8024809/SelfInitializerInLambdaTestb.java                                   Passed. Compilation failed as expected
+tools/javac/lambda/self_initializer/T8053906/SelfInitializerInLambdaTestc.java                                   Passed. Compilation failed as expected
+tools/javac/lambda/separate/Test.java                                                                            Passed. Compilation successful
+tools/javac/lambda/speculative/8147546/T8147546a.java                                                            Passed. Compilation successful
+tools/javac/lambda/speculative/8147546/T8147546b.java                                                            Passed. Compilation successful
+tools/javac/lambda/speculative/8154180/T8154180a.java                                                            Passed. Compilation successful
+tools/javac/lambda/speculative/8154180/T8154180b.java                                                            Passed. Compilation failed as expected
+tools/javac/lambda/speculative/DiamondFinder.java                                                                Passed. Compilation successful
+tools/javac/lambda/speculative/InferStrict.java                                                                  Passed. Compilation successful
+tools/javac/lambda/speculative/InferWeak.java                                                                    Passed. Compilation successful
+tools/javac/lambda/speculative/Main.java                                                                         Passed. Compilation failed as expected
+tools/javac/lambda/speculative/MissingError.java                                                                 Passed. Compilation failed as expected
+tools/javac/lambda/speculative/NestedLambdaGenerics.java                                                         Passed. Compilation successful
+tools/javac/lambda/speculative/NestedLambdaNoGenerics.java                                                       Passed. Compilation successful
+tools/javac/lambda/speculative/T8046685.java                                                                     Passed. Compilation successful
+tools/javac/lambda/speculative/T8055984.java                                                                     Passed. Compilation successful
+tools/javac/lambda/speculative/T8077247.java                                                                     Passed. Compilation successful
+tools/javac/lambda/speculative/T8078093.java                                                                     Passed. Compilation successful
+tools/javac/lambda/typeInference/InferenceTest11.java                                                            Passed. Execution successful
+tools/javac/lambda/typeInference/InferenceTest2.java                                                             Passed. Execution successful
+tools/javac/lambda/typeInference/InferenceTest2b.java                                                            Passed. Execution successful
+tools/javac/lambda/typeInference/InferenceTest3.java                                                             Passed. Execution successful
+tools/javac/lambda/typeInference/InferenceTest4.java                                                             Passed. Execution successful
+tools/javac/lambda/typeInference/InferenceTest6.java                                                             Passed. Compilation successful
+tools/javac/lambda/typeInference/InferenceTest789.java                                                           Passed. Execution successful
+tools/javac/lambda/typeInference/InferenceTest_neg1_2.java                                                       Passed. Compilation failed as expected
+tools/javac/lambda/typeInference/combo/TypeInferenceComboTest.java                                               Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/javac/FDTest.java                                                     Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/AttributeInjector.java                                       Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/ClassFile.java                                               Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/ClassFilePreprocessor.java                                   Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/ClassToInterfaceConverter.java                               Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/Compiler.java                                                Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/DirectedClassLoader.java                                     Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/SourceModel.java                                             Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/separate/TestHarness.java                                             Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/ClassCase.java                                               Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/Hierarchy.java                                               Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/HierarchyGenerator.java                                      Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/Rule.java                                                    Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/RuleGroup.java                                               Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/TTNode.java                                                  Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/TTParser.java                                                Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/shapegen/TTShape.java                                                 Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/vm/DefaultMethodsTest.java                                            Passed. Execution successful
+tools/javac/lambdaShapes/org/openjdk/tests/vm/FDSeparateCompilationTest.java                                     Passed. Execution successful
+tools/javac/launcher/GetResourceTest.java                                                                        Passed. Execution successful
+tools/javac/launcher/SourceLauncherTest.java                                                                     Passed. Execution successful
+tools/javac/lexer/JavaLexerTest.java                                                                             Passed. Execution successful
+tools/javac/lib/DPrinter.java                                                                                    Passed. Compilation successful
+tools/javac/limits/ArrayDims1.java                                                                               Passed. Compilation successful
+tools/javac/limits/ArrayDims2.java                                                                               Passed. Compilation failed as expected
+tools/javac/limits/ArrayDims3.java                                                                               Passed. Compilation successful
+tools/javac/limits/ArrayDims4.java                                                                               Passed. Compilation failed as expected
+tools/javac/limits/ArrayDims5.java                                                                               Passed. Compilation failed as expected
+tools/javac/limits/CodeSize.java                                                                                 Passed. Compilation failed as expected
+tools/javac/limits/LongName.java                                                                                 Passed. Compilation failed as expected
+tools/javac/limits/NestedClassConstructorArgs.java                                                               Passed. Execution successful
+tools/javac/limits/NestedClassMethodArgs.java                                                                    Passed. Execution successful
+tools/javac/limits/PoolSize1.java                                                                                Passed. Compilation failed as expected
+tools/javac/limits/PoolSize2.java                                                                                Passed. Compilation failed as expected
+tools/javac/limits/StaticNestedClassConstructorArgs.java                                                         Passed. Execution successful
+tools/javac/limits/StringLength.java                                                                             Passed. Compilation failed as expected
+tools/javac/limits/TopLevelClassConstructorArgs.java                                                             Passed. Execution successful
+tools/javac/limits/TopLevelClassMethodArgs.java                                                                  Passed. Execution successful
+tools/javac/limits/TopLevelClassStaticMethodArgs.java                                                            Passed. Execution successful
+tools/javac/linenumbers/ConditionalLineNumberTest.java                                                           Passed. Execution successful
+tools/javac/linenumbers/FinallyLineNumberTest.java                                                               Passed. Execution successful
+tools/javac/linenumbers/NestedLineNumberTest.java                                                                Passed. Execution successful
+tools/javac/linenumbers/NullCheckLineNumberTest.java                                                             Passed. Execution successful
+tools/javac/links/LinksTest.java                                                                                 Passed. Execution successful
+tools/javac/lint/Deprecation.java                                                                                Passed. Compilation failed as expected
+tools/javac/lint/FallThrough.java                                                                                Passed. Compilation failed as expected
+tools/javac/lint/NoWarn.java                                                                                     Passed. Compilation successful
+tools/javac/lint/Unchecked.java                                                                                  Passed. Compilation failed as expected
+tools/javac/literals/BadBinaryLiterals.java                                                                      Passed. Compilation failed as expected
+tools/javac/literals/BadUnderscoreLiterals.java                                                                  Passed. Compilation failed as expected
+tools/javac/literals/BinaryLiterals.java                                                                         Passed. Execution successful
+tools/javac/literals/T6891079.java                                                                               Passed. Compilation failed as expected
+tools/javac/literals/UnderscoreLiterals.java                                                                     Passed. Execution successful
+tools/javac/lvti/BadLocalVarInferenceTest.java                                                                   Passed. Compilation failed as expected
+tools/javac/lvti/FoldingTest.java                                                                                Passed. Compilation failed as expected
+tools/javac/lvti/ParserTest.java                                                                                 Passed. Compilation failed as expected
+tools/javac/lvti/SelfRefTest.java                                                                                Passed. Compilation failed as expected
+tools/javac/lvti/T8191893.java                                                                                   Passed. Compilation successful
+tools/javac/lvti/T8191959.java                                                                                   Passed. Compilation successful
+tools/javac/lvti/T8200199.java                                                                                   Passed. Compilation failed as expected
+tools/javac/lvti/TestBadArray.java                                                                               Passed. Compilation successful
+tools/javac/lvti/badTypeReference/BadTypeReference.java                                                          Passed. Compilation failed as expected
+tools/javac/lvti/harness/NonDenotableTest.java                                                                   Passed. Execution successful
+tools/javac/lvti/harness/PrimitiveTypeTest.java                                                                  Passed. Execution successful
+tools/javac/lvti/harness/ReferenceTypeTest.java                                                                  Passed. Execution successful
+tools/javac/lvti/harness/UpperBounds.java                                                                        Passed. Execution successful
+tools/javac/main/AtFileTest.java                                                                                 Passed. Execution successful
+tools/javac/main/EnvVariableTest.java                                                                            Passed. Execution successful
+tools/javac/main/Option_J_At_Test.java                                                                           Passed. Execution successful
+tools/javac/main/StreamsTest.java                                                                                Passed. Execution successful
+tools/javac/main/T8058445.java                                                                                   Passed. Execution successful
+tools/javac/main/ToolProviderTest.java                                                                           Passed. Execution successful
+tools/javac/mandatoryWarnings/deprecated/Test.java                                                               Passed. Compilation successful
+tools/javac/mandatoryWarnings/unchecked/Test.java                                                                Passed. Compilation successful
+tools/javac/meth/BadPolySig/BadPolySig.java                                                                      Passed. Compilation successful
+tools/javac/meth/InvokeMH.java                                                                                   Passed. Compilation successful
+tools/javac/meth/TestCP.java                                                                                     Passed. Execution successful
+tools/javac/meth/VarargsWarn.java                                                                                Passed. Compilation failed as expected
+tools/javac/meth/XlintWarn.java                                                                                  Passed. Compilation successful
+tools/javac/miranda/4686148/Test.java                                                                            Passed. Compilation failed as expected
+tools/javac/miranda/4686811/Tryit.java                                                                           Passed. Compilation successful
+tools/javac/miranda/4711056/T1.java                                                                              Passed. Compilation failed as expected
+tools/javac/miranda/T4279316a.java                                                                               Passed. Compilation successful
+tools/javac/miranda/T4279316b.java                                                                               Passed. Compilation successful
+tools/javac/miranda/T4279316c.java                                                                               Passed. Compilation successful
+tools/javac/miranda/T4279316d.java                                                                               Passed. Compilation successful
+tools/javac/miranda/T4528315.java                                                                                Passed. Compilation successful
+tools/javac/miranda/T4666866.java                                                                                Passed. Compilation failed as expected
+tools/javac/miranda/T4711325.java                                                                                Passed. Compilation successful
+tools/javac/missingClass/A.java                                                                                  Passed. Compilation failed as expected
+tools/javac/missingSuperRecovery/MissingInterfaceTest.java                                                       Passed. Compilation failed as expected
+tools/javac/missingSuperRecovery/MissingSuperRecovery.java                                                       Passed. Compilation failed as expected
+tools/javac/mixedTarget/ExtendCovariant1.java                                                                    Passed. Compilation successful
+tools/javac/mixedTarget/ExtendCovariant2.java                                                                    Passed. Compilation successful
+tools/javac/modules/AbstractOrInnerClassServiceImplTest.java                                                     Passed. Execution successful
+tools/javac/modules/AddExportsTest.java                                                                          Passed. Execution successful
+tools/javac/modules/AddLimitMods.java                                                                            Passed. Execution successful
+tools/javac/modules/AddModulesTest.java                                                                          Passed. Execution successful
+tools/javac/modules/AddReadsTest.java                                                                            Passed. Execution successful
+tools/javac/modules/AllDefaultTest.java                                                                          Passed. Execution successful
+tools/javac/modules/AnachronisticModuleInfo/AnachronisticModuleInfoTest.java                                     Passed. Execution successful
+tools/javac/modules/AnnotationProcessing.java                                                                    Passed. Execution successful
+tools/javac/modules/AnnotationProcessingWithModuleInfoInWrongPlace.java                                          Passed. Execution successful
+tools/javac/modules/AnnotationProcessorsInModulesTest.java                                                       Passed. Execution successful
+tools/javac/modules/AnnotationsOnModules.java                                                                    Passed. Execution successful
+tools/javac/modules/AutomaticModules.java                                                                        Passed. Execution successful
+tools/javac/modules/BrokenModulesTest.java                                                                       Passed. Execution successful
+tools/javac/modules/CompileModulePatchTest.java                                                                  Passed. Execution successful
+tools/javac/modules/ContainsTest.java                                                                            Passed. Execution successful
+tools/javac/modules/ConvenientAccessErrorsTest.java                                                              Passed. Execution successful
+tools/javac/modules/DirectiveVisitorTest.java                                                                    Passed. Execution successful
+tools/javac/modules/DoclintOtherModules.java                                                                     Passed. Execution successful
+tools/javac/modules/DuplicateClassTest.java                                                                      Passed. Execution successful
+tools/javac/modules/EdgeCases.java                                                                               Passed. Execution successful
+tools/javac/modules/EnvVarTest.java                                                                              Passed. Execution successful
+tools/javac/modules/ExportsUnexported.java                                                                       Passed. Execution successful
+tools/javac/modules/FileManagerGetServiceLoaderTest.java                                                         Passed. Execution successful
+tools/javac/modules/GetLocationForModuleTest.java                                                                Passed. Execution successful
+tools/javac/modules/GraphsTest.java                                                                              Passed. Execution successful
+tools/javac/modules/HelloWorldTest.java                                                                          Passed. Execution successful
+tools/javac/modules/IncubatingTest.java                                                                          Passed. Execution successful
+tools/javac/modules/InheritRuntimeEnvironmentTest.java                                                           Passed. Execution successful
+tools/javac/modules/InvalidModuleDirective/module-info.java                                                      Passed. Compilation failed as expected
+tools/javac/modules/JavaBaseTest.java                                                                            Passed. Execution successful
+tools/javac/modules/LimitModulesTest.java                                                                        Passed. Execution successful
+tools/javac/modules/MOptionTest.java                                                                             Passed. Execution successful
+tools/javac/modules/MissingJarInModulePathTest.java                                                              Passed. Compilation failed as expected
+tools/javac/modules/MissingModuleTest.java                                                                       Passed. Execution successful
+tools/javac/modules/ModuleFinderTest.java                                                                        Passed. Execution successful
+tools/javac/modules/ModuleInfoPatchPath.java                                                                     Passed. Execution successful
+tools/javac/modules/ModuleInfoTest.java                                                                          Passed. Execution successful
+tools/javac/modules/ModuleInfoTreeAccess.java                                                                    Passed. Execution successful
+tools/javac/modules/ModulePathTest.java                                                                          Passed. Execution successful
+tools/javac/modules/ModuleSourcePathTest.java                                                                    Passed. Execution successful
+tools/javac/modules/ModuleVersion.java                                                                           Passed. Execution successful
+tools/javac/modules/ModulesAndClassPathTest.java                                                                 Passed. Execution successful
+tools/javac/modules/ModulesAndModuleSourcePathTest.java                                                          Passed. Execution successful
+tools/javac/modules/MultiModuleModeTest.java                                                                     Passed. Execution successful
+tools/javac/modules/NPECompilingModuleInfoTest.java                                                              Passed. Execution successful
+tools/javac/modules/NPEEmptyFileTest.java                                                                        Passed. Execution successful
+tools/javac/modules/ObscureMessageForBadProvidesTest.java                                                        Passed. Execution successful
+tools/javac/modules/OpenModulesTest.java                                                                         Passed. Execution successful
+tools/javac/modules/OutputDirTest.java                                                                           Passed. Execution successful
+tools/javac/modules/PackageConflictTest.java                                                                     Passed. Execution successful
+tools/javac/modules/PackageMultipleModules.java                                                                  Passed. Execution successful
+tools/javac/modules/PatchModulesTest.java                                                                        Passed. Execution successful
+tools/javac/modules/PluginsInModulesTest.java                                                                    Passed. Execution successful
+tools/javac/modules/PoorChoiceForModuleNameTest.java                                                             Passed. Execution successful
+tools/javac/modules/ProvidesTest.java                                                                            Passed. Execution successful
+tools/javac/modules/QueryBeforeEnter.java                                                                        Passed. Execution successful
+tools/javac/modules/RepeatedUsesAndProvidesTest.java                                                             Passed. Execution successful
+tools/javac/modules/ReportNonExistentPackageTest.java                                                            Passed. Execution successful
+tools/javac/modules/RequiresStaticTest.java                                                                      Passed. Execution successful
+tools/javac/modules/RequiresTransitiveTest.java                                                                  Passed. Execution successful
+tools/javac/modules/ResolveTest.java                                                                             Passed. Execution successful
+tools/javac/modules/ServiceInStaticClassErrorTest.java                                                           Passed. Execution successful
+tools/javac/modules/ServiceProvidedButNotExportedOrUsedTest.java                                                 Passed. Execution successful
+tools/javac/modules/SingleModuleModeTest.java                                                                    Passed. Execution successful
+tools/javac/modules/SourceInSymlinkTest.java                                                                     Passed. Execution successful
+tools/javac/modules/SourcePathTest.java                                                                          Passed. Execution successful
+tools/javac/modules/SubpackageTest.java                                                                          Passed. Execution successful
+tools/javac/modules/T8158224/T8158224.java                                                                       Passed. Execution successful
+tools/javac/modules/T8159439/NPEForModuleInfoWithNonZeroSuperClassTest.java                                      Passed. Compilation failed as expected
+tools/javac/modules/T8160454/NPEGetDirectivesTest.java                                                           Passed. Compilation successful
+tools/javac/modules/T8161501/UnnamedModuleUnnamedPackageTest.java                                                Passed. Compilation successful
+tools/javac/modules/T8168854/module-info.java                                                                    Passed. Compilation successful
+tools/javac/modules/UnexpectedTokenInModuleInfoTest.java                                                         Passed. Execution successful
+tools/javac/modules/UpgradeModulePathTest.java                                                                   Passed. Execution successful
+tools/javac/modules/UsesTest.java                                                                                Passed. Execution successful
+tools/javac/modules/WrongErrorMessageForNestedServiceProviderTest.java                                           Passed. Execution successful
+tools/javac/multicatch/7005371/T7005371.java                                                                     Passed. Execution successful
+tools/javac/multicatch/7030606/DisjunctiveTypeWellFormednessTest.java                                            Passed. Execution successful
+tools/javac/multicatch/7030606/T7030606.java                                                                     Passed. Compilation failed as expected
+tools/javac/multicatch/8071291/T8071291.java                                                                     Passed. Compilation successful
+tools/javac/multicatch/Neg01.java                                                                                Passed. Compilation failed as expected
+tools/javac/multicatch/Neg01eff_final.java                                                                       Passed. Compilation failed as expected
+tools/javac/multicatch/Neg02.java                                                                                Passed. Compilation failed as expected
+tools/javac/multicatch/Neg02eff_final.java                                                                       Passed. Compilation failed as expected
+tools/javac/multicatch/Neg03.java                                                                                Passed. Compilation failed as expected
+tools/javac/multicatch/Neg04.java                                                                                Passed. Compilation failed as expected
+tools/javac/multicatch/Neg04eff_final.java                                                                       Passed. Compilation failed as expected
+tools/javac/multicatch/Neg06.java                                                                                Passed. Compilation failed as expected
+tools/javac/multicatch/Neg07.java                                                                                Passed. Compilation failed as expected
+tools/javac/multicatch/Pos01.java                                                                                Passed. Execution successful
+tools/javac/multicatch/Pos02.java                                                                                Passed. Execution successful
+tools/javac/multicatch/Pos03.java                                                                                Passed. Compilation successful
+tools/javac/multicatch/Pos04.java                                                                                Passed. Execution successful
+tools/javac/multicatch/Pos05.java                                                                                Passed. Execution successful
+tools/javac/multicatch/Pos06.java                                                                                Passed. Compilation successful
+tools/javac/multicatch/Pos07.java                                                                                Passed. Compilation successful
+tools/javac/multicatch/Pos08.java                                                                                Passed. Compilation successful
+tools/javac/multicatch/Pos08eff_final.java                                                                       Passed. Compilation successful
+tools/javac/multicatch/Pos09.java                                                                                Passed. Compilation successful
+tools/javac/multicatch/Pos10.java                                                                                Passed. Execution successful
+tools/javac/multicatch/Pos11.java                                                                                Passed. Execution successful
+tools/javac/multicatch/Pos12.java                                                                                Passed. Execution successful
+tools/javac/multicatch/T6978574.java                                                                             Passed. Execution successful
+tools/javac/multicatch/model/ModelChecker.java                                                                   Passed. Compilation successful
+tools/javac/nativeHeaders/NativeHeaderTest.java                                                                  Passed. Execution successful
+tools/javac/nested/4903103/T4903103.java                                                                         Passed. Execution successful
+tools/javac/nested/5009484/X.java                                                                                Passed. Compilation failed as expected
+tools/javac/nested/5009484/Y.java                                                                                Passed. Compilation failed as expected
+tools/javac/nestmates/CheckNestmateAttrs.java                                                                    Passed. Execution successful
+tools/javac/newlines/NewLineTest.java                                                                            Passed. Execution successful
+tools/javac/options/BCPOrSystemNotSpecified.java                                                                 Passed. Execution successful
+tools/javac/options/IsSupportedOptionTest.java                                                                   Passed. Execution successful
+tools/javac/options/T6900037.java                                                                                Passed. Compilation successful
+tools/javac/options/T6949443.java                                                                                Passed. Compilation successful
+tools/javac/options/T6986895.java                                                                                Passed. Execution successful
+tools/javac/options/T7022337.java                                                                                Passed. Execution successful
+tools/javac/options/XjcovUnionTypeTest.java                                                                      Passed. Compilation successful
+tools/javac/options/modes/AtFilesTest.java                                                                       Passed. Execution successful
+tools/javac/options/modes/DocLintTest.java                                                                       Passed. Execution successful
+tools/javac/options/modes/FSInfoTest.java                                                                        Passed. Execution successful
+tools/javac/options/modes/InfoOptsTest.java                                                                      Passed. Execution successful
+tools/javac/options/modes/NoOperandsTest.java                                                                    Passed. Execution successful
+tools/javac/options/modes/OutputDirTest.java                                                                     Passed. Execution successful
+tools/javac/options/modes/ProfileBootClassPathTest.java                                                          Passed. Execution successful
+tools/javac/options/modes/ProfileTargetTest.java                                                                 Passed. Execution successful
+tools/javac/options/modes/SourceTargetTest.java                                                                  Passed. Execution successful
+tools/javac/options/modes/StdOutTest.java                                                                        Passed. Execution successful
+tools/javac/options/release/ReleaseOption.java                                                                   Passed. Compilation failed as expected
+tools/javac/options/release/ReleaseOption9.java                                                                  Passed. Execution successful
+tools/javac/options/release/ReleaseOptionCurrent.java                                                            Passed. Execution successful
+tools/javac/options/release/ReleaseOptionThroughAPI.java                                                         Passed. Execution successful
+tools/javac/options/release/ReleaseOptionUnsupported.java                                                        Passed. Execution successful
+tools/javac/options/smokeTests/OptionSmokeTest.java                                                              Passed. Execution successful
+tools/javac/options/xprefer/XPreferTest.java                                                                     Passed. Execution successful
+tools/javac/overload/T4494762.java                                                                               Passed. Compilation successful
+tools/javac/overload/T4723909.java                                                                               Passed. Compilation successful
+tools/javac/overload/T4743490.java                                                                               Passed. Compilation failed as expected
+tools/javac/overload/T5090220.java                                                                               Passed. Compilation failed as expected
+tools/javac/overload/T6776289.java                                                                               Passed. Compilation successful
+tools/javac/overload/T8176265.java                                                                               Passed. Compilation successful
+tools/javac/overrridecrash/B.java                                                                                Passed. Compilation failed as expected
+tools/javac/parser/7157165/T7157165.java                                                                         Passed. Compilation failed as expected
+tools/javac/parser/8014643/T8014643.java                                                                         Passed. Compilation successful
+tools/javac/parser/8081769/T8081769.java                                                                         Passed. Compilation failed as expected
+tools/javac/parser/8134007/T8134007.java                                                                         Passed. Compilation successful
+tools/javac/parser/ErroneousParameters.java                                                                      Passed. Compilation failed as expected
+tools/javac/parser/ExtraSemiTest.java                                                                            Passed. Execution successful
+tools/javac/parser/JavacParserTest.java                                                                          Passed. Execution successful
+tools/javac/parser/MissingClosingBrace.java                                                                      Passed. Compilation failed as expected
+tools/javac/parser/SingleCommaAnnotationValue.java                                                               Passed. Compilation successful
+tools/javac/parser/SingleCommaAnnotationValueFail.java                                                           Passed. Compilation failed as expected
+tools/javac/parser/StringFoldingTest.java                                                                        Passed. Execution successful
+tools/javac/parser/T4881269.java                                                                                 Passed. Compilation failed as expected
+tools/javac/parser/T4910483.java                                                                                 Passed. Execution successful
+tools/javac/parser/extend/JavacExtensionTest.java                                                                Passed. Execution successful
+tools/javac/patterns/BindingsExistTest.java                                                                      Passed. Compilation failed as expected
+tools/javac/patterns/BindingsTest1.java                                                                          Passed. Execution successful
+tools/javac/patterns/BindingsTest1Merging.java                                                                   Passed. Compilation failed as expected
+tools/javac/patterns/BindingsTest2.java                                                                          Passed. Compilation failed as expected
+tools/javac/patterns/BreakAndLoops.java                                                                          Passed. Execution successful
+tools/javac/patterns/CastConversionMatch.java                                                                    Passed. Compilation failed as expected
+tools/javac/patterns/ConditionalTest.java                                                                        Passed. Execution successful
+tools/javac/patterns/DuplicateBindingTest.java                                                                   Passed. Compilation failed as expected
+tools/javac/patterns/EnsureTypesOrderTest.java                                                                   Passed. Compilation failed as expected
+tools/javac/patterns/ExamplesFromProposal.java                                                                   Passed. Execution successful
+tools/javac/patterns/ImpossibleTypeTest.java                                                                     Passed. Compilation failed as expected
+tools/javac/patterns/LocalVariableTable.java                                                                     Passed. Execution successful
+tools/javac/patterns/MatchBindingScopeTest.java                                                                  Passed. Compilation failed as expected
+tools/javac/patterns/NullsInPatterns.java                                                                        Passed. Execution successful
+tools/javac/patterns/PatternMatchPosTest.java                                                                    Passed. Compilation successful
+tools/javac/patterns/PatternTypeTest2.java                                                                       Passed. Execution successful
+tools/javac/patterns/PatternVariablesAreFinal.java                                                               Passed. Compilation failed as expected
+tools/javac/patterns/PatternVariablesAreFinal2.java                                                              Passed. Execution successful
+tools/javac/patterns/PatternsSimpleVisitorTest.java                                                              Passed. Execution successful
+tools/javac/patterns/Reifiable.java                                                                              Passed. Compilation failed as expected
+tools/javac/patterns/ReifiableOld.java                                                                           Passed. Compilation failed as expected
+tools/javac/patterns/UncheckedWarningOnMatchesTest.java                                                          Passed. Compilation failed as expected
+tools/javac/patterns/scope/ScopeTest.java                                                                        Passed. Execution successful
+tools/javac/platform/CanHandleClassFilesTest.java                                                                Passed. Execution successful
+tools/javac/platform/NoProfileAnnotationWarning.java                                                             Passed. Compilation successful
+tools/javac/platform/NumericalComparatorTest.java                                                                Passed. Execution successful
+tools/javac/platform/PlatformProviderTest.java                                                                   Passed. Execution successful
+tools/javac/platform/ReleaseModulesAndTypeElement.java                                                           Passed. Compilation successful
+tools/javac/plugin/AutostartPlugins.java                                                                         Passed. Execution successful
+tools/javac/plugin/InternalAPI.java                                                                              Passed. Execution successful
+tools/javac/plugin/MultiplePlugins.java                                                                          Passed. Execution successful
+tools/javac/plugin/missing/PluginNotFound.java                                                                   Passed. Compilation failed as expected
+tools/javac/plugin/showtype/Test.java                                                                            Passed. Execution successful
+tools/javac/policy/test1/Test1a.java#id0                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1a.java#id1                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1a.java#id2                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1a.java#id3                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1a.java#id4                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1a.java#id5                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1a.java#id6                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1a.java#id7                                                                         Passed. Compilation failed as expected
+tools/javac/policy/test1/Test1b.java#id0                                                                         Passed. Execution successful
+tools/javac/policy/test1/Test1b.java#id1                                                                         Passed. Execution successful
+tools/javac/policy/test1/Test1b.java#id2                                                                         Passed. Execution successful
+tools/javac/policy/test1/Test1b.java#id3                                                                         Passed. Execution successful
+tools/javac/policy/test2/Test.java#id0                                                                           Passed. Compilation successful
+tools/javac/policy/test2/Test.java#id1                                                                           Passed. Compilation successful
+tools/javac/policy/test2/Test.java#id2                                                                           Passed. Compilation successful
+tools/javac/policy/test2/Test.java#id3                                                                           Passed. Compilation successful
+tools/javac/policy/test3/Test.java                                                                               Passed. Execution successful
+tools/javac/positions/T6264029.java                                                                              Passed. Compilation successful
+tools/javac/positions/T6402077.java                                                                              Passed. Execution successful
+tools/javac/positions/T6404194.java                                                                              Passed. Execution successful
+tools/javac/positions/T8184739.java                                                                              Passed. Execution successful
+tools/javac/positions/TreeEndPosTest.java                                                                        Passed. Execution successful
+tools/javac/preview/PreviewErrors.java                                                                           Passed. Execution successful
+tools/javac/preview/PreviewOptionTest.java                                                                       Passed. Execution successful
+tools/javac/preview/classReaderTest/Client.java                                                                  Passed. Compilation failed as expected
+tools/javac/processing/6348193/T6348193.java                                                                     Passed. Execution successful
+tools/javac/processing/6348499/T6348499.java                                                                     Passed. Execution successful
+tools/javac/processing/6350124/T6350124.java                                                                     Passed. Execution successful
+tools/javac/processing/6359313/T6359313.java                                                                     Passed. Compilation successful
+tools/javac/processing/6365040/T6365040.java                                                                     Passed. Compilation failed as expected
+tools/javac/processing/6378728/T6378728.java                                                                     Passed. Execution successful
+tools/javac/processing/6413690/T6413690.java                                                                     Passed. Compilation successful
+tools/javac/processing/6414633/T6414633.java                                                                     Passed. Execution successful
+tools/javac/processing/6430209/T6430209.java                                                                     Passed. Execution successful
+tools/javac/processing/6499119/ClassProcessor.java                                                               Passed. Compilation successful
+tools/javac/processing/6511613/clss41701.java                                                                    Passed. Compilation failed as expected
+tools/javac/processing/6512707/T6512707.java                                                                     Passed. Compilation successful
+tools/javac/processing/6634138/T6634138.java                                                                     Passed. Execution successful
+tools/javac/processing/6994946/SemanticErrorTest.java                                                            Passed. Compilation failed as expected
+tools/javac/processing/6994946/SyntaxErrorTest.java                                                              Passed. Compilation failed as expected
+tools/javac/processing/8132446/T8132446.java                                                                     Passed. Compilation successful
+tools/javac/processing/GenerateAndError.java                                                                     Passed. Compilation failed as expected
+tools/javac/processing/OverwriteInitialInput.java                                                                Passed. Execution successful
+tools/javac/processing/PackageInfo/ClassAnnotations/ClassAnnotations.java                                        Passed. Compilation successful
+tools/javac/processing/PackageInfo/Overwrite/Overwrite.java                                                      Passed. Compilation successful
+tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java                    Passed. Execution successful
+tools/javac/processing/StopAfterError/StopAfterError.java                                                        Passed. Compilation failed as expected
+tools/javac/processing/T6439826.java                                                                             Passed. Execution successful
+tools/javac/processing/T6920317.java                                                                             Passed. Execution successful
+tools/javac/processing/T7196462.java                                                                             Passed. Compilation successful
+tools/javac/processing/T8142931.java                                                                             Passed. Execution successful
+tools/javac/processing/TestMultipleErrors.java                                                                   Passed. Compilation failed as expected
+tools/javac/processing/TestWarnErrorCount.java                                                                   Passed. Execution successful
+tools/javac/processing/completion/TestCompletions.java                                                           Passed. Execution successful
+tools/javac/processing/environment/ProcessingEnvAnnoDiscovery.java                                               Passed. Compilation successful
+tools/javac/processing/environment/TestPreviewEnabled.java                                                       Passed. Compilation successful
+tools/javac/processing/environment/TestSourceVersion.java                                                        Passed. Compilation successful
+tools/javac/processing/environment/round/TestContext.java                                                        Passed. Compilation successful
+tools/javac/processing/environment/round/TestElementsAnnotatedWith.java                                          Passed. Compilation successful
+tools/javac/processing/errors/CrashOnNonExistingAnnotation/Source.java                                           Passed. Execution successful
+tools/javac/processing/errors/EnsureAnnotationTypeMismatchException/Source.java                                  Passed. Compilation failed as expected
+tools/javac/processing/errors/EnsureMirroredTypeException/Source.java                                            Passed. Compilation failed as expected
+tools/javac/processing/errors/StopOnInapplicableAnnotations/GenerateFunctionalInterface.java                     Passed. Compilation successful
+tools/javac/processing/errors/StopOnInapplicableAnnotations/Source.java                                          Passed. Execution successful
+tools/javac/processing/errors/TestBadProcessor.java                                                              Passed. Execution successful
+tools/javac/processing/errors/TestClassNames.java                                                                Passed. Execution successful
+tools/javac/processing/errors/TestErrorCount.java                                                                Passed. Compilation failed as expected
+tools/javac/processing/errors/TestFatalityOfParseErrors.java                                                     Passed. Compilation failed as expected
+tools/javac/processing/errors/TestOptionSyntaxErrors.java                                                        Passed. Execution successful
+tools/javac/processing/errors/TestParseErrors/TestParseErrors.java                                               Passed. Compilation failed as expected
+tools/javac/processing/errors/TestReturnCode.java                                                                Passed. Execution successful
+tools/javac/processing/errors/TestSuppression.java                                                               Passed. Execution successful
+tools/javac/processing/filer/TestFilerConstraints.java                                                           Passed. Compilation successful
+tools/javac/processing/filer/TestGetResource.java                                                                Passed. Compilation successful
+tools/javac/processing/filer/TestGetResource2.java                                                               Passed. Execution successful
+tools/javac/processing/filer/TestInvalidRelativeNames.java                                                       Passed. Compilation successful
+tools/javac/processing/filer/TestLastRound.java                                                                  Passed. Compilation failed as expected
+tools/javac/processing/filer/TestPackageInfo.java                                                                Passed. Compilation successful
+tools/javac/processing/filer/TestValidRelativeNames.java                                                         Passed. Compilation successful
+tools/javac/processing/loader/testClose/TestClose.java                                                           Passed. Execution successful
+tools/javac/processing/loader/testClose/TestClose2.java                                                          Passed. Execution successful
+tools/javac/processing/messager/6362067/T6362067.java                                                            Passed. Compilation successful
+tools/javac/processing/messager/6388543/T6388543.java                                                            Passed. Compilation successful
+tools/javac/processing/messager/MessagerBasics.java                                                              Passed. Compilation failed as expected
+tools/javac/processing/messager/MessagerDiags.java                                                               Passed. Execution successful
+tools/javac/processing/model/6194785/T6194785.java                                                               Passed. Compilation successful
+tools/javac/processing/model/6341534/T6341534.java                                                               Passed. Compilation successful
+tools/javac/processing/model/LocalClasses/LocalClassesModel.java                                                 Passed. Compilation successful
+tools/javac/processing/model/LocalInAnonymous.java                                                               Passed. Execution successful
+tools/javac/processing/model/MissingClassRecursiveAccessible.java                                                Passed. Execution successful
+tools/javac/processing/model/TestExceptions.java                                                                 Passed. Execution successful
+tools/javac/processing/model/TestSourceVersion.java                                                              Passed. Execution successful
+tools/javac/processing/model/TestSymtabItems.java                                                                Passed. Execution successful
+tools/javac/processing/model/TestVisitorDefaults.java                                                            Passed. Execution successful
+tools/javac/processing/model/completionfailure/MissingClassFile.java                                             Passed. Execution successful
+tools/javac/processing/model/completionfailure/NoAbortForBadClassFile.java                                       Passed. Execution successful
+tools/javac/processing/model/completionfailure/SymbolsDontCumulate.java                                          Passed. Execution successful
+tools/javac/processing/model/element/8009367/TestQualifiedNameUsed.java                                          Passed. Compilation successful
+tools/javac/processing/model/element/AnnoProcessorOnRecordsTest.java                                             Passed. Execution successful
+tools/javac/processing/model/element/AnnotationToStringTest.java                                                 Passed. Compilation successful
+tools/javac/processing/model/element/CheckingTypeAnnotationsOnRecords.java                                       Passed. Execution successful
+tools/javac/processing/model/element/JavaxLangModelForRecords.java                                               Passed. Execution successful
+tools/javac/processing/model/element/TestAnonClassNames.java                                                     Passed. Execution successful
+tools/javac/processing/model/element/TestBindingVariable.java                                                    Passed. Compilation successful
+tools/javac/processing/model/element/TestElement.java                                                            Passed. Compilation successful
+tools/javac/processing/model/element/TestElementAsType.java                                                      Passed. Compilation successful
+tools/javac/processing/model/element/TestElementKindPredicates.java                                              Passed. Execution successful
+tools/javac/processing/model/element/TestEmptyContainer.java                                                     Passed. Compilation successful
+tools/javac/processing/model/element/TestExecutableElement.java                                                  Passed. Compilation successful
+tools/javac/processing/model/element/TestExecutableReceiverType.java                                             Passed. Compilation successful
+tools/javac/processing/model/element/TestMissingElement/TestMissingElement.java                                  Passed. Compilation failed as expected
+tools/javac/processing/model/element/TestMissingElement2/TestMissingClass.java                                   Passed. Execution successful
+tools/javac/processing/model/element/TestMissingElement2/TestMissingGenericClass1.java                           Passed. Execution successful
+tools/javac/processing/model/element/TestMissingElement2/TestMissingGenericClass2.java                           Passed. Execution successful
+tools/javac/processing/model/element/TestMissingElement2/TestMissingGenericInterface1.java                       Passed. Execution successful
+tools/javac/processing/model/element/TestMissingElement2/TestMissingGenericInterface2.java                       Passed. Execution successful
+tools/javac/processing/model/element/TestMissingElement2/TestMissingInterface.java                               Passed. Execution successful
+tools/javac/processing/model/element/TestModuleElementNames.java                                                 Passed. Compilation successful
+tools/javac/processing/model/element/TestNames.java                                                              Passed. Compilation successful
+tools/javac/processing/model/element/TestNonInherited.java                                                       Passed. Compilation successful
+tools/javac/processing/model/element/TestOrigin.java                                                             Passed. Execution successful
+tools/javac/processing/model/element/TestPackageElement.java                                                     Passed. Compilation successful
+tools/javac/processing/model/element/TestRecord.java                                                             Passed. Execution successful
+tools/javac/processing/model/element/TestRecordDesugar.java                                                      Passed. Execution successful
+tools/javac/processing/model/element/TestResourceElement.java                                                    Passed. Compilation successful
+tools/javac/processing/model/element/TestResourceVariable.java                                                   Passed. Compilation successful
+tools/javac/processing/model/element/TestTypeElement.java                                                        Passed. Compilation successful
+tools/javac/processing/model/element/TestTypeParameter.java                                                      Passed. Compilation successful
+tools/javac/processing/model/element/TestTypeParameterAnnotations.java                                           Passed. Compilation successful
+tools/javac/processing/model/element/TypeParamBounds.java                                                        Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixRepeatableAndOfficialContainerBasicTest.java        Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixRepeatableAndOfficialContainerInheritedA1Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixRepeatableAndOfficialContainerInheritedA2Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixRepeatableAndOfficialContainerInheritedB1Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixRepeatableAndOfficialContainerInheritedB2Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixSingularAndUnofficialContainerBasicTest.java        Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixSingularAndUnofficialContainerInheritedA1Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixSingularAndUnofficialContainerInheritedA2Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixSingularAndUnofficialContainerInheritedB1Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/MixSingularAndUnofficialContainerInheritedB2Test.java  Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/OfficialContainerBasicTest.java                        Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/OfficialContainerInheritedTest.java                    Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/RepeatableBasicTest.java                               Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/RepeatableInheritedTest.java                           Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/RepeatableOfficialContainerBasicTest.java              Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/RepeatableOfficialContainerInheritedTest.java          Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/RepeatableOverrideATest.java                           Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/RepeatableOverrideBTest.java                           Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/RepeatingAnnotationsOnRecords.java                     Passed. Execution successful
+tools/javac/processing/model/element/repeatingAnnotations/SingularBasicTest.java                                 Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/SingularInheritedATest.java                            Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/SingularInheritedBTest.java                            Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/UnofficialContainerBasicTest.java                      Passed. Compilation successful
+tools/javac/processing/model/element/repeatingAnnotations/UnofficialContainerInheritedTest.java                  Passed. Compilation successful
+tools/javac/processing/model/inheritedByType/EnsureOrder.java                                                    Passed. Compilation successful
+tools/javac/processing/model/nestedTypeVars/NestedTypeVars.java                                                  Passed. Compilation successful
+tools/javac/processing/model/testgetallmembers/Main.java                                                         Passed. Execution successful
+tools/javac/processing/model/trees/BrokenEnumConstructor.java                                                    Passed. Compilation failed as expected
+tools/javac/processing/model/trees/OnDemandAttribution.java                                                      Passed. Compilation successful
+tools/javac/processing/model/type/BasicAnnoTests.java                                                            Passed. Compilation successful
+tools/javac/processing/model/type/BoundsTest.java                                                                Passed. Execution successful
+tools/javac/processing/model/type/InheritedAP.java                                                               Passed. Compilation successful
+tools/javac/processing/model/type/IntersectionPropertiesTest.java                                                Passed. Execution successful
+tools/javac/processing/model/type/MirroredTypeEx/NpeTest.java                                                    Passed. Execution successful
+tools/javac/processing/model/type/MirroredTypeEx/OverEager.java                                                  Passed. Compilation successful
+tools/javac/processing/model/type/MirroredTypeEx/Plurality.java                                                  Passed. Compilation successful
+tools/javac/processing/model/type/NoTypes.java                                                                   Passed. Compilation successful
+tools/javac/processing/model/type/TestTypeKind.java                                                              Passed. Execution successful
+tools/javac/processing/model/type/TestUnionType.java                                                             Passed. Execution successful
+tools/javac/processing/model/util/BinaryName.java                                                                Passed. Compilation successful
+tools/javac/processing/model/util/DirectSuperOfInt.java                                                          Passed. Compilation successful
+tools/javac/processing/model/util/GetTypeElemBadArg.java                                                         Passed. Compilation successful
+tools/javac/processing/model/util/NoSupers.java                                                                  Passed. Compilation successful
+tools/javac/processing/model/util/OverridesSpecEx.java                                                           Passed. Compilation successful
+tools/javac/processing/model/util/TestIntersectionTypeVisitors.java                                              Passed. Execution successful
+tools/javac/processing/model/util/TestTypeKindVisitors.java                                                      Passed. Compilation successful
+tools/javac/processing/model/util/TypesBadArg.java                                                               Passed. Compilation successful
+tools/javac/processing/model/util/deprecation/TestDeprecation.java                                               Passed. Compilation successful
+tools/javac/processing/model/util/directSupersOfErr/DirectSupersOfErr.java                                       Passed. Compilation failed as expected
+tools/javac/processing/model/util/elements/TestAllFoos.java                                                      Passed. Compilation successful
+tools/javac/processing/model/util/elements/TestGetConstantExpression.java                                        Passed. Compilation successful
+tools/javac/processing/model/util/elements/TestGetModuleOf.java                                                  Passed. Compilation successful
+tools/javac/processing/model/util/elements/TestGetPackageOf.java                                                 Passed. Compilation successful
+tools/javac/processing/model/util/elements/TestIsFunctionalInterface.java                                        Passed. Compilation successful
+tools/javac/processing/model/util/elements/VacuousEnum.java                                                      Passed. Compilation successful
+tools/javac/processing/model/util/elements/doccomments/TestDocComments.java                                      Passed. Execution successful
+tools/javac/processing/model/util/elements/doccomments/TestPackageInfoComments.java                              Passed. Execution successful
+tools/javac/processing/model/util/elements/hides/Hides.java                                                      Passed. Compilation successful
+tools/javac/processing/model/util/filter/TestIterables.java                                                      Passed. Compilation successful
+tools/javac/processing/model/util/printing/module-info.java                                                      Passed. Compilation successful
+tools/javac/processing/model/util/types/TestPseudoTypeHandling.java                                              Passed. Compilation successful
+tools/javac/processing/options/TestImplicitNone.java                                                             Passed. Execution successful
+tools/javac/processing/options/Xprint.java                                                                       Passed. Execution successful
+tools/javac/processing/options/XprintDocComments.java                                                            Passed. Compilation successful
+tools/javac/processing/options/testCommandLineClasses/Test.java                                                  Passed. Execution successful
+tools/javac/processing/options/testPrintProcessorInfo/Test.java                                                  Passed. Compilation failed as expected
+tools/javac/processing/options/testPrintProcessorInfo/TestWithXstdout.java                                       Passed. Execution successful
+tools/javac/processing/rounds/BaseClassesNotReRead.java                                                          Passed. Execution successful
+tools/javac/processing/rounds/ClassDependingOnGenerated.java                                                     Passed. Compilation successful
+tools/javac/processing/rounds/CompleteOnClosed.java                                                              Passed. Execution successful
+tools/javac/processing/rounds/GenerateAnonymousClass.java                                                        Passed. Compilation successful
+tools/javac/processing/rounds/GetElementsAnnotatedWithOnMissing.java                                             Passed. Execution successful
+tools/javac/processing/rounds/MethodsDroppedBetweenRounds.java                                                   Passed. Compilation successful
+tools/javac/processing/rounds/OverwriteBetweenCompilations.java                                                  Passed. Compilation successful
+tools/javac/processing/rounds/TypesCachesCleared.java                                                            Passed. Compilation successful
+tools/javac/processing/rounds/ValidTypesAreKept.java                                                             Passed. Execution successful
+tools/javac/processing/warnings/LintProcessing/TestAnnotationsWithoutProcessors.java                             Passed. Compilation successful
+tools/javac/processing/warnings/TestRepeatedItemsRuntime.java                                                    Passed. Compilation successful
+tools/javac/processing/warnings/TestRepeatedSupportedItems.java                                                  Passed. Compilation successful
+tools/javac/processing/warnings/TestSourceVersionWarnings.java                                                   Passed. Compilation successful
+tools/javac/processing/warnings/TypeAlreadyExists/TestProcTypeAlreadyExistsWarning.java                          Passed. Compilation successful
+tools/javac/processing/warnings/UseImplicit/TestProcUseImplicitWarning.java                                      Passed. Compilation successful
+tools/javac/processing/werror/WError1.java                                                                       Passed. Compilation failed as expected
+tools/javac/processing/werror/WErrorGen.java                                                                     Passed. Compilation failed as expected
+tools/javac/processing/werror/WErrorLast.java                                                                    Passed. Compilation failed as expected
+tools/javac/profiles/ProfileOptionTest.java                                                                      Passed. Execution successful
+tools/javac/protectedAccess/ProtectedAccess_1.java                                                               Passed. Compilation successful
+tools/javac/protectedAccess/ProtectedAccess_2.java                                                               Passed. Compilation failed as expected
+tools/javac/protectedAccess/ProtectedAccess_3.java                                                               Passed. Execution successful
+tools/javac/protectedAccess/ProtectedMemberAccess1.java                                                          Passed. Compilation successful
+tools/javac/protectedAccess/ProtectedMemberAccess2.java                                                          Passed. Compilation failed as expected
+tools/javac/protectedAccess/ProtectedMemberAccess3.java                                                          Passed. Compilation failed as expected
+tools/javac/protectedAccess/ProtectedMemberAccess4.java                                                          Passed. Compilation failed as expected
+tools/javac/protectedAccess/ProtectedMemberAccess5/Main.java                                                     Passed. Execution successful
+tools/javac/protectedInner/AnonInnerClass.java                                                                   Passed. Compilation successful
+tools/javac/protectedInner/InnerClass.java                                                                       Passed. Compilation successful
+tools/javac/protectedInner/Outerclass.java                                                                       Passed. Execution successful
+tools/javac/quid/T6999438.java                                                                                   Passed. Compilation failed as expected
+tools/javac/rawDiags/Error.java                                                                                  Passed. Compilation failed as expected
+tools/javac/rawDiags/Note.java                                                                                   Passed. Compilation successful
+tools/javac/rawDiags/Warning.java                                                                                Passed. Compilation successful
+tools/javac/records/MapAccessorToComponent.java                                                                  Passed. Execution successful
+tools/javac/records/RecordCompilationTests.java                                                                  Passed. Execution successful
+tools/javac/records/RecordMemberTests.java                                                                       Passed. Execution successful
+tools/javac/records/VarargsRecordsTest.java                                                                      Passed. Execution successful
+tools/javac/records/mandated_members/CheckRecordMembers.java                                                     Passed. Execution successful
+tools/javac/records/writeread/WriteReadTest.java                                                                 Passed. Compilation successful
+tools/javac/recovery/LocalVarHiding.java                                                                         Passed. Compilation failed as expected
+tools/javac/redefineObject/Object1-test.java                                                                     Passed. Compilation failed as expected
+tools/javac/redefineObject/Object2-test.java                                                                     Passed. Compilation failed as expected
+tools/javac/resolve/AmbiguityErrorTest.java                                                                      Passed. Execution successful
+tools/javac/resolve/BitWiseOperators.java                                                                        Passed. Execution successful
+tools/javac/resolve/BrokenAnonymous.java                                                                         Passed. Execution successful
+tools/javac/resolve/ResolveHarness.java                                                                          Passed. Execution successful
+tools/javac/scope/6225935/Estatico4.java                                                                         Passed. Compilation failed as expected
+tools/javac/scope/6225935/StaticImportAccess.java                                                                Passed. Compilation successful
+tools/javac/scope/6225935/T6214959.java                                                                          Passed. Compilation failed as expected
+tools/javac/scope/6225935/T6225935.java                                                                          Passed. Execution successful
+tools/javac/scope/6225935/T6381787.java                                                                          Passed. Compilation successful
+tools/javac/scope/6225935/Test.java                                                                              Passed. Compilation successful
+tools/javac/scope/6392998/T6392998.java                                                                          Passed. Compilation successful
+tools/javac/scope/7017664/CompoundScopeTest.java                                                                 Passed. Execution successful
+tools/javac/scope/7017664/ImplementationCacheTest.java                                                           Passed. Execution successful
+tools/javac/scope/7046348/EagerInterfaceCompletionTest.java                                                      Passed. Execution successful
+tools/javac/scope/DupUnsharedTest.java                                                                           Passed. Execution successful
+tools/javac/scope/HashCollisionTest.java                                                                         Passed. Execution successful
+tools/javac/scope/IterateAndRemove.java                                                                          Passed. Execution successful
+tools/javac/scope/RemoveSymbolTest.java                                                                          Passed. Execution successful
+tools/javac/scope/RemoveSymbolUnitTest.java                                                                      Passed. Execution successful
+tools/javac/scope/StarImportTest.java                                                                            Passed. Execution successful
+tools/javac/serial/SerialWarn.java                                                                               Passed. Compilation failed as expected
+tools/javac/serial/SerialWarnAnon.java                                                                           Passed. Compilation successful
+tools/javac/sourcePath/SourcePath.java                                                                           Passed. Execution successful
+tools/javac/sourcePath2/SourcePath2.java                                                                         Passed. Compilation failed as expected
+tools/javac/stackmap/StackMapTest.java                                                                           Passed. Execution successful
+tools/javac/stackmap/UninitThis.java                                                                             Passed. Execution successful
+tools/javac/staticImport/6537020/T6537020.java                                                                   Passed. Compilation failed as expected
+tools/javac/staticImport/6665223/T6665223.java                                                                   Passed. Compilation successful
+tools/javac/staticImport/6695838/T6695838.java                                                                   Passed. Compilation failed as expected
+tools/javac/staticImport/Ambig1.java                                                                             Passed. Compilation failed as expected
+tools/javac/staticImport/ImportInherit.java                                                                      Passed. Compilation successful
+tools/javac/staticImport/ImportPrivate.java                                                                      Passed. Compilation failed as expected
+tools/javac/staticImport/PrivateStaticImport.java                                                                Passed. Compilation failed as expected
+tools/javac/staticImport/Shadow.java                                                                             Passed. Compilation failed as expected
+tools/javac/staticImport/StaticImport.java                                                                       Passed. Execution successful
+tools/javac/staticImport/StaticImport2.java                                                                      Passed. Compilation failed as expected
+tools/javac/staticQualifiedNew/StaticQualifiedNew.java                                                           Passed. Compilation failed as expected
+tools/javac/switchexpr/BlockExpression.java                                                                      Passed. Execution successful
+tools/javac/switchexpr/BooleanNumericNonNumeric.java                                                             Passed. Compilation failed as expected
+tools/javac/switchexpr/BreakTest.java                                                                            Passed. Execution successful
+tools/javac/switchexpr/CRT.java                                                                                  Passed. Execution successful
+tools/javac/switchexpr/DefiniteAssignment1.java                                                                  Passed. Execution successful
+tools/javac/switchexpr/DefiniteAssignment2.java                                                                  Passed. Compilation failed as expected
+tools/javac/switchexpr/EmptySwitch.java                                                                          Passed. Compilation failed as expected
+tools/javac/switchexpr/ExhaustiveEnumSwitch.java                                                                 Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitch.java                                                                     Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchBreaks1.java                                                              Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchBreaks2.java                                                              Passed. Compilation failed as expected
+tools/javac/switchexpr/ExpressionSwitchBugs.java                                                                 Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchBugsInGen.java                                                            Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchCodeFromJLS.java                                                          Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchDA.java                                                                   Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchEmbedding.java                                                            Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchFallThrough.java                                                          Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchFallThrough1.java                                                         Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchFlow.java                                                                 Passed. Compilation failed as expected
+tools/javac/switchexpr/ExpressionSwitchInExpressionSwitch.java                                                   Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchInfer.java                                                                Passed. Compilation failed as expected
+tools/javac/switchexpr/ExpressionSwitchIntersectionTypes.java                                                    Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchNotExhaustive.java                                                        Passed. Compilation failed as expected
+tools/javac/switchexpr/ExpressionSwitchToString.java                                                             Passed. Execution successful
+tools/javac/switchexpr/ExpressionSwitchUnreachable.java                                                          Passed. Compilation failed as expected
+tools/javac/switchexpr/LambdaCapture.java                                                                        Passed. Compilation successful
+tools/javac/switchexpr/ParseIncomplete.java                                                                      Passed. Execution successful
+tools/javac/switchexpr/ParserRecovery.java                                                                       Passed. Compilation failed as expected
+tools/javac/switchexpr/SwitchExpressionIsNotAConstant.java                                                       Passed. Execution successful
+tools/javac/switchexpr/SwitchExpressionScopesIsolated.java                                                       Passed. Compilation failed as expected
+tools/javac/switchexpr/SwitchExpressionSimpleVisitorTest.java                                                    Passed. Execution successful
+tools/javac/switchexpr/TryCatch.java                                                                             Passed. Execution successful
+tools/javac/switchexpr/TryCatchFinally.java                                                                      Passed. Execution successful
+tools/javac/switchexpr/WarnWrongYieldTest.java                                                                   Passed. Compilation successful
+tools/javac/switchexpr/WrongBreakTest.java                                                                       Passed. Compilation failed as expected
+tools/javac/switchexpr/WrongYieldTest.java                                                                       Passed. Compilation failed as expected
+tools/javac/switchextra/CaseTest.java                                                                            Passed. Execution successful
+tools/javac/switchextra/DefiniteAssignment1.java                                                                 Passed. Execution successful
+tools/javac/switchextra/DefiniteAssignment2.java                                                                 Passed. Compilation failed as expected
+tools/javac/switchextra/MultipleLabelsExpression.java                                                            Passed. Execution successful
+tools/javac/switchextra/MultipleLabelsStatement.java                                                             Passed. Execution successful
+tools/javac/switchextra/RuleParsingTest.java                                                                     Passed. Execution successful
+tools/javac/switchextra/SwitchArrowBrokenConstant.java                                                           Passed. Compilation failed as expected
+tools/javac/switchextra/SwitchNoExtraTypes.java                                                                  Passed. Compilation failed as expected
+tools/javac/switchextra/SwitchObject.java                                                                        Passed. Compilation failed as expected
+tools/javac/switchextra/SwitchStatementArrow.java                                                                Passed. Execution successful
+tools/javac/switchextra/SwitchStatementBroken.java                                                               Passed. Compilation failed as expected
+tools/javac/switchextra/SwitchStatementBroken2.java                                                              Passed. Compilation failed as expected
+tools/javac/switchextra/SwitchStatementScopesIsolated.java                                                       Passed. Compilation failed as expected
+tools/javac/switchnull/SwitchNullDisabled.java                                                                   Passed. Compilation failed as expected
+tools/javac/sym/ElementStructureTest.java                                                                        Passed. Execution successful
+tools/javac/synthesize/Main.java                                                                                 Passed. Execution successful
+tools/javac/tree/8067914/NukeExtraCast.java                                                                      Passed. Execution successful
+tools/javac/tree/ArrayTypeToString.java                                                                          Passed. Compilation successful
+tools/javac/tree/ClassTreeTest.java                                                                              Passed. Execution successful
+tools/javac/tree/DocCommentToplevelTest.java                                                                     Passed. Execution successful
+tools/javac/tree/JavacTreeScannerTest.java                                                                       Passed. Execution successful
+tools/javac/tree/MakeLiteralTest.java                                                                            Passed. Execution successful
+tools/javac/tree/MakeQualIdent.java                                                                              Passed. Execution successful
+tools/javac/tree/MakeTypeTest.java                                                                               Passed. Compilation successful
+tools/javac/tree/MissingSemicolonTest.java                                                                       Passed. Execution successful
+tools/javac/tree/NewArrayPretty.java                                                                             Passed. Execution successful
+tools/javac/tree/NewClassDefEnclosing.java                                                                       Passed. Execution successful
+tools/javac/tree/NoPrivateTypesExported.java                                                                     Passed. Compilation successful
+tools/javac/tree/PrettySimpleStringTest.java                                                                     Passed. Execution successful
+tools/javac/tree/ScopeClassHeaderTest.java                                                                       Passed. Execution successful
+tools/javac/tree/ScopeTest.java                                                                                  Passed. Execution successful
+tools/javac/tree/SourceDocTreeScannerTest.java                                                                   Passed. Execution successful
+tools/javac/tree/SourceTreeScannerTest.java                                                                      Passed. Execution successful
+tools/javac/tree/T6963934.java                                                                                   Passed. Execution successful
+tools/javac/tree/T6993305.java                                                                                   Passed. Execution successful
+tools/javac/tree/T8024415.java                                                                                   Passed. Execution successful
+tools/javac/tree/TestPrettyDocComment.java                                                                       Passed. Execution successful
+tools/javac/tree/TestToString.java                                                                               Passed. Execution successful
+tools/javac/tree/TreeKindTest.java                                                                               Passed. Execution successful
+tools/javac/tree/TreePosRoundsTest.java                                                                          Passed. Execution successful
+tools/javac/tree/TreePosTest.java                                                                                Passed. Execution successful
+tools/javac/tree/TypeAnnotationsPretty.java                                                                      Passed. Execution successful
+tools/javac/tree/VarTree.java                                                                                    Passed. Execution successful
+tools/javac/treeannotests/AnnoTreeTests.java                                                                     Passed. Compilation successful
+tools/javac/typeVariableCast/TypeVariableCastTest.java                                                           Passed. Execution successful
+tools/javac/types/BadSigTest.java                                                                                Passed. Execution successful
+tools/javac/types/BoxingConversionTest.java                                                                      Passed. Execution successful
+tools/javac/types/CastObjectToPrimitiveTest.java                                                                 Passed. Compilation successful
+tools/javac/types/CastTest.java                                                                                  Passed. Execution successful
+tools/javac/types/CastToTypeVarTest.java                                                                         Passed. Compilation successful
+tools/javac/types/CastTypeVarToPrimitiveTest.java                                                                Passed. Compilation successful
+tools/javac/types/GenericTypeWellFormednessTest.java                                                             Passed. Execution successful
+tools/javac/types/PrimitiveConversionTest.java                                                                   Passed. Execution successful
+tools/javac/types/ScopeListenerTest.java                                                                         Passed. Execution successful
+tools/javac/types/TestComparisons.java                                                                           Passed. Execution successful
+tools/javac/types/VarInstanceMemberTest.java                                                                     Passed. Execution successful
+tools/javac/unicode/FirstChar.java                                                                               Passed. Execution successful
+tools/javac/unicode/NonasciiDigit.java                                                                           Passed. Compilation failed as expected
+tools/javac/unicode/SubChar.java                                                                                 Passed. Compilation successful
+tools/javac/unicode/SupplementaryJavaID1.java                                                                    Passed. Execution successful
+tools/javac/unicode/SupplementaryJavaID2.java                                                                    Passed. Compilation failed as expected
+tools/javac/unicode/SupplementaryJavaID3.java                                                                    Passed. Compilation failed as expected
+tools/javac/unicode/SupplementaryJavaID4.java                                                                    Passed. Compilation failed as expected
+tools/javac/unicode/SupplementaryJavaID5.java                                                                    Passed. Compilation failed as expected
+tools/javac/unicode/SupplementaryJavaID6.java                                                                    Passed. Execution successful
+tools/javac/unicode/TripleQuote.java                                                                             Passed. Compilation failed as expected
+tools/javac/unicode/UnicodeAtEOL.java                                                                            Passed. Compilation successful
+tools/javac/unicode/UnicodeCommentDelimiter.java                                                                 Passed. Compilation successful
+tools/javac/unicode/UnicodeNewline.java                                                                          Passed. Compilation failed as expected
+tools/javac/unicode/UnicodeUnicode.java                                                                          Passed. Compilation successful
+tools/javac/unicode/Unmappable.java                                                                              Passed. Compilation failed as expected
+tools/javac/unit/T6198196.java                                                                                   Passed. Execution successful
+tools/javac/unit/util/convert/EnclosingCandidates.java                                                           Passed. Execution successful
+tools/javac/unit/util/list/AbstractList.java                                                                     Passed. Execution successful
+tools/javac/unit/util/list/FromArray.java                                                                        Passed. Execution successful
+tools/javac/util/BitsTest.java                                                                                   Passed. Execution successful
+tools/javac/util/JavacTaskPoolTest.java                                                                          Passed. Execution successful
+tools/javac/util/NewlineOnlyDiagnostic.java                                                                      Passed. Compilation successful
+tools/javac/util/StringUtilsTest.java                                                                            Passed. Execution successful
+tools/javac/util/T6597678.java                                                                                   Passed. Execution successful
+tools/javac/util/filemanager/TestName.java                                                                       Passed. Execution successful
+tools/javac/util/list/ListBufferTest.java                                                                        Passed. Execution successful
+tools/javac/util/list/TList.java                                                                                 Passed. Execution successful
+tools/javac/var_implicit_lambda/VarInImplicitLambdaNegTest01.java                                                Passed. Compilation failed as expected
+tools/javac/varargs/5088429/T5088429Neg01.java                                                                   Passed. Compilation failed as expected
+tools/javac/varargs/5088429/T5088429Neg02.java                                                                   Passed. Compilation failed as expected
+tools/javac/varargs/5088429/T5088429Pos01.java                                                                   Passed. Compilation successful
+tools/javac/varargs/5088429/T5088429Pos02.java                                                                   Passed. Compilation successful
+tools/javac/varargs/6199075/T6199075.java                                                                        Passed. Execution successful
+tools/javac/varargs/6313164/T6313164.java                                                                        Passed. Compilation failed as expected
+tools/javac/varargs/6313164/T7175433.java                                                                        Passed. Compilation failed as expected
+tools/javac/varargs/6569633/T6569633.java                                                                        Passed. Compilation failed as expected
+tools/javac/varargs/6730476/T6730476a.java                                                                       Passed. Compilation successful
+tools/javac/varargs/6730476/T6730476b.java                                                                       Passed. Compilation successful
+tools/javac/varargs/6806876/T6806876.java                                                                        Passed. Compilation failed as expected
+tools/javac/varargs/6993978/T6993978neg.java                                                                     Passed. Compilation failed as expected
+tools/javac/varargs/7042566/T7042566.java                                                                        Passed. Execution successful
+tools/javac/varargs/7043922/T7043922.java                                                                        Passed. Execution successful
+tools/javac/varargs/7097436/T7097436.java                                                                        Passed. Compilation failed as expected
+tools/javac/varargs/8055514/T8055514.java                                                                        Passed. Compilation failed as expected
+tools/javac/varargs/Anon.java                                                                                    Passed. Compilation successful
+tools/javac/varargs/BadSyntax2.java                                                                              Passed. Compilation successful
+tools/javac/varargs/ElementTypeMissingTest.java                                                                  Passed. Compilation failed as expected
+tools/javac/varargs/MethodHandleCrash.java                                                                       Passed. Compilation successful
+tools/javac/varargs/T6746184.java                                                                                Passed. Execution successful
+tools/javac/varargs/T7013865.java                                                                                Passed. Compilation successful
+tools/javac/varargs/Varargs1.java                                                                                Passed. Execution successful
+tools/javac/varargs/VarargsOverride.java                                                                         Passed. Compilation successful
+tools/javac/varargs/Warn1.java                                                                                   Passed. Compilation successful
+tools/javac/varargs/Warn2.java                                                                                   Passed. Compilation successful
+tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest.java                                          Passed. Compilation successful
+tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest2.java                                         Passed. Compilation successful
+tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest3.java                                         Passed. Compilation successful
+tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest4.java                                         Passed. Compilation successful
+tools/javac/varargs/access/VarargsInferredPrivateType.java                                                       Passed. Compilation failed as expected
+tools/javac/varargs/warning/Warn2.java                                                                           Passed. Compilation successful
+tools/javac/varargs/warning/Warn3.java                                                                           Passed. Compilation successful
+tools/javac/varargs/warning/Warn4.java                                                                           Passed. Execution successful
+tools/javac/varargs/warning/Warn5.java                                                                           Passed. Execution successful
+tools/javac/varargs/warning/Warn6.java                                                                           Passed. Compilation successful
+tools/javac/versions/SourceTargetTest.java                                                                       Passed. Execution successful
+tools/javac/versions/Versions.java                                                                               Passed. Execution successful
+tools/javac/warnings/6594914/ImplicitCompilation.java                                                            Passed. Compilation successful
+tools/javac/warnings/6594914/T6594914a.java                                                                      Passed. Compilation successful
+tools/javac/warnings/6747671/T6747671.java                                                                       Passed. Compilation successful
+tools/javac/warnings/6885255/T6885255.java                                                                       Passed. Compilation successful
+tools/javac/warnings/7090499/T7090499.java                                                                       Passed. Compilation failed as expected
+tools/javac/warnings/AuxiliaryClass/ClassUsingAnotherAuxiliary.java                                              Passed. Compilation failed as expected
+tools/javac/warnings/AuxiliaryClass/ClassUsingAuxiliary.java                                                     Passed. Compilation failed as expected
+tools/javac/warnings/AuxiliaryClass/SelfClassWithAux.java                                                        Passed. Compilation successful
+tools/javac/warnings/DepAnn.java                                                                                 Passed. Compilation successful
+tools/javac/warnings/Deprecation.java                                                                            Passed. Compilation successful
+tools/javac/warnings/DeprecationSE8Test.java                                                                     Passed. Compilation successful
+tools/javac/warnings/DivZero.java                                                                                Passed. Compilation successful
+tools/javac/warnings/FallThrough.java                                                                            Passed. Compilation successful
+tools/javac/warnings/Finally.java                                                                                Passed. Compilation successful
+tools/javac/warnings/MaxDiagsRecompile.java                                                                      Passed. Compilation failed as expected
+tools/javac/warnings/MaxWarnsRecompile.java                                                                      Passed. Compilation successful
+tools/javac/warnings/NestedDeprecation/NestedDeprecation.java                                                    Passed. Compilation successful
+tools/javac/warnings/Removal.java                                                                                Passed. Execution successful
+tools/javac/warnings/Serial.java                                                                                 Passed. Compilation successful
+tools/javac/warnings/T6763518.java                                                                               Passed. Compilation successful
+tools/javac/warnings/Unchecked.java                                                                              Passed. Compilation successful
+tools/javac/warnings/VerifyLintDescriptions.java                                                                 Passed. Execution successful
+tools/javac/warnings/suppress/ImplicitTest.java                                                                  Passed. Compilation successful
+tools/javac/warnings/suppress/Overridden.java                                                                    Passed. Execution successful
+tools/javac/warnings/suppress/OverriddenSuppressed.java                                                          Passed. Compilation successful
+tools/javac/warnings/suppress/PackageInfo.java                                                                   Passed. Compilation successful
+tools/javac/warnings/suppress/T6480588.java                                                                      Passed. Execution successful
+tools/javac/warnings/suppress/T6707032.java                                                                      Passed. Execution successful
+tools/javac/warnings/suppress/T8021112a.java                                                                     Passed. Compilation successful
+tools/javac/warnings/suppress/T8021112b.java                                                                     Passed. Execution successful
+tools/javac/warnings/suppress/T8069094.java                                                                      Passed. Execution successful
+tools/javap/4111861/T4111861.java                                                                                Passed. Execution successful
+tools/javap/4798312/JavapShouldLoadClassesFromRTJarTest.java                                                     Passed. Execution successful
+tools/javap/4866831/PublicInterfaceTest.java                                                                     Passed. Execution successful
+tools/javap/4870651/T4870651.java                                                                                Passed. Execution successful
+tools/javap/6937244/T6937244.java                                                                                Passed. Execution successful
+tools/javap/6937244/T6937244A.java                                                                               Passed. Execution successful
+tools/javap/8006334/JavapTaskCtorFailWithNPE.java                                                                Passed. Execution successful
+tools/javap/8007907/JavapReturns0AfterClassNotFoundTest.java                                                     Passed. Execution successful
+tools/javap/AccessModifiers.java                                                                                 Passed. Execution successful
+tools/javap/AnnoTest.java                                                                                        Passed. Execution successful
+tools/javap/BadAttributeLength.java                                                                              Passed. Execution successful
+tools/javap/BadAttributeName.java                                                                                Passed. Execution successful
+tools/javap/BoundsTypeVariableTest.java                                                                          Passed. Execution successful
+tools/javap/ControlCharTest.java                                                                                 Passed. Execution successful
+tools/javap/DescriptorTest.java                                                                                  Passed. Execution successful
+tools/javap/ExtPath.java                                                                                         Passed. Execution successful
+tools/javap/InvalidOptions.java                                                                                  Passed. Execution successful
+tools/javap/MethodParameters.java                                                                                Passed. Execution successful
+tools/javap/StackMapTableTest.java                                                                               Passed. Execution successful
+tools/javap/T4075403.java                                                                                        Passed. Execution successful
+tools/javap/T4459541.java                                                                                        Passed. Execution successful
+tools/javap/T4501660.java                                                                                        Passed. Execution successful
+tools/javap/T4501661.java                                                                                        Passed. Execution successful
+tools/javap/T4777949.java                                                                                        Passed. Execution successful
+tools/javap/T4876942.java                                                                                        Passed. Execution successful
+tools/javap/T4880663.java                                                                                        Passed. Execution successful
+tools/javap/T4880672.java                                                                                        Passed. Execution successful
+tools/javap/T4884240.java                                                                                        Passed. Execution successful
+tools/javap/T4975569.java                                                                                        Passed. Execution successful
+tools/javap/T6271787.java                                                                                        Passed. Execution successful
+tools/javap/T6474890.java                                                                                        Passed. Execution successful
+tools/javap/T6622216.java                                                                                        Passed. Execution successful
+tools/javap/T6622232.java                                                                                        Passed. Execution successful
+tools/javap/T6622260.java                                                                                        Passed. Execution successful
+tools/javap/T6715251.java                                                                                        Passed. Execution successful
+tools/javap/T6715753.java                                                                                        Passed. Execution successful
+tools/javap/T6715767.java                                                                                        Passed. Execution successful
+tools/javap/T6716452.java                                                                                        Passed. Execution successful
+tools/javap/T6729471.java                                                                                        Passed. Execution successful
+tools/javap/T6824493.java                                                                                        Passed. Execution successful
+tools/javap/T6863746.java                                                                                        Passed. Execution successful
+tools/javap/T6866657.java                                                                                        Passed. Execution successful
+tools/javap/T6868539.java                                                                                        Passed. Execution successful
+tools/javap/T6879371.java                                                                                        Passed. Execution successful
+tools/javap/T6980017.java                                                                                        Passed. Execution successful
+tools/javap/T7004698.java                                                                                        Passed. Execution successful
+tools/javap/T7186925.java                                                                                        Passed. Execution successful
+tools/javap/T7190862.java                                                                                        Passed. Execution successful
+tools/javap/T8032814.java                                                                                        Passed. Execution successful
+tools/javap/T8032819.java                                                                                        Passed. Execution successful
+tools/javap/T8033180.java                                                                                        Passed. Execution successful
+tools/javap/T8033711.java                                                                                        Passed. Execution successful
+tools/javap/T8035104.java                                                                                        Passed. Execution successful
+tools/javap/T8038414.java                                                                                        Passed. Execution successful
+tools/javap/TestClassNameWarning.java                                                                            Passed. Execution successful
+tools/javap/TestSuperclass.java                                                                                  Passed. Execution successful
+tools/javap/WhitespaceTest.java                                                                                  Passed. Execution successful
+tools/javap/classfile/6888367/T6888367.java                                                                      Passed. Execution successful
+tools/javap/classfile/T6887895.java                                                                              Passed. Execution successful
+tools/javap/classfile/deps/T6907575.java                                                                         Passed. Execution successful
+tools/javap/default_methods/JavapNotPrintingDefaultModifierTest.java                                             Passed. Execution successful
+tools/javap/stackmap/StackmapTest.java                                                                           Passed. Execution successful
+tools/javap/typeAnnotations/AnnotationDefaultNewlineTest.java                                                    Passed. Execution successful
+tools/javap/typeAnnotations/InvisibleParameterAnnotationsTest.java                                               Passed. Execution successful
+tools/javap/typeAnnotations/JSR175Annotations.java                                                               Passed. Execution successful
+tools/javap/typeAnnotations/NewArray.java                                                                        Passed. Execution successful
+tools/javap/typeAnnotations/Presence.java                                                                        Passed. Execution successful
+tools/javap/typeAnnotations/PresenceInner.java                                                                   Passed. Execution successful
+tools/javap/typeAnnotations/T6855990.java                                                                        Passed. Execution successful
+tools/javap/typeAnnotations/TypeCasts.java                                                                       Passed. Execution successful
+tools/javap/typeAnnotations/Visibility.java                                                                      Passed. Execution successful
+tools/javap/typeAnnotations/Wildcards.java                                                                       Passed. Execution successful
+tools/jdeprscan/tests/jdk/jdeprscan/TestCSV.java                                                                 Passed. Execution successful
+tools/jdeprscan/tests/jdk/jdeprscan/TestLoad.java                                                                Passed. Execution successful
+tools/jdeprscan/tests/jdk/jdeprscan/TestMethodSig.java                                                           Passed. Execution successful
+tools/jdeprscan/tests/jdk/jdeprscan/TestNotFound.java                                                            Passed. Execution successful
+tools/jdeprscan/tests/jdk/jdeprscan/TestPrims.java                                                               Passed. Execution successful
+tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java                                                             Passed. Execution successful
+tools/jdeprscan/tests/jdk/jdeprscan/TestScan.java                                                                Passed. Execution successful
+tools/jdeps/APIDeps.java                                                                                         Passed. Execution successful
+tools/jdeps/Basic.java                                                                                           Passed. Execution successful
+tools/jdeps/DotFileTest.java                                                                                     Passed. Execution successful
+tools/jdeps/MultiReleaseJar.java                                                                                 Passed. Execution successful
+tools/jdeps/Options.java                                                                                         Passed. Execution successful
+tools/jdeps/VerboseFormat/JdepsDependencyClosure.java                                                            Passed. Execution successful
+tools/jdeps/jdkinternals/RemovedJDKInternals.java                                                                Passed. Execution successful
+tools/jdeps/jdkinternals/ShowReplacement.java                                                                    Passed. Execution successful
+tools/jdeps/listdeps/ListModuleDeps.java                                                                         Passed. Execution successful
+tools/jdeps/missingDeps/MissingDepsTest.java                                                                     Passed. Execution successful
+tools/jdeps/modules/CheckModuleTest.java                                                                         Passed. Execution successful
+tools/jdeps/modules/DotFileTest.java                                                                             Passed. Execution successful
+tools/jdeps/modules/GenModuleInfo.java                                                                           Passed. Execution successful
+tools/jdeps/modules/GenOpenModule.java                                                                           Passed. Execution successful
+tools/jdeps/modules/InverseDeps.java                                                                             Passed. Execution successful
+tools/jdeps/modules/ModuleTest.java                                                                              Passed. Execution successful
+tools/jdeps/modules/SplitPackage.java                                                                            Passed. Execution successful
+tools/jdeps/modules/TransitiveDeps.java                                                                          Passed. Execution successful
+tools/jdeps/modules/UnnamedPackage.java                                                                          Passed. Execution successful
+tools/jdeps/modules/upgrademodulepath/UpgradeModulePathTest.java                                                 Passed. Execution successful
+tools/jdeps/unsupported/JDKUnsupportedTest.java                                                                  Passed. Execution successful
+tools/sjavac/CompileCircularSources.java                                                                         Passed. Execution successful
+tools/sjavac/CompileExcludingDependency.java                                                                     Passed. Execution successful
+tools/sjavac/CompileWithAtFile.java                                                                              Passed. Execution successful
+tools/sjavac/CompileWithInvisibleSources.java                                                                    Passed. Execution successful
+tools/sjavac/CompileWithOverrideSources.java                                                                     Passed. Execution successful
+tools/sjavac/HiddenFiles.java                                                                                    Passed. Execution successful
+tools/sjavac/IdleShutdown.java                                                                                   Passed. Execution successful
+tools/sjavac/IncCompInheritance.java                                                                             Passed. Execution successful
+tools/sjavac/IncCompileChangeNative.java                                                                         Passed. Execution successful
+tools/sjavac/IncCompileDropClasses.java                                                                          Passed. Execution successful
+tools/sjavac/IncCompileNoChanges.java                                                                            Passed. Execution successful
+tools/sjavac/IncCompileUpdateNative.java                                                                         Passed. Execution successful
+tools/sjavac/IncludeExcludePatterns.java                                                                         Passed. Execution successful
+tools/sjavac/JavacOptionPrep.java                                                                                Passed. Execution successful
+tools/sjavac/NoState.java                                                                                        Passed. Execution successful
+tools/sjavac/OptionDecoding.java                                                                                 Passed. Execution successful
+tools/sjavac/OverlappingSrcDst.java                                                                              Passed. Execution successful
+tools/sjavac/PackagePathMismatch.java                                                                            Passed. Execution successful
+tools/sjavac/ParallelCompilations.java                                                                           Passed. Execution successful
+tools/sjavac/PermittedArtifact.java                                                                              Passed. Execution successful
+tools/sjavac/PooledExecution.java                                                                                Passed. Execution successful
+tools/sjavac/Serialization.java                                                                                  Passed. Execution successful
+tools/sjavac/StateDir.java                                                                                       Passed. Execution successful


### PR DESCRIPTION
Related to https://github.com/checkstyle/checkstyle/pull/8634, this file is to be used for testing Checkstyle's ability to parse openjdk14 test files, mostly from `jdk14/test/langtools/tools/`.  Sourced from https://download.java.net/openjdk/testresults/14/archives/36/langtools-36-summary.txt . 