### PR TITLE
 Issue #529: Deprecate launch.groovy and merge functionality into diff.groovy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,7 @@ environment:
       CMD3: " && cd checkstyle && git checkout -b patch-branch"
       CMD4: " "
       CMD5: " && cd ..\\checkstyle-tester "
-      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -c my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -i -s"
+      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -c my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -s"
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       DESC: "checkstyle-tester (diff.groovy with base and patch configs) on guava"
       CMD1: " git clone -q --depth=10 --branch=master "
@@ -91,7 +91,7 @@ environment:
       CMD3: " && cd checkstyle && git checkout -b patch-branch"
       CMD4: " "
       CMD5: " && cd ..\\checkstyle-tester "
-      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -i -s"
+      CMD6: " && groovy diff.groovy -l projects-for-travis.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -s"
 
 build_script:
   - ps: >

--- a/checkstyle-tester/LAUNCH_GROOVY_README.md
+++ b/checkstyle-tester/LAUNCH_GROOVY_README.md
@@ -1,3 +1,5 @@
+# _LAUNCH.GROOVY IS BEING DEPRECATED!!!_
+
 # launch.groovy
 
 Checkstyle report generation

--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -26,7 +26,7 @@ you may require other tools like Git or Mericural, for Git and HG repositories r
 
 `diff.groovy` supports the following command line arguments:
 
-**localGitRepo** (r) - path to the local Checkstyle repository (required);
+**localGitRepo** (r) - path to the local Checkstyle repository (required in diff mode);
 
 **baseBranch** (b) - name of the base branch in local Checkstyle repository
 (optional, if absent, then the tool will use only patchBranch in case the tool
@@ -42,7 +42,7 @@ will finish the execution with the error.
 You must specify 'patchBranch' and 'patchConfig' if the mode is 'single', and 'baseBranch',
 'baseConfig', 'patchBranch', and 'patchConfig' if the mode is 'diff');
 
-**patchBranch** (p) - name of the branch with your changes (required);
+**patchBranch** (p) - name of the branch with your changes (required in diff mode);
 
 **baseConfig** (bc) - path to the base checkstyle configuration file.
 It will be applied to base branch (required if patchConfig is specified);
@@ -64,6 +64,10 @@ This option is useful for Windows users where they are restricted to maximum dir
 **extraMvnRegressionOptions** (xm) - this option can be used to supply extra command line arguments
 to maven during the Checkstyle regression run.  For example, if you want to skip site generation, you
 would add `--extraMvnRegressionOptions "-Dmaven.site.skip=true"` to `diff.groovy` execution.
+
+**allowExcludes** (g) - this option tells `diff.groovy` to allow paths and files defined in the file specified for
+the `--listOfProjects (-l)` argument to be excluded from report generation (optional, default is false). This option is
+ used for files that are not compilable or that Checkstyle cannot parse.
 
 ## Outputs
 

--- a/checkstyle-tester/diff-groovy-regression-config.xml
+++ b/checkstyle-tester/diff-groovy-regression-config.xml
@@ -1,0 +1,638 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <!-- do not change severity to 'error', as that will hide errors caused by exceptions -->
+    <property name="severity" value="warning"/>
+
+    <!-- haltOnException is required for exception fixes and reporting of all exceptions -->
+    <property name="haltOnException" value="false"/>
+
+    <!-- BeforeExecutionFileFilters is required for sources of java9 -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+    <!-- Filters -->
+    <module name="SeverityMatchFilter">
+        <!-- report all violations except ignore -->
+        <property name="severity" value="ignore"/>
+        <property name="acceptOnMatch" value="false"/>
+    </module>
+    <!--     require separate config file
+    <module name="SuppressionFilter">
+      <property name="file" value="${checkstyle.suppressions.file}"/>
+    </module>
+    -->
+    <module name="SuppressWarningsFilter"/>
+
+    <!-- Headers -->
+    <module name="Header">
+        <!-- require separate config file, so we use default
+        <property name="headerFile" value="${checkstyle.header.file}"/>
+        <property name="fileExtensions" value="java"/>
+        <property name="id" value="header"/>
+        -->
+    </module>
+    <module name="RegexpHeader">
+        <!-- require separate config file, so we use default
+      <property name="headerFile" value="${checkstyle.regexp.header.file}"/>
+      <property name="fileExtensions" value="java"/>
+      -->
+    </module>
+
+    <!-- Javadoc Comments -->
+    <module name="JavadocPackage">
+        <property name="allowLegacy" value="false"/>
+    </module>
+
+    <!-- Miscellaneous -->
+    <module name="NewlineAtEndOfFile"/>
+    <module name="Translation">
+        <property name="requiredTranslations" value="de, fr, fi, es, pt, ja, tr, zh"/>
+    </module>
+    <module name="UniqueProperties"/>
+    <module name="OrderedProperties"/>
+
+    <!-- Regexp -->
+    <!-- we need only one instance of Check
+    <module name="RegexpMultiline"/>
+    -->
+    <module name="RegexpMultiline">
+        <property name="format" value="\r?\n[\t ]*\r?\n[\t ]*\r?\n"/>
+        <property name="fileExtensions" value="java,xml,properties"/>
+        <property name="message" value="Unnecessary consecutive lines"/>
+    </module>
+    <!-- we need only one instance of Check
+    <module name="RegexpMultiline">
+        <property name="format" value="/\*\*\W+\* +\p{javaLowerCase}"/>
+        <property name="fileExtensions" value="java"/>
+        <property name="message" value="First sentence in a comment should start with a capital letter"/>
+    </module>
+    -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+    </module>
+    <!-- we need only one instance of Check
+    <module name="RegexpSingleline">
+        <property name="format" value="/\*\* +\p{javaLowerCase}"/>
+        <property name="fileExtensions" value="java"/>
+        <property name="message" value="First sentence in a comment should start with a capital letter"/>
+    </module>
+    <module name="RegexpSingleline">
+      <property name="format" value="^(?!(.*http|import)).{101,}$"/>
+      <property name="fileExtensions" value="g, g4"/>
+      <property name="message" value="Line should not be longer then 100 symbols"/>
+    </module>
+    -->
+    <module name="RegexpOnFilename"/>
+    <!-- we need only one instance of Check
+    <module name="RegexpOnFilename">
+        <property name="folderPattern" value="[\\/]src[\\/]\w+[\\/]java[\\/]"/>
+        <property name="fileNamePattern" value="\.java$"/>
+        <property name="match" value="false"/>
+        <message key="regexp.filepath.mismatch" value="Only java files should be located in the ''src/*/java'' folders."/>
+    </module>
+    <module name="RegexpOnFilename">
+        <property name="folderPattern" value="[\\/]src[\\/]xdocs[\\/]"/>
+        <property name="fileNamePattern" value="\.(xml)|(vm)$"/>
+        <property name="match" value="false"/>
+        <message key="regexp.filepath.mismatch" value="All files in the ''src/xdocs'' folder should have the ''xml'' or ''vm'' extension."/>
+    </module>
+    <module name="RegexpOnFilename">
+        <property name="folderPattern" value="[\\/]src[\\/]it[\\/]java[\\/]"/>
+        <property name="fileNamePattern" value="^((\w+Test)|(Base\w+))\.java$"/>
+        <property name="match" value="false"/>
+        <message key="regexp.filepath.mismatch" value="All files in the ''src/it/java'' folder should be named ''*Test.java'' or ''Base*.java''."/>
+    </module>
+    -->
+
+    <!-- Size Violations -->
+    <module name="FileLength">
+        <property name="fileExtensions" value="java"/>
+    </module>
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
+    </module>
+
+    <!-- Whitespace -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="false"/>
+    </module>
+
+    <module name="TreeWalker">
+        <property name="tabWidth" value="4"/>
+
+        <!-- Miscellaneous -->
+        <module name="NoCodeInFile"/>
+
+        <!-- Annotations -->
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF"/>
+            <property name="tokens" value="INTERFACE_DEF"/>
+            <property name="tokens" value="PACKAGE_DEF"/>
+            <property name="tokens" value="ENUM_CONSTANT_DEF"/>
+            <property name="tokens" value="ENUM_DEF"/>
+            <property name="tokens" value="METHOD_DEF"/>
+            <property name="tokens" value="CTOR_DEF"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="tokens" value="ANNOTATION_DEF"/>
+            <property name="tokens" value="ANNOTATION_FIELD_DEF"/>
+            <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF"/>
+            <property name="tokens" value="INTERFACE_DEF"/>
+            <property name="tokens" value="PACKAGE_DEF"/>
+            <property name="tokens" value="ENUM_CONSTANT_DEF"/>
+            <property name="tokens" value="ENUM_DEF"/>
+            <property name="tokens" value="METHOD_DEF"/>
+            <property name="tokens" value="CTOR_DEF"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="tokens" value="ANNOTATION_DEF"/>
+            <property name="tokens" value="ANNOTATION_FIELD_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="AnnotationOnSameLine">
+            <property name="tokens" value="METHOD_DEF"/>
+            <property name="tokens" value="CTOR_DEF"/>
+            <property name="tokens" value="TYPECAST"/>
+            <property name="tokens" value="DOT"/>
+            <property name="tokens" value="CLASS_DEF"/>
+            <property name="tokens" value="ENUM_DEF"/>
+            <property name="tokens" value="INTERFACE_DEF"/>
+            <property name="tokens" value="TYPE_ARGUMENT"/>
+            <property name="tokens" value="ANNOTATION_DEF"/>
+            <property name="tokens" value="LITERAL_NEW"/>
+            <property name="tokens" value="LITERAL_THROWS"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="tokens" value="PARAMETER_DEF"/>
+            <property name="tokens" value="IMPLEMENTS_CLAUSE"/>
+            <property name="tokens" value="ANNOTATION_FIELD_DEF"/>
+        </module>
+        <module name="AnnotationUseStyle"/>
+        <module name="MissingOverride">
+            <property name="javaFiveCompatibility" value="true"/>
+        </module>
+        <module name="PackageAnnotation"/>
+        <module name="SuppressWarnings">
+            <property name="format" value="^((?!unchecked|deprecation|rawtypes).)*$"/>
+            <message key="suppressed.warning.not.allowed"
+                     value="The warning ''{0}'' cannot be suppressed at this location. Only few javac warnings are allowed to suppress. If try to suppress checkstyle/pmd/..... violation please do this in their config file. If you try to suppress IntelliJ IDEA inspection, please use javadoc block tag @noinspection"
+            />
+        </module>
+        <module name="SuppressWarningsHolder"/>
+
+        <!-- Block Checks -->
+        <module name="AvoidNestedBlocks">
+            <property name="allowInSwitchCase" value="true"/>
+        </module>
+        <module name="EmptyBlock">
+            <property name="tokens" value="LITERAL_CATCH"/>
+            <property name="tokens" value="ARRAY_INIT"/>
+            <property name="tokens" value="LITERAL_DEFAULT"/>
+            <property name="tokens" value="LITERAL_CASE"/>
+            <property name="tokens" value="INSTANCE_INIT"/>
+            <property name="tokens" value="LITERAL_DO"/>
+            <property name="tokens" value="LITERAL_ELSE"/>
+            <property name="tokens" value="LITERAL_FINALLY"/>
+            <property name="tokens" value="LITERAL_FOR"/>
+            <property name="tokens" value="LITERAL_IF"/>
+            <property name="tokens" value="LITERAL_SWITCH"/>
+            <property name="tokens" value="LITERAL_SYNCHRONIZED"/>
+            <property name="tokens" value="LITERAL_TRY"/>
+            <property name="tokens" value="LITERAL_WHILE"/>
+            <property name="tokens" value="STATIC_INIT"/>
+            <property name="option" value="text"/>
+        </module>
+        <module name="EmptyCatchBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="NeedBraces">
+            <property name="tokens" value="LAMBDA"/>
+            <property name="allowSingleLineStatement" value="true"/>
+        </module>
+        <module name="RightCurly">
+            <property name="tokens" value="METHOD_DEF"/>
+            <property name="tokens" value="CTOR_DEF"/>
+            <property name="tokens" value="CLASS_DEF"/>
+            <property name="tokens" value="INSTANCE_INIT"/>
+            <property name="tokens" value="LITERAL_FOR"/>
+            <property name="tokens" value="STATIC_INIT"/>
+            <property name="tokens" value="LITERAL_WHILE"/>
+            <property name="tokens" value="LITERAL_CATCH"/>
+            <property name="tokens" value="LITERAL_ELSE"/>
+            <property name="tokens" value="LITERAL_FINALLY"/>
+            <property name="tokens" value="LITERAL_IF"/>
+            <property name="tokens" value="LITERAL_TRY"/>
+            <property name="option" value="alone"/>
+        </module>
+        <module name="RightCurly">
+            <property name="tokens" value="LITERAL_DO"/>
+            <property name="option" value="same"/>
+        </module>
+
+        <!-- Class Design -->
+        <module name="DesignForExtension">
+            <property name="ignoredAnnotations" value="Override, Test, Before, After, BeforeClass, AfterClass"/>
+        </module>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InnerTypeLast"/>
+        <module name="InterfaceIsType"/>
+        <module name="MutableException"/>
+        <module name="OneTopLevelClass"/>
+        <module name="ThrowsCount">
+            <property name="max" value="2"/>
+        </module>
+        <module name="VisibilityModifier"/>
+
+        <!-- Coding -->
+        <module name="ArrayTrailingComma"/>
+        <module name="AvoidDoubleBraceInitialization"/>
+        <module name="AvoidInlineConditionals"/>
+        <module name="AvoidNoArgumentSuperConstructorCall"/>
+        <module name="CovariantEquals"/>
+        <module name="DeclarationOrder"/>
+        <module name="DefaultComesLast"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsAvoidNull"/>
+        <module name="EqualsHashCode"/>
+        <module name="ExplicitInitialization"/>
+        <module name="FallThrough"/>
+        <module name="FinalLocalVariable"/>
+        <module name="HiddenField">
+            <property name="ignoreConstructorParameter" value="true"/>
+            <property name="ignoreSetter" value="true"/>
+            <property name="setterCanReturnItsClass" value="true"/>
+        </module>
+        <module name="IllegalCatch">
+            <property name="illegalClassNames"
+                      value="java.lang.Exception, java.lang.Throwable, java.lang.RuntimeException, java.lang.NullPointerException"/>
+        </module>
+        <module name="IllegalInstantiation">
+            <property name="classes" value="org.xml.sax.SAXException, org.xml.sax.SAXParseException, org.apache.commons.beanutils.ConversionException,
+            org.antlr.v4.runtime.misc.ParseCancellationException, antlr.RecognitionException, antlr.TokenStreamException, antlr.TokenStreamRecognitionException, antlr.ANTLRException"/>
+        </module>
+        <module name="IllegalThrows"/>
+        <module name="IllegalToken">
+            <property name="tokens" value="LABELED_STAT"/>
+            <property name="tokens" value="LITERAL_NATIVE"/>
+            <property name="tokens" value="LITERAL_VOLATILE"/>
+            <property name="tokens" value="LITERAL_ASSERT"/>
+        </module>
+        <module name="IllegalTokenText"/>
+        <module name="IllegalType"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber"/>
+        <module name="MatchXpath">
+            <property name="query"
+                      value="//LITERAL_CATCH//METHOD_CALL[.//IDENT[@text = 'printStackTrace']]/.."/>
+            <message key="matchxpath.match" value="Avoid using 'printStackTrace'."/>
+        </module>
+        <module name="MissingCtor"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="ModifiedControlVariable"/>
+        <module name="MultipleStringLiterals"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="NestedForDepth">
+            <property name="max" value="2"/>
+        </module>
+        <module name="NestedIfDepth">
+            <property name="max" value="3"/>
+        </module>
+        <module name="NestedTryDepth"/>
+        <module name="NoClone"/>
+        <module name="NoEnumTrailingComma"/>
+        <module name="NoArrayTrailingComma"/>
+        <module name="NoFinalizer"/>
+        <module name="OneStatementPerLine"/>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="PackageDeclaration"/>
+        <module name="ParameterAssignment"/>
+        <module name="RequireThis"/>
+        <!-- extra config for RequireThis module base of missed regression -->
+        <module name="RequireThis">
+            <property name="validateOnlyOverlapping" value="false"/>
+        </module>
+        <module name="ReturnCount">
+            <property name="maxForVoid" value="0"/>
+        </module>
+        <module name="ReturnCount">
+            <property name="id" value="returnCountMaxOne"/>
+            <property name="max" value="1"/>
+        </module>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StringLiteralEquality"/>
+        <module name="SuperClone"/>
+        <module name="SuperFinalize"/>
+        <module name="UnnecessaryParentheses"/>
+        <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/>
+        <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
+        <module name="UnnecessarySemicolonInEnumeration"/>
+        <module name="UnnecessarySemicolonInTryWithResources"/>
+        <module name="VariableDeclarationUsageDistance"/>
+
+        <!-- Filters-->
+        <module name="SuppressionCommentFilter">
+            <!--
+              Use suppressions.xml for suppressions, this is only example.
+              checkFormat will prevent suppression comments from being valid.
+            -->
+            <property name="checkFormat" value="IGNORETHIS"/>
+            <property name="offCommentFormat" value="CSOFF\: .*"/>
+            <property name="onCommentFormat" value="CSON\: .*"/>
+        </module>
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="commentFormat" value="-@cs\[(\w{8,}(\|\w{8,})*)\] \w[\(\)\-\.\'\`\,\:\;\w ]{10,}"/>
+            <property name="checkFormat" value="$1"/>
+            <property name="influenceFormat" value="3"/>
+        </module>
+
+        <!-- Imports -->
+        <module name="AvoidStarImport"/>
+        <module name="AvoidStaticImport"/>
+        <module name="CustomImportOrder">
+            <property name="customImportOrderRules" value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>
+            <property name="specialImportsRegExp" value="^org\."/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+        </module>
+        <module name="IllegalImport"/>
+        <!-- require separate config file
+        <module name="ImportControl">
+          <property name="file" value="${checkstyle.importcontrol.file}"/>
+          <property name="path" value="^.*[\\/]src[\\/]main[\\/].*$"/>
+        </module>
+        -->
+        <module name="ImportOrder">
+            <property name="groups" value="/^java\./,javax,org"/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="top"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+        </module>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+        <!-- Javadoc Comments -->
+        <!-- JavadocAST Checks - disabled due to performance problem
+        <module name="AtclauseOrder"/>
+        -->
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocMethod">
+            <property name="validateThrows" value="true"/>
+        </module>
+        <!-- JavadocAST Checks - disabled due to performance problem
+        <module name="JavadocParagraph"/>
+        -->
+        <module name="JavadocStyle">
+            <property name="scope" value="public"/>
+        </module>
+        <!-- JavadocAST Checks - disabled due to performance problem
+        <module name="JavadocTagContinuationIndentation"/>
+        -->
+        <module name="JavadocType">
+            <property name="authorFormat" value="\S"/>
+            <property name="allowUnknownTags" value="true"/>
+        </module>
+        <module name="JavadocVariable"/>
+        <!-- JavadocAST Checks - disabled due to performance problem
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="SingleLineJavadoc"/>
+        <module name="SummaryJavadoc"/>
+        -->
+        <module name="MissingJavadocMethod"/>
+        <module name="MissingJavadocPackage"/>
+        <module name="MissingJavadocType"/>
+        <module name="WriteTag"/>
+
+        <!-- Metrics -->
+        <module name="BooleanExpressionComplexity">
+            <property name="max" value="7"/>
+        </module>
+        <module name="ClassDataAbstractionCoupling">
+            <!-- Default classes are also listed-->
+            <property name="excludedClasses" value="boolean, byte, char, double, float, int, long, short, void, Boolean, Byte, Character, Double, Float, Integer, Long, Short, Void, Object, Class, String, StringBuffer, StringBuilder, ArrayIndexOutOfBoundsException, Exception, RuntimeException, IllegalArgumentException, IllegalStateException, IndexOutOfBoundsException, NullPointerException, Throwable, SecurityException, UnsupportedOperationException, List, ArrayList, Deque, Queue, LinkedList, Set, HashSet, SortedSet, TreeSet, Map, HashMap, SortedMap, TreeMap,
+            DetailsAST, CheckstyleException, UnsupportedEncodingException, BuildException, ConversionException, FileNotFoundException, TestException"/>
+        </module>
+        <module name="ClassFanOutComplexity">
+            <property name="max" value="25"/>
+            <!-- Default classes are also listed-->
+            <property name="excludedClasses"
+                      value="boolean, byte, char, double, float, int, long, short,  void, Boolean, Byte, Character, Double, Float, Integer, Long, Short, Void, Object, Class, String, StringBuffer, StringBuilder, ArrayIndexOutOfBoundsException, Exception, RuntimeException, IllegalArgumentException, IllegalStateException, IndexOutOfBoundsException, NullPointerException, Throwable, SecurityException, UnsupportedOperationException, List, ArrayList, Deque, Queue, LinkedList, Set, HashSet, SortedSet, TreeSet, Map, HashMap, SortedMap, TreeMap, DetailsAST, CheckstyleException, UnsupportedEncodingException, BuildException, ConversionException, FileNotFoundException, TestException, Log, Sets, Multimap, TokenStreamRecognitionException, RecognitionException, TokenStreamException, IOException"/>
+        </module>
+        <module name="CyclomaticComplexity">
+            <property name="switchBlockAsSingleDecisionPoint" value="true"/>
+        </module>
+        <module name="JavaNCSS"/>
+        <module name="NPathComplexity"/>
+
+        <!-- Misc -->
+        <module name="ArrayTypeStyle"/>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowIfAllCharactersEscaped" value="true"/>
+        </module>
+        <module name="CommentsIndentation"/>
+        <module name="DescendantToken"/>
+        <module name="FinalParameters"/>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="8"/>
+        </module>
+        <module name="OuterTypeFilename"/>
+        <module name="TodoComment">
+            <property name="format" value="(TODO)|(FIXME)"/>
+        </module>
+        <module name="TrailingComment"/>
+        <module name="UncommentedMain">
+            <property name="excludedClasses" value="\.Main$"/>
+        </module>
+        <module name="UpperEll"/>
+
+        <!-- Modifiers -->
+        <module name="ClassMemberImpliedModifier"/>
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+        <module name="InterfaceMemberImpliedModifier"/>
+
+        <!-- Naming Conventions -->
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="0"/>
+            <property name="allowedAbbreviations" value="AST"/>
+        </module>
+        <module name="AbstractClassName"/>
+        <module name="ClassTypeParameterName"/>
+        <module name="RecordTypeParameterName"/>
+        <module name="ConstantName"/>
+        <module name="InterfaceTypeParameterName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName">
+            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+        </module>
+        <module name="MethodName"/>
+        <module name="MethodTypeParameterName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName">
+            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+            <property name="ignoreOverridden" value="true"/>
+        </module>
+        <module name="PatternVariableName"/>
+        <module name="LambdaParameterName">
+            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^(ex|[a-z][a-z][a-zA-Z]+)$"/>
+        </module>
+        <module name="StaticVariableName">
+            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+        </module>
+        <module name="TypeName"/>
+        <module name="IllegalIdentifierName"/>
+        <module name="RecordComponentName"/>
+
+        <!-- Regexp -->
+        <module name="Regexp"/>
+        <!-- we need only one instance of Check
+        <module name="RegexpSinglelineJava"/>
+        -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="[^\p{ASCII}]"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
+        <!-- Size Violations -->
+        <module name="AnonInnerLength"/>
+        <module name="ExecutableStatementCount">
+            <property name="max" value="30"/>
+        </module>
+        <module name="LambdaBodyLength"/>
+        <module name="MethodCount">
+            <property name="maxTotal" value="35"/>
+        </module>
+        <module name="MethodLength"/>
+        <module name="OuterTypeNumber"/>
+        <module name="ParameterNumber"/>
+        <module name="RecordComponentNumber"/>
+
+        <!-- Whitespace -->
+        <module name="EmptyForInitializerPad"/>
+        <module name="EmptyForIteratorPad"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+            <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+        </module>
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="NoLineWrap"/>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="ARRAY_INIT"/>
+            <property name="tokens" value="BNOT"/>
+            <property name="tokens" value="DEC"/>
+            <property name="tokens" value="DOT"/>
+            <property name="tokens" value="INC"/>
+            <property name="tokens" value="LNOT"/>
+            <property name="tokens" value="UNARY_MINUS"/>
+            <property name="tokens" value="UNARY_PLUS"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="tokens" value="INDEX_OP"/>
+            <property name="tokens" value="METHOD_REF"/>
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="DOT"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="tokens" value="QUESTION"/>
+            <property name="tokens" value="COLON"/>
+            <property name="tokens" value="EQUAL"/>
+            <property name="tokens" value="NOT_EQUAL"/>
+            <property name="tokens" value="DIV"/>
+            <property name="tokens" value="PLUS"/>
+            <property name="tokens" value="MINUS"/>
+            <property name="tokens" value="STAR"/>
+            <property name="tokens" value="MOD"/>
+            <property name="tokens" value="SR"/>
+            <property name="tokens" value="BSR"/>
+            <property name="tokens" value="GE"/>
+            <property name="tokens" value="GT"/>
+            <property name="tokens" value="SL"/>
+            <property name="tokens" value="LE"/>
+            <property name="tokens" value="LT"/>
+            <property name="tokens" value="BXOR"/>
+            <property name="tokens" value="BOR"/>
+            <property name="tokens" value="LOR"/>
+            <property name="tokens" value="BAND"/>
+            <property name="tokens" value="LAND"/>
+            <property name="tokens" value="TYPE_EXTENSION_AND"/>
+            <property name="tokens" value="LITERAL_INSTANCEOF"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="tokens" value="ASSIGN"/>
+            <property name="tokens" value="DIV_ASSIGN"/>
+            <property name="tokens" value="PLUS_ASSIGN"/>
+            <property name="tokens" value="MINUS_ASSIGN"/>
+            <property name="tokens" value="STAR_ASSIGN"/>
+            <property name="tokens" value="MOD_ASSIGN"/>
+            <property name="tokens" value="SR_ASSIGN"/>
+            <property name="tokens" value="BSR_ASSIGN"/>
+            <property name="tokens" value="SL_ASSIGN"/>
+            <property name="tokens" value="BXOR_ASSIGN"/>
+            <property name="tokens" value="BOR_ASSIGN"/>
+            <property name="tokens" value="BAND_ASSIGN"/>
+            <property name="option" value="eol"/>
+        </module>
+        <module name="ParenPad"/>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="tokens" value="AT"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="tokens" value="RBRACK"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="tokens" value="SEMI"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SingleSpaceSeparator">
+            <property name="validateComments" value="false"/>
+        </module>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <!-- usuppress javadoc parsing errors, as we test Check not a parser -->
+        <module name="SuppressionXpathSingleFilter">
+            <property name="message" value="Javadoc comment at column \d+ has parse error"/>
+        </module>
+
+    </module>
+
+    <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+    <module name="SuppressionSingleFilter">
+        <property name="message" value="Exception occurred while parsing"/>
+        <property name="checks" value="Checker"/>
+    </module>
+</module>


### PR DESCRIPTION
 Issue #529: Deprecate launch.groovy and merge functionality into diff.groovy

Notes:

-  We should replace all usages of `launch.groovy` with `diff.groovy` in single mode, using 'patchBranch' and 'patchConfig' . This isn't a big deal, we are just saving an extra checkstyle run using `master` branch.
- Any usages of `launch` that are being replaced with `diff` that DO NOT use `-i` need to specify `--allowExcludes` now.
- All existing `diff.groovy` usage needs to be reviewed; `no-exception` tests can be done in single mode.

Related PRs that must be merged after this for CI in other projects:
https://github.com/checkstyle/checkstyle/pull/9278
https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/828

A good example of `no-exception` testing and replacing `launch.groovy` for many cases is:
https://github.com/checkstyle/checkstyle/blob/492dd22e4730b7902e0af91819da840c2dac7b23/.ci/no-exception-test.sh#L68