### PR TITLE
minor: rename all instances of "record" as identifier to "checkstyleRecord"

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffReport.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffReport.java
@@ -129,8 +129,8 @@ public final class DiffReport {
     private static boolean isInList(List<CheckstyleRecord> list,
             CheckstyleRecord testedRecord) {
         boolean belongsToList = false;
-        for (CheckstyleRecord record : list) {
-            if (testedRecord.specificEquals(record)) {
+        for (CheckstyleRecord checkstyleRecord : list) {
+            if (testedRecord.specificEquals(checkstyleRecord)) {
                 belongsToList = true;
                 break;
             }

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
@@ -173,14 +173,14 @@ public final class CheckstyleTextParser {
                 xref = patchFile.getPath();
             }
 
-            final CheckstyleRecord record = new CheckstyleRecord(diff.getIndex(),
+            final CheckstyleRecord checkstyleRecord = new CheckstyleRecord(diff.getIndex(),
                     diff.getLineNo() + 1, 1, DEFAULT_SEVERITY, DEFAULT_SOURCE, diff.getLine(),
                     xref);
 
             statistics.addSeverityRecord(DEFAULT_SEVERITY, diff.getIndex());
             statistics.addModuleRecord(DEFAULT_SOURCE, diff.getIndex());
 
-            records.add(record);
+            records.add(checkstyleRecord);
         }
 
         diffReport.addRecords(records, filePath);
@@ -219,13 +219,14 @@ public final class CheckstyleTextParser {
         final Statistics statistics = diffReport.getStatistics();
         final List<CheckstyleRecord> records = new ArrayList<>();
 
-        final CheckstyleRecord record = new CheckstyleRecord(otherIndex, 1, 1, DEFAULT_SEVERITY,
+        final CheckstyleRecord checkstyleRecord =
+            new CheckstyleRecord(otherIndex, 1, 1, DEFAULT_SEVERITY,
                 DEFAULT_SOURCE, "File not found.", xref);
 
         statistics.addSeverityRecord(DEFAULT_SEVERITY, otherIndex);
         statistics.addModuleRecord(DEFAULT_SOURCE, otherIndex);
 
-        records.add(record);
+        records.add(checkstyleRecord);
 
         diffReport.addRecords(records, filePath);
 

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -163,10 +163,10 @@ public final class SiteGenerator {
 
             xrefGenerator.reset();
 
-            for (CheckstyleRecord record : records) {
-                final String xreference = xrefGenerator.generateXref(record.getXref(),
+            for (CheckstyleRecord checkstyleRecord : records) {
+                final String xreference = xrefGenerator.generateXref(checkstyleRecord.getXref(),
                             paths.isShortFilePaths());
-                record.setXref(xreference);
+                checkstyleRecord.setXref(xreference);
             }
 
             if (refFilesPath != null) {


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/8766#issuecomment-681989527:
> from wercker:
```
[INFO] --- maven-checkstyle-plugin:3.1.1:check (check) @ patch-diff-report-tool ---
[INFO] There are 4 errors reported by Checkstyle 8.36-SNAPSHOT with ../../../config/checkstyle_checks.xml ruleset.
[ERROR] src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java:[176,36] (naming) IllegalIdentifierName: Name 'record' must match pattern '(?i)^(?!(record|yield|var)$).+$'.
[ERROR] src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java:[222,32] (naming) IllegalIdentifierName: Name 'record' must match pattern '(?i)^(?!(record|yield|var)$).+$'.
[ERROR] src/main/java/com/github/checkstyle/data/DiffReport.java:[132,31] (naming) IllegalIdentifierName: Name 'record' must match pattern '(?i)^(?!(record|yield|var)$).+$'.
[ERROR] src/main/java/com/github/checkstyle/site/SiteGenerator.java:[166,35] (naming) IllegalIdentifierName: Name 'record' must match pattern '(?i)^(?!(record|yield|var)$).+$'.
```

These identifiers need to be changed in order for wercker to pass with new check `IllegalIdentifierCheck`.