### PR TITLE
Issue #344: add multi-thread support to CheckstyleReportsParser

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/CliArgsValidator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/CliArgsValidator.java
@@ -21,7 +21,7 @@ package com.github.checkstyle;
 
 import java.nio.file.Files;
 
-import com.github.checkstyle.data.CliPaths;
+import com.github.checkstyle.data.CliOptions;
 import com.github.checkstyle.data.CompareMode;
 
 /**
@@ -52,7 +52,7 @@ public final class CliArgsValidator {
      * @throws IllegalArgumentException
      *             on failure of any check.
      */
-    public static void checkPaths(CliPaths paths) throws IllegalArgumentException {
+    public static void checkPaths(CliOptions paths) throws IllegalArgumentException {
         if (paths.getPatchReportPath() == null) {
             throw new IllegalArgumentException("obligatory argument --patchReportPath "
                     + "not present, -h for help");

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliOptions.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliOptions.java
@@ -22,11 +22,11 @@ package com.github.checkstyle.data;
 import java.nio.file.Path;
 
 /**
- * POJO class that hold input paths.
+ * POJO class that hold input options.
  *
  * @author attatrol
  */
-public final class CliPaths {
+public final class CliOptions {
     /**
      * Option to control which type of diff comparison to do.
      */
@@ -68,6 +68,12 @@ public final class CliPaths {
     private final boolean shortFilePaths;
 
     /**
+     * Switch specifying if report generation should be done in a single-threaded
+     * or multi-threaded mode.
+     */
+    private final ThreadingMode threadingMode;
+
+    /**
      * POJO ctor.
      *
      * @param compareMode
@@ -75,22 +81,24 @@ public final class CliPaths {
      * @param baseReportPath
      *        path to the base checkstyle-report.xml.
      * @param patchReportPath
-     *        path to the patch checkstyle-report.xml.
+ *        path to the patch checkstyle-report.xml.
      * @param refFilesPath
-     *        path to the data, tested by checkstyle.
+*        path to the data, tested by checkstyle.
      * @param outputPath
-     *        path to the result site.
-     * @param patchConfigPath
-     *        path to the configuration of the base report.
+*        path to the result site.
      * @param baseConfigPath
-     *        path to the configuration of the patch report.
+*        path to the configuration of the patch report.
+     * @param patchConfigPath
+*        path to the configuration of the base report.
      * @param shortFilePaths
-     *           {@code true} if only short file names should be used with no paths.
+*           {@code true} if only short file names should be used with no paths.
+     * @param threadingMode
+*           type of threading mode to use.
      */
     // -@cs[ParameterNumber] Helper class to pass all CLI attributes around.
-    public CliPaths(CompareMode compareMode, Path baseReportPath, Path patchReportPath,
+    public CliOptions(CompareMode compareMode, Path baseReportPath, Path patchReportPath,
             Path refFilesPath, Path outputPath, Path baseConfigPath, Path patchConfigPath,
-            boolean shortFilePaths) {
+            boolean shortFilePaths, ThreadingMode threadingMode) {
         this.compareMode = compareMode;
         this.baseReportPath = baseReportPath;
         this.patchReportPath = patchReportPath;
@@ -99,6 +107,7 @@ public final class CliPaths {
         this.baseConfigPath = baseConfigPath;
         this.patchConfigPath = patchConfigPath;
         this.shortFilePaths = shortFilePaths;
+        this.threadingMode = threadingMode;
     }
 
     public CompareMode getCompareMode() {
@@ -131,6 +140,10 @@ public final class CliPaths {
 
     public boolean isShortFilePaths() {
         return shortFilePaths;
+    }
+
+    public ThreadingMode getThreadingMode() {
+        return threadingMode;
     }
 
     /**

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffUtils.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/DiffUtils.java
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.data;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Utility class to calculate difference between 2 sorted lists.
+ */
+public final class DiffUtils {
+
+    /** Private ctor. */
+    private DiffUtils() {
+    }
+
+    /**
+     * Creates difference between 2 sorted lists.
+     *
+     * @param firstList
+     *        the first list.
+     * @param secondList
+     *        the second list.
+     * @param <T> the type of elements.
+     * @return the difference list.
+     */
+    public static <T extends Comparable<T>> List<T> produceDiff(
+            List<T> firstList, List<T> secondList) {
+        final List<T> result;
+        if (firstList.isEmpty()) {
+            result = secondList;
+        }
+        else if (secondList.isEmpty()) {
+            result = firstList;
+        }
+        else {
+            result = produceDiff(firstList.iterator(), secondList.iterator());
+        }
+        return result;
+    }
+
+    /**
+     * Creates difference between 2 non-empty iterators.
+     *
+     * @param firstIterator
+     *        the first iterator.
+     * @param secondIterator
+     *        the second iterator.
+     * @param <T> the type of elements.
+     * @return the difference list (always sorted).
+     */
+    private static <T extends Comparable<T>> List<T> produceDiff(
+            Iterator<T> firstIterator, Iterator<T> secondIterator) {
+        T firstVal = firstIterator.next();
+        T secondVal = secondIterator.next();
+        final List<T> result = new ArrayList<>();
+        while (true) {
+            final int diff = firstVal.compareTo(secondVal);
+            if (diff < 0) {
+                result.add(firstVal);
+                if (!firstIterator.hasNext()) {
+                    result.add(secondVal);
+                    break;
+                }
+                firstVal = firstIterator.next();
+            }
+            else if (diff > 0) {
+                result.add(secondVal);
+                if (!secondIterator.hasNext()) {
+                    result.add(firstVal);
+                    break;
+                }
+                secondVal = secondIterator.next();
+            }
+            else {
+                if (!firstIterator.hasNext() || !secondIterator.hasNext()) {
+                    break;
+                }
+                firstVal = firstIterator.next();
+                secondVal = secondIterator.next();
+            }
+        }
+        // add tails
+        while (firstIterator.hasNext()) {
+            result.add(firstIterator.next());
+        }
+        while (secondIterator.hasNext()) {
+            result.add(secondIterator.next());
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/ThreadingMode.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/ThreadingMode.java
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.data;
+
+/**
+ * Different threading modes.
+ */
+public enum ThreadingMode {
+    /**
+     * Process files in a single thread.
+     */
+    SINGLE,
+    /**
+     * Process files in multiple threads.
+     */
+    MULTI
+}

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleReportsParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleReportsParser.java
@@ -35,6 +35,7 @@ import javax.xml.stream.events.XMLEvent;
 import com.github.checkstyle.data.CheckstyleRecord;
 import com.github.checkstyle.data.DiffReport;
 import com.github.checkstyle.data.Statistics;
+import com.github.checkstyle.data.ThreadingMode;
 
 /**
  * Contains logics of the StaX parser for the checkstyle xml reports.
@@ -116,6 +117,8 @@ public final class CheckstyleReportsParser {
      *        path to base XML file.
      * @param patchXml
      *        path to patch XML file.
+     * @param threadingMode
+     *        type of threading mode to use.
      * @param portionSize
      *        single portion of XML file processed at once by any parser.
      * @return parsed content.
@@ -124,9 +127,10 @@ public final class CheckstyleReportsParser {
      * @throws XMLStreamException
      *         on internal parser error.
      */
-    public static DiffReport parse(Path baseXml, Path patchXml, int portionSize)
+    public static DiffReport parse(Path baseXml, Path patchXml,
+                    ThreadingMode threadingMode, int portionSize)
                     throws FileNotFoundException, XMLStreamException {
-        final DiffReport content = new DiffReport();
+        final DiffReport content = new DiffReport(threadingMode);
         final XMLEventReader baseReader = StaxUtils.createReader(baseXml);
         final XMLEventReader patchReader = StaxUtils.createReader(patchXml);
         while (baseReader.hasNext() || patchReader.hasNext()) {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
@@ -30,6 +30,7 @@ import java.util.List;
 import com.github.checkstyle.data.CheckstyleRecord;
 import com.github.checkstyle.data.DiffReport;
 import com.github.checkstyle.data.Statistics;
+import com.github.checkstyle.data.ThreadingMode;
 import com.github.checkstyle.parser.JgitUtils.JgitDifference;
 
 /**
@@ -72,12 +73,15 @@ public final class CheckstyleTextParser {
      *            path to base directory.
      * @param patchReport
      *            path to patch directory.
+     * @param threadingMode
+     *            type of threading mode to use.
      * @return parsed content.
      * @throws IOException
      *             if there is a problem accessing a file.
      */
-    public static DiffReport parse(Path baseReport, Path patchReport) throws IOException {
-        final DiffReport content = new DiffReport();
+    public static DiffReport parse(Path baseReport, Path patchReport, ThreadingMode threadingMode)
+            throws IOException {
+        final DiffReport content = new DiffReport(threadingMode);
         final StringListIterator baseReader = getFiles(baseReport);
         final StringListIterator patchReader = getFiles(patchReport);
         while (true) {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -33,7 +33,7 @@ import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 
 import com.github.checkstyle.Main;
 import com.github.checkstyle.data.CheckstyleRecord;
-import com.github.checkstyle.data.CliPaths;
+import com.github.checkstyle.data.CliOptions;
 import com.github.checkstyle.data.DiffReport;
 import com.github.checkstyle.data.MergedConfigurationModule;
 import com.github.checkstyle.data.Statistics;
@@ -81,7 +81,7 @@ public final class SiteGenerator {
      *         on failure to write site to disc.
      */
     public static void generate(DiffReport diffReport, MergedConfigurationModule diffConfiguration,
-            CliPaths paths) throws IOException {
+            CliOptions paths) throws IOException {
         // setup thymeleaf engine
         final TemplateEngine tplEngine = getTemplateEngine();
         // setup xreference generator
@@ -147,16 +147,16 @@ public final class SiteGenerator {
      *        file writer.
      * @param diffReport
      *        difference between two checkstyle reports.
-     * @param paths
-     *        CLI paths.
+     * @param options
+     *        CLI options.
      * @param xrefGenerator
      *        xReference generator.
      */
     private static void generateBody(TemplateEngine tplEngine, FileWriter writer,
-            DiffReport diffReport, CliPaths paths, XrefGenerator xrefGenerator) {
+            DiffReport diffReport, CliOptions options, XrefGenerator xrefGenerator) {
         final AnchorCounter anchorCounter = new AnchorCounter();
 
-        final Path refFilesPath = paths.getRefFilesPath();
+        final Path refFilesPath = options.getRefFilesPath();
         for (Map.Entry<String, List<CheckstyleRecord>> entry : diffReport.getRecords().entrySet()) {
             final List<CheckstyleRecord> records = entry.getValue();
             String filename = entry.getKey();
@@ -165,7 +165,7 @@ public final class SiteGenerator {
 
             for (CheckstyleRecord checkstyleRecord : records) {
                 final String xreference = xrefGenerator.generateXref(checkstyleRecord.getXref(),
-                            paths.isShortFilePaths());
+                            options.isShortFilePaths());
                 checkstyleRecord.setXref(xreference);
             }
 

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/DiffUtilsTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/DiffUtilsTest.java
@@ -1,0 +1,134 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.github.checkstyle.data.DiffUtils;
+import com.github.checkstyle.internal.AbstractTest;
+
+public class DiffUtilsTest extends AbstractTest {
+
+    @Test
+    public void testConstructor() throws Exception {
+        assertUtilsClassHasPrivateConstructor(DiffUtils.class);
+    }
+
+    @Test
+    public void testEmptyLists() {
+        final List<Integer> list1 = Collections.emptyList();
+        final List<Integer> list2 = Collections.emptyList();
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected empty list", Collections.emptyList(), actual);
+    }
+
+    @Test
+    public void testMatch() {
+        final List<Integer> list1 = Arrays.asList(1, 2, 3);
+        final List<Integer> list2 = Arrays.asList(1, 2, 3);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected empty list", Collections.emptyList(), actual);
+    }
+
+    @Test
+    public void testOddEven() {
+        final List<Integer> list1 = Arrays.asList(1, 3, 5);
+        final List<Integer> list2 = Arrays.asList(2, 4, 6);
+        final List<Integer> expected = Arrays.asList(1, 2, 3, 4, 5, 6);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected [1, 2, 3, 4, 5, 6]", expected, actual);
+    }
+
+    @Test
+    public void testEmptyLeft() {
+        final List<Integer> list1 = Collections.emptyList();
+        final List<Integer> list2 = Arrays.asList(1, 2, 3);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected list2", list2, actual);
+    }
+
+    @Test
+    public void testEmptyRight() {
+        final List<Integer> list1 = Arrays.asList(1, 2, 3);
+        final List<Integer> list2 = Collections.emptyList();
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected list1", list1, actual);
+    }
+
+    @Test
+    public void testLeftTail() {
+        final List<Integer> list1 = Arrays.asList(1, 2, 3, 4);
+        final List<Integer> list2 = Arrays.asList(1, 2);
+        final List<Integer> expected = Arrays.asList(3, 4);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected [3, 4]", expected, actual);
+    }
+
+    @Test
+    public void testRightTail() {
+        final List<Integer> list1 = Arrays.asList(1, 2);
+        final List<Integer> list2 = Arrays.asList(1, 2, 4, 5);
+        final List<Integer> expected = Arrays.asList(4, 5);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected [4, 5]", expected, actual);
+    }
+
+    @Test
+    public void testLeftLower() {
+        final List<Integer> list1 = Arrays.asList(1, 2);
+        final List<Integer> list2 = Arrays.asList(4, 5);
+        final List<Integer> expected = Arrays.asList(1, 2, 4, 5);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected [1, 2, 4, 5]", expected, actual);
+    }
+
+    @Test
+    public void testRightLower() {
+        final List<Integer> list1 = Arrays.asList(4, 5);
+        final List<Integer> list2 = Arrays.asList(1, 2);
+        final List<Integer> expected = Arrays.asList(1, 2, 4, 5);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected [1, 2, 4, 5]", expected, actual);
+    }
+
+    @Test
+    public void testLeftHeadTail() {
+        final List<Integer> list1 = Arrays.asList(1, 2, 3, 5, 6, 7);
+        final List<Integer> list2 = Arrays.asList(3, 4, 5);
+        final List<Integer> expected = Arrays.asList(1, 2, 4, 6, 7);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected [1, 2, 4, 6, 7]", expected, actual);
+    }
+
+    @Test
+    public void testRightHeadTail() {
+        final List<Integer> list1 = Arrays.asList(3, 4, 5);
+        final List<Integer> list2 = Arrays.asList(1, 2, 3, 5, 6, 7);
+        final List<Integer> expected = Arrays.asList(1, 2, 4, 6, 7);
+        final List<Integer> actual = DiffUtils.produceDiff(list1, list2);
+        Assert.assertEquals("Expected [1, 2, 4, 6, 7]", expected, actual);
+    }
+
+}

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
@@ -48,7 +48,9 @@ public class MainTest extends AbstractTest {
                 + "\t--output - path to store the resulting diff report (optional,"
                 + " if absent then default path will be used:"
                 + " ~/XMLDiffGen_report_yyyy.mm.dd_hh_mm_ss), remember, if this folder"
-                + " exists its content will be purged;\n" + "\t-h - simply shows help message.\n"
+                + " exists its content will be purged;\n"
+                + "\t--threadingMode - which type of threading mode to use: SINGLE or MULTI;\n"
+                + "\t-h - simply shows help message.\n"
                 + "patch-diff-report-tool execution finished.\n", getSystemOut());
     }
 


### PR DESCRIPTION
Issue #344

@rnveach @romani @strkkk
Here is my attempt to speed up the diff report generation

* `CheckstyleRecord` now implements `Comparable`
* The method `specificEquals` now `Comparable::compareTo` as we need the order of records
* The list of records to process is pre-sorted (it has to be already sorted, so it does not take much time)
* The method `produceDiff` now is O(N) as both lists are sorted
* Difference generation is threaded to utilize more CPU and speed up the process
* `PositionOrderComparator` removed
* `produceDiff` now is a generic method and extracted to `DiffUtils` class
* `CliPaths` renamed to `CliOptions`
* New option for threading mode: SINGLE or MULTI

TODO:
- [x]  Do some regression for regression testing
- [x] Add an option to disable multithreading to easily diagnose any problems with threading that may occur in the future