### PR TITLE
Travis: problem with JAVA_HOME for groovy package 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,11 @@ addons:
       - xmlstarlet
       - ruby
       - groovy
+      
+before_script:
+    - export JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-ppc64el
+    - export PATH=$JAVA_HOME/bin:$PATH
+    - groovy --version
 
 script:
   - |


### PR DESCRIPTION
Setting JAVA_HOME to /usr/lib/jvm/adoptopenjdk-8-hotspot-ppc64el