### PR TITLE
config: uncomment many projects in projects-to-test-on.properties

### DIFF
--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -114,7 +114,7 @@ Report configuration([template](https://raw.githubusercontent.com/checkstyle/con
 
 4) **Optional** `Diff Regression projects: {{URI to projects-to-test-on.properties}}`
 Link to custom list of projects([template](https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on.properties)).
-If no list is provided, [default](https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on.properties) list is taken.
+If no list is provided, [default](https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on-for-github-action.properties) list is taken.
 
 5) **Optional** `Report label: here is some label`
 Everything between "Report label: " and EOL will be taken as a label for the report. For the example above,

--- a/checkstyle-tester/projects-to-test-on-for-github-action.properties
+++ b/checkstyle-tester/projects-to-test-on-for-github-action.properties
@@ -1,0 +1,44 @@
+# List of GIT repositories to clone / pull for checking with Checkstyle
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# Please note that bash comments works in this file
+
+# Few projects that delivers set of unusual Java constructions that shall be correctly handled by AST visitor
+# 'InputAllEscapedUnicodeCharacters' must be skipped because it is too big and slows down JXR
+checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/.ci-temp/**/*,**/resources-noncompilable/**/asttreestringprinter/**/*,**/resources-noncompilable/**/filefilters/**/*,**/resources-noncompilable/**/main/**/*,**/resources-noncompilable/**/suppressionsstringprinter/**/*,**/resources-noncompilable/**/gui/**/*,**/resources-noncompilable/**/javadocpropertiesgenerator/**/*,src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParser.java,**/InputAllEscapedUnicodeCharacters.java,**/resources-noncompilable/**/javaparser/InputJavaParser.java,**/resources-noncompilable/**/checks/imports/unusedimports/InputUnusedImportsSingleWordPackage.java
+sevntu-checkstyle|git|https://github.com/sevntu-checkstyle/sevntu.checkstyle|master||
+checkstyle-sonar|git|https://github.com/checkstyle/sonar-checkstyle|master||
+
+#All details at checkstyle/checkstyle#3033: ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
+openjdk9|git|https://github.com/AdoptOpenJDK/openjdk-jdk9.git|master|**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
+guava|git|https://github.com/google/guava|v28.2||
+
+spotbugs|git|https://github.com/spotbugs/spotbugs|3.1.2||
+pmd|git|https://github.com/pmd/pmd|pmd_releases/6.21.0|**/pmd/pmd-java/src/test/**/*,**/pmd/cpd/files/*
+spoon|git|https://github.com/INRIA/spoon.git|spoon-core-8.0.0|
+lombok-ast|git|https://github.com/rzwitserloot/lombok.ast|v0.2|**/lombok-ast/test/**/*
+
+spring-framework|git|https://github.com/spring-projects/spring-framework|v4.1.6.RELEASE||
+hibernate-orm|git|https://github.com/hibernate/hibernate-orm|4.2.19.Final|**/hibernate-orm/documentation/**/*
+elasticsearch|git|https://github.com/elastic/elasticsearch|v1.5.2||
+java-design-patterns|git|https://github.com/iluwatar/java-design-patterns|dd855a376bc025aa61f6816584f79eb9854fe5d7||
+MaterialDesignLibrary|git|https://github.com/navasmdc/MaterialDesignLibrary|1.3||
+Hbase|git|https://github.com/apache/hbase|1.1.0.1||
+Orekit|git|https://github.com/CS-SI/Orekit|8.0.1||
+
+# Those projects are quite old and have lot of legacy code
+apache-ant|git|https://github.com/apache/ant|ANT_194|**/apache-ant/src/tests/**/*,**/apache-ant/src/etc/testcases/
+apache-jsecurity|git|https://github.com/apache/jsecurity|c2ac5b90a467aedb04b52ae50a99e83207d847b3||
+android-launcher|git|https://github.com/android/platform_packages_apps_launcher|android-2.1_r2.1p2||
+apache-struts|git|https://github.com/apache/struts.git|master|**/apache-struts/**/resources/**/*
+
+# Projects which contain a lot of labmda expressions
+infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
+protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
+jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
+RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
+Vavr|git|https://github.com/vavr-io/vavr|v0.9.0||
+
+# custom javadoc tags
+nbia-dcm4che-tools|git|https://github.com/thprakash/nbia-dcm4che-tools|c3591e6f0f84827586db25abded6708e5386ef1a||
+# RequireThis usage
+spring-integration|git|https://github.com/spring-projects/spring-integration.git|master|


### PR DESCRIPTION
Useful for https://github.com/checkstyle/checkstyle/pull/9258

Left commented out
1. Duplicated projects with exclusion (default project list does not need duplication)
2. Open jdk repos (very heavy, can take a lot of time to create report for them)