### PR TITLE
Issue #560: fix stack overflow in ignore pattern

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/CommitMessage.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/CommitMessage.java
@@ -1,0 +1,134 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.github;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Commit message wrapper.
+ */
+/* package */ class CommitMessage {
+
+    /** Regexp pattern for revert commit messages. */
+    private static final Pattern REVERT_COMMIT_MESSAGES_PATTERN =
+        Pattern.compile("Revert \"[^\"]+?\"");
+
+    /** Regexp pattern for ignoring commit messages. */
+    private static final Pattern IGNORED_COMMIT_MESSAGES_PATTERN =
+        Pattern.compile("^\\[maven-release-plugin]|"
+            + "^update to ([0-9]|\\.)+-SNAPSHOT|"
+            + "^doc: release notes|"
+            + "^(config|dependency|infra|minor|supplemental):");
+
+    /** Full commit message. */
+    private final String message;
+
+    /**
+     * Creates new instance of {@code CommitMessage}.
+     *
+     * @param message the full commit message
+     */
+    /* package */ CommitMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Returns the commit message.
+     *
+     * @return the commit message
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Checks whether commits message is associated with a pull request or an issue.
+     * Commit message which is associated with a pull request or an issue starts with 'Pull'
+     * or 'Issue' prefix.
+     *
+     * @return true if commits message is associated with a pull request or an issue.
+     */
+    public boolean isIssueOrPull() {
+        return message.startsWith("Issue") || message.startsWith("Pull");
+    }
+
+    /**
+     * Extracts an issue number from commit message.
+     *
+     * @return issue number.
+     */
+    public int getIssueNumber() {
+        final int numberSignIndex = message.indexOf('#');
+        final int colonIndex = message.indexOf(':');
+        return Integer.parseInt(message.substring(numberSignIndex + 1, colonIndex));
+    }
+
+    /**
+     * Checks commit message to determine whether commit should be ignored.
+     *
+     * @return {@code true} if commit with the message should be ignored.
+     */
+    public boolean isIgnored() {
+        final Matcher matcher = IGNORED_COMMIT_MESSAGES_PATTERN.matcher(message);
+        return matcher.find();
+    }
+
+    /**
+     * Checks whether a commit message starts with the 'Revert' word.
+     *
+     * @return {@code true} if a commit message starts with the 'Revert' word.
+     */
+    public boolean isRevert() {
+        final Matcher matcher = REVERT_COMMIT_MESSAGES_PATTERN.matcher(message);
+        return matcher.find();
+    }
+
+    /**
+     * Returns the original commit hash that was reverted by this commit.
+     *
+     * @return the commit SHA, if present, the string {@code "nonexistingsha"} otherwise.
+     */
+    public String getRevertedCommitReference() {
+        final int lastSpaceIndex = message.lastIndexOf(' ');
+        final int lastPeriodIndex = message.lastIndexOf('.');
+        final String result;
+        if (lastSpaceIndex > lastPeriodIndex) {
+            // Something is wrong with commit message, revert commit was changed manually.
+            result = "nonexistingsha";
+        }
+        else {
+            result = message.substring(lastSpaceIndex + 1, lastPeriodIndex);
+        }
+        return result;
+    }
+
+    /**
+     * Returns the original commit message that was reverted by this commit.
+     *
+     * @return the commit message
+     */
+    public String getRevertedCommitMessage() {
+        final int firstQuoteIndex = message.indexOf('"');
+        final int lastQuoteIndex = message.lastIndexOf('"');
+        return message.substring(firstQuoteIndex + 1, lastQuoteIndex);
+    }
+
+}

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/github/CommitMessageTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/github/CommitMessageTest.java
@@ -1,0 +1,160 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.github;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CommitMessageTest {
+
+    @Test
+    public void testIssue() {
+        final CommitMessage message = new CommitMessage(
+            "Issue #1487: workaround for cobertura at CheckstyleAntTask.java to get 100% coverage");
+        Assert.assertTrue("Message should match issue/pull pattern", message.isIssueOrPull());
+    }
+
+    @Test
+    public void testPull() {
+        final CommitMessage message = new CommitMessage(
+            "Pull #9314: fix escaped char pattern in AvoidEscapedUnicodeCharactersCheck");
+        Assert.assertTrue("Message should match issue/pull pattern", message.isIssueOrPull());
+    }
+
+    @Test
+    public void testRevert() {
+        final CommitMessage message = new CommitMessage(
+            "Revert \"issue 530, was removed from release notes, as it was reverted\"\n"
+                + "\n"
+                + "This reverts commit 5fe5bcee40e39eb6a23864f7f55128cbf2f10641.");
+        Assert.assertTrue("Message should match revert pattern", message.isRevert());
+        Assert.assertEquals("Invalid commit message",
+            "issue 530, was removed from release notes, as it was reverted",
+            message.getRevertedCommitMessage());
+        Assert.assertEquals("Invalid commit reference",
+            "5fe5bcee40e39eb6a23864f7f55128cbf2f10641", message.getRevertedCommitReference());
+    }
+
+    @Test
+    public void testRevertNotInBeginningOfMessage() {
+        final CommitMessage message = new CommitMessage(
+            "minor: Revert \"Issue #3323: use Orekit fork to pass CI for this issue\"\n"
+                + "\n"
+                + "This reverts commit 7a8b92371b9b1a605ec4caa8ef138cbd194738d5.");
+        Assert.assertTrue("Message should match revert pattern", message.isRevert());
+    }
+
+    @Test
+    public void testReleaseIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "[maven-release-plugin] prepare release checkstyle-8.35");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testUpdateToIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "update to 7.0-SNAPSHOT");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testDocReleaseNotesIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "doc: release notes 8.43");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testConfigIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "config: update to 8.42-SNAPSHOT");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testDependencyIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "dependency: bump spotbugs-maven-plugin from 4.2.3 to 4.3.0\n"
+                + "\n"
+                + "Bumps [spotbugs-maven-plugin](https://github.com/spotbugs/spotbugs-maven-plugin)"
+                + " from 4.2.3 to 4.3.0.\n"
+                + "- [Release notes](https://github.com/spotbugs/spotbugs-maven-plugin/releases)\n"
+                + "- [Commits](https://github.com/spotbugs/spotbugs-maven-plugin/compare/"
+                + "spotbugs-maven-plugin-4.2.3...spotbugs-maven-plugin-4.3.0)\n"
+                + "\n"
+                + "---\n"
+                + "updated-dependencies:\n"
+                + "- dependency-name: com.github.spotbugs:spotbugs-maven-plugin\n"
+                + "  dependency-type: direct:production\n"
+                + "  update-type: version-update:semver-minor\n"
+                + "...\n"
+                + "\n"
+                + "Signed-off-by: dependabot[bot] <support@github.com>");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testInfraIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "infra: update README to have links to travis.com");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testMinorIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "minor: refactor boolean expression to fix TC build");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testSupplementalIsIgnored() {
+        final CommitMessage message = new CommitMessage(
+            "supplemental: divide description into paragraph for Issue #8928");
+        Assert.assertTrue("Message should match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testMarkersNotInBeginningOfMessage() {
+        final CommitMessage message = new CommitMessage(
+            "Regular message.\n"
+                + "[maven-release-plugin]|\n"
+                + "update to 1.23-SNAPSHOT|\n"
+                + "doc: release notes\n"
+                + "config:\n"
+                + "dependency:\n"
+                + "infra:\n"
+                + "minor:\n"
+                + "supplemental:\n"
+                + "\n");
+        Assert.assertFalse("Message should not match ignore pattern", message.isIgnored());
+    }
+
+    @Test
+    public void testUnclassifiedCommit() {
+        final CommitMessage message = new CommitMessage(
+            "Some commit message of unknown type");
+        Assert.assertFalse("Message should not match revert pattern", message.isRevert());
+        Assert.assertFalse("Message should not match ignore pattern", message.isIgnored());
+        Assert.assertFalse("Message should not match issue/pull pattern", message.isIssueOrPull());
+    }
+
+}


### PR DESCRIPTION
Fixes #560

The existing pattern validates the presence of "\n" at the end of the message. But this is not necessary. All messages are checked in CI.
To skip some release notes, it is enough to simply examine the beginning of the message.

All message matching code extracted to a helper class `CommitMessage`.