### PR TITLE
infra: Dockefile for jdk 11 groovy image

### DIFF
--- a/devops/docker/no-exception-build-image/jdk-11-groovy-git-mvn/Dockerfile
+++ b/devops/docker/no-exception-build-image/jdk-11-groovy-git-mvn/Dockerfile
@@ -1,0 +1,15 @@
+##################### Using official groovy image ######################
+FROM groovy:jdk11
+##################### End of images used ############################### 
+
+## Changing user to root to get access to /var/lib/dpkg/lock-frontend ##
+USER root
+##################### End of Change User ###############################
+
+##################### Installing Maven and git #########################
+RUN apt-get update \
+    && echo "Installing maven and git dependencies" \
+    && apt-get install --yes --no-install-recommends \
+        git \
+        maven
+##################### End of install and Dockerfile ####################


### PR DESCRIPTION
New Docker image for checkstyle/checkstyle#9146

Based on https://hub.docker.com/layers/groovy/library/groovy/jdk11/images/sha256-42bf7a975b867ded59c87f541e58f4be60b42c2ba4840939986950da2a8f013d