### PR TITLE
infra: change spring-integration master branch to main

### DIFF
--- a/checkstyle-tester/projects-to-test-on-for-github-action.properties
+++ b/checkstyle-tester/projects-to-test-on-for-github-action.properties
@@ -39,4 +39,4 @@ Vavr|git|https://github.com/vavr-io/vavr|v0.9.0||
 # custom javadoc tags
 nbia-dcm4che-tools|git|https://github.com/thprakash/nbia-dcm4che-tools|c3591e6f0f84827586db25abded6708e5386ef1a||
 # RequireThis usage
-spring-integration|git|https://github.com/spring-projects/spring-integration.git|master|
+spring-integration|git|https://github.com/spring-projects/spring-integration.git|main|

--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -53,4 +53,4 @@ guava|git|https://github.com/google/guava|v28.2||
 # custom javadoc tags
 #nbia-dcm4che-tools|git|https://github.com/thprakash/nbia-dcm4che-tools|c3591e6f0f84827586db25abded6708e5386ef1a||
 # RequireThis usage
-#spring-integration|git|https://github.com/spring-projects/spring-integration.git|master|
+#spring-integration|git|https://github.com/spring-projects/spring-integration.git|main|


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/pull/9755?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDE3NDM0OTc2ODA6MzEyNTI1MzI%3D#issuecomment-816673317

spring-integration has changed from `master` branch to `main`.


This occurred at https://github.com/spring-projects/spring-integration/pull/3539