### PR TITLE
config: remove OpenJDK repos that cause issue with regression

### DIFF
--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -12,8 +12,6 @@
 #openjdk8|hg|http://hg.openjdk.java.net/jdk8/jdk8/jdk/|default|
 #All details at checkstyle/checkstyle#3033: ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
 #openjdk9|hg|http://hg.openjdk.java.net/jdk9/jdk9/jdk/|default|**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
-#openjdk10|hg|http://hg.openjdk.java.net/jdk10/jdk10/jdk/|default|**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
-#openjdk11|git|https://github.com/openjdk/jdk11u|master||
 guava|git|https://github.com/google/guava|v28.2||
 
 #spotbugs|git|https://github.com/spotbugs/spotbugs|3.1.2||


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/8177#issuecomment-774805912 and lots of other places, until Checkstyle can parse OpenJDK > 9, we should remove 10 and 11 so that contributors do not get confused when generating reports.