### PR TITLE
infra: remove OpenJDK9 repo from github action project file

### DIFF
--- a/checkstyle-tester/projects-to-test-on-for-github-action.properties
+++ b/checkstyle-tester/projects-to-test-on-for-github-action.properties
@@ -8,8 +8,6 @@ checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/.ci-temp/*
 sevntu-checkstyle|git|https://github.com/sevntu-checkstyle/sevntu.checkstyle|master||
 checkstyle-sonar|git|https://github.com/checkstyle/sonar-checkstyle|master||
 
-#All details at checkstyle/checkstyle#3033: ModalDialogActivationTest till JDK-8166015 ; 'jxc/8073519/**' not compilable by design ; ', jhsdb/**' - checkstyle do not support unicode identifiers
-openjdk9|git|https://github.com/AdoptOpenJDK/openjdk-jdk9.git|master|**/test/java/awt/Focus/ModalDialogActivationTest/ModalDialogActivationTest.java,**/test/javax/xml/bind/jxc/8073519/**,**/test/sun/tools/jhsdb/**
 guava|git|https://github.com/google/guava|v28.2||
 
 spotbugs|git|https://github.com/spotbugs/spotbugs|3.1.2||


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/9760#issuecomment-810324358 and other Checkstyle PR's, OpenJDK9 has been causing problems in report generation; we should disable it for now.