### PR TITLE
config: remove 'set -e' in Travis

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -20,6 +20,17 @@ function checkout_from {
 
 case $1 in
 
+update-settings-xml)
+  MVN_SETTINGS=${TRAVIS_HOME}/.m2/settings.xml
+  if [[ -f ${MVN_SETTINGS} ]]; then
+    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+      sed -i'' -e "/<mirrors>/,/<\/mirrors>/ d" $MVN_SETTINGS
+    else
+      xmlstarlet ed --inplace -d "//mirrors" $MVN_SETTINGS
+    fi
+  fi
+  ;;
+
 releasenotes-builder)
   cd releasenotes-builder
   mvn clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,18 +74,7 @@ before_script:
     - groovy --version
 
 script:
-  - |
-    set -e
-    MVN_SETTINGS=${TRAVIS_HOME}/.m2/settings.xml
-    if [[ -f ${MVN_SETTINGS} ]]; then
-      if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-        sed -i'' -e "/<mirrors>/,/<\/mirrors>/ d" $MVN_SETTINGS
-      else
-        xmlstarlet ed --inplace -d "//mirrors" $MVN_SETTINGS
-      fi
-    fi
-  - |
-    set -e
-    eval $CMD
+  - ./.ci/travis.sh update-settings-xml
+  - eval $CMD
 
 after_success:


### PR DESCRIPTION
this PR is required for Travis support to investigate problem with long delay(by timeout eventually) in fail of build


https://app.travis-ci.com/github/checkstyle/contribution/jobs/547768471


![image](https://user-images.githubusercontent.com/812984/141348091-0b69b123-3241-4687-9fdf-24f6032e6dbf.png)

```
README.md:1: MD002 First header should be a top level header

README.md:1: MD041 First line in file should be a top level header

A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

The build has been terminated
```