### PR TITLE
Issue #530: Remove JXR library from launch.groovy

### DIFF
--- a/checkstyle-tester/pom.xml
+++ b/checkstyle-tester/pom.xml
@@ -14,7 +14,6 @@
 		<checkstyle-plugin.version>3.1.1</checkstyle-plugin.version>
 		<checkstyle.version>8.39-SNAPSHOT</checkstyle.version>
 		<sevntu-checkstyle.version>1.38.0</sevntu-checkstyle.version>
-		<jxr-plugin.version>2.5</jxr-plugin.version>
 		<checkstyle.config.location>https://raw.githubusercontent.com/checkstyle/checkstyle/master/src/main/resources/google_checks.xml</checkstyle.config.location>
 		<checkstyle.failsOnError>true</checkstyle.failsOnError>
 	</properties>
@@ -35,11 +34,6 @@
 						<groupId>com.github.sevntu-checkstyle</groupId>
 						<artifactId>sevntu-checks</artifactId>
 						<version>${sevntu-checkstyle.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-jxr-plugin</artifactId>
-						<version>${jxr-plugin.version}</version>
 					</dependency>
 				</dependencies>
 	        </plugin>
@@ -70,17 +64,6 @@
 					<failsOnError>${checkstyle.failsOnError}</failsOnError>
 				</configuration>
 			</plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jxr-plugin</artifactId>
-            <version>${jxr-plugin.version}</version>
-            <!-- plugin do not have ability to define followinng by system property -->
-            <configuration>
-              <excludes>
-                <exclude>**/.ci-temp/**/*</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
 
 		</plugins>
 	</reporting>


### PR DESCRIPTION
Issue #530: Remove JXR library from launch.groovy
Ok, I wanted to provide as much proof as possible that this change has no ill effects; please let me know what else I can show. 

First, a simple example using two repos that I created (note that my `zsh` prompt shows the branch that I am currently on, as well as my notes).
One has non-compilable code that should cause exception (`broken-repo`) and one has compilable code (`not-broken`) that should( and does) allow for a `checkstyle-results.xml` to be generated: https://gist.github.com/nmancus1/d097e9654130329200849742ccf0971c

If anyone would like to verify the above, here are the projects file lines:
```
#broken|git|https://github.com/nmancus1/broken-repo.git|master||
#not-broken|git|https://github.com/nmancus1/not-broken.git|master||
```

Note at the end of the gist above, I diff the two `checkstyle-result.xml` files, successfully.
This shows that `launch.groovy` works as intended after removal of JXR and associated code in `launch.groovy`.
The only difference in the end result of `launch.groovy` is that the final report is not correctly cross-linked, as shown in https://github.com/checkstyle/contribution/pull/527#issuecomment-750363419. This is not a problem, because we only use launch.groovy to create `checkstyle-result.xml` files and validate that checkstyle can parse specified repositories.

Next, `diff.groovy` uses `launch.groovy` to create `checkstyle-result.xml` files that it compares across branches. So, as proof that `diff.groovy` still functions as intended, I ran a diff report with config and projects file from https://github.com/checkstyle/checkstyle/pull/9135, found here: https://nmancus1.github.io/remove-jxr-avoidescapes-diff/diff/index.html . ~~It looks like we have lost the links to source files with violations.  I am looking into this now, marked as draft.~~