### PR TITLE
infra: move CI to new diff.groovy

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -32,15 +32,15 @@ patch-diff-report-tool)
   ;;
 
 checkstyle-tester-launch-groovy)
-  checkout_from https://github.com/checkstyle/checkstyle
+  checkout_from "-b issue-529 https://github.com/nmancus1/contribution.git"
   cd .ci-temp/checkstyle
   mvn --batch-mode clean install -Passembly
   cd ../../checkstyle-tester
-  groovy launch.groovy -l projects-for-travis.properties -c my_check.xml -i
+  groovy diff.groovy -l projects-for-travis.properties -c my_check.xml
   ;;
 
 checkstyle-tester-diff-groovy-patch)
-  checkout_from https://github.com/checkstyle/checkstyle
+  checkout_from "-b issue-529 https://github.com/nmancus1/contribution.git"
   cd .ci-temp/checkstyle
   git checkout -b patch-branch
   cd ../../checkstyle-tester
@@ -52,7 +52,7 @@ checkstyle-tester-diff-groovy-patch)
   ;;
 
 checkstyle-tester-diff-groovy-base-patch)
-  checkout_from https://github.com/checkstyle/checkstyle
+  checkout_from "-b issue-529 https://github.com/nmancus1/contribution.git"
   cd .ci-temp/checkstyle
   git checkout -b patch-branch
   cd ../../checkstyle-tester
@@ -61,7 +61,7 @@ checkstyle-tester-diff-groovy-base-patch)
   ;;
 
 checkstyle-tester-diff-groovy-patch-only)
-  checkout_from https://github.com/checkstyle/checkstyle
+  checkout_from "-b issue-529 https://github.com/nmancus1/contribution.git"
   cd .ci-temp/checkstyle
   git checkout -b patch-branch
   cd ../../checkstyle-tester
@@ -72,7 +72,7 @@ checkstyle-tester-diff-groovy-patch-only)
 codenarc)
   cd checkstyle-tester
   ./codenarc.sh . diff.groovy > diff.log && cat diff.log && grep '(p1=0; p2=0; p3=0)' diff.log
-  ./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=11; p3=1)' launch.log
+  #./codenarc.sh . launch.groovy > launch.log && cat launch.log && grep '(p1=0; p2=11; p3=1)' launch.log
   ;;
 
 markdownlint)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,29 +69,29 @@ environment:
       CMD1: "cd patch-diff-report-tool && mvn clean install"
     # checkstyle-tester
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      DESC: "checkstyle-tester (launch.groovy) on guava"
-      CMD1: " git clone -q --depth=10 --branch=master "
-      CMD2: "      https://github.com/checkstyle/checkstyle C:\\projects\\contribution\\checkstyle "
+      DESC: "checkstyle-tester (diff.groovy) on guava"
+      CMD1: " git clone -q --depth=10 --branch=issue-529 "
+      CMD2: "      https://github.com/nmancus1/checkstyle C:\\projects\\contribution\\checkstyle "
       CMD3: " && cd checkstyle && mvn clean install -Passembly"
       CMD4: " "
       CMD5: " && cd ..\\checkstyle-tester "
-      CMD7: " && groovy launch.groovy -l projects-for-travis.properties -c checks-nonjavadoc-error.xml -i\""
+      CMD7: " && groovy diff.groovy -l projects-for-travis.properties -c checks-nonjavadoc-error.xml \""
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       DESC: "checkstyle-tester (diff.groovy) on guava"
-      CMD1: " git clone -q --depth=10 --branch=master "
-      CMD2: "      https://github.com/checkstyle/checkstyle C:\\projects\\contribution\\checkstyle "
+      CMD1: " git clone -q --depth=10 --branch=issue-529 "
+      CMD2: "      https://github.com/nmancus1/checkstyle C:\\projects\\contribution\\checkstyle "
       CMD3: " && cd checkstyle && git checkout -b patch-branch"
       CMD4: " "
       CMD5: " && cd ..\\checkstyle-tester "
-      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -c my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -i -s"
+      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -c my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -s"
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       DESC: "checkstyle-tester (diff.groovy with base and patch configs) on guava"
-      CMD1: " git clone -q --depth=10 --branch=master "
-      CMD2: "      https://github.com/checkstyle/checkstyle C:\\projects\\contribution\\checkstyle "
+      CMD1: " git clone -q --depth=10 --branch=issue-529 "
+      CMD2: "      https://github.com/nmancus1/checkstyle C:\\projects\\contribution\\checkstyle "
       CMD3: " && cd checkstyle && git checkout -b patch-branch"
       CMD4: " "
       CMD5: " && cd ..\\checkstyle-tester "
-      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -i -s"
+      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -s"
 
 build_script:
   - ps: >


### PR DESCRIPTION
infra: move CI to new diff.groovy

Right now, this PR is only a test to make sure that combined diff/launch .groovy will work as intended for contribution CI. Once PR for checkstyle/contribution#529 is merged, we can change the repo in `checkout-from` back to checkstyle's contribution repo and review this PR.