### PR TITLE
Minor various fixes for diff-report-tool-util

### DIFF
--- a/patch-diff-report-tool/README.md
+++ b/patch-diff-report-tool/README.md
@@ -26,6 +26,9 @@ You have 2 different checkstyle repos, original (base) and forked (patch), for e
 
 8) Now execute this utility with 6 command line arguments:
 
+`--compareMode` - type of comparison to do with the files; `XML` parses the report files as
+   Checkstyle XML files with violation results. `TEXT` parses the report files as pure text
+   files, line by line. (required argument); default: XML \
 `--baseReport` - path to the base checkstyle-result.xml (optional argument,
    if absent then only configuration and violations for patch will be in the report); \
 `--patchReport` - path to the patch checkstyle-result.xml (required argument); \

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/CliArgsValidator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/CliArgsValidator.java
@@ -21,7 +21,7 @@ package com.github.checkstyle;
 
 import java.nio.file.Files;
 
-import com.github.checkstyle.data.CliPaths;
+import com.github.checkstyle.data.CliOptions;
 import com.github.checkstyle.data.CompareMode;
 
 /**
@@ -45,86 +45,109 @@ public final class CliArgsValidator {
     }
 
     /**
-     * Performs file existence checks.
+     * Performs validation of the options.
      *
-     * @param paths
-     *            POJO holding all input paths.
+     * @param options
+     *            POJO holding all options.
      * @throws IllegalArgumentException
      *             on failure of any check.
      */
-    public static void checkPaths(CliPaths paths) throws IllegalArgumentException {
-        if (paths.getPatchReportPath() == null) {
+    public static void validate(CliOptions options) throws IllegalArgumentException {
+        if (options.getPatchReportPath() == null) {
             throw new IllegalArgumentException("obligatory argument --patchReportPath "
                     + "not present, -h for help");
         }
-        if (paths.getRefFilesPath() != null && !Files.isDirectory(paths.getRefFilesPath())) {
+        if (options.getRefFilesPath() != null && !Files.isDirectory(options.getRefFilesPath())) {
             throw new IllegalArgumentException("Ref Files path is not a directory: "
-                    + paths.getRefFilesPath());
+                    + options.getRefFilesPath());
         }
-        if (Files.isRegularFile(paths.getOutputPath())) {
+        if (Files.isRegularFile(options.getOutputPath())) {
             throw new IllegalArgumentException("Output path is not a directory: "
-                    + paths.getOutputPath());
+                    + options.getOutputPath());
         }
 
-        if (paths.getCompareMode() == CompareMode.XML) {
-            if (!Files.isRegularFile(paths.getPatchReportPath())) {
-                throw new IllegalArgumentException("Patch XML Report file doesn't exist: "
-                        + paths.getPatchReportPath());
-            }
-            if (paths.getPatchConfigPath() != null
-                    && !Files.isRegularFile(paths.getPatchConfigPath())) {
-                throw new IllegalArgumentException(
-                        "Patch checkstyle configuration xml file is missing: "
-                                + paths.getPatchConfigPath());
-            }
-            if (paths.getBaseReportPath() == null) {
-                if (paths.getBaseConfigPath() != null) {
-                    throw new IllegalArgumentException("Base checkstyle configuration xml path is "
-                            + "missing while base configuration path is present.");
-                }
-            }
-            else {
-                if (!Files.isRegularFile(paths.getBaseReportPath())) {
-                    throw new IllegalArgumentException("Base XML Report file doesn't exist: "
-                            + paths.getBaseReportPath());
-                }
-                if (paths.getPatchReportPath().equals(paths.getBaseReportPath())) {
-                    throw new IllegalArgumentException(
-                            "Both Base and Patch XML report files have the same path.");
-                }
-                if (paths.getBaseConfigPath() != null && paths.getPatchConfigPath() == null) {
-                    throw new IllegalArgumentException(
-                            "Patch checkstyle configuration xml path is missing while base "
-                                    + "configuration path is present");
-                }
-                if (paths.getPatchConfigPath() != null && paths.getBaseConfigPath() == null) {
-                    throw new IllegalArgumentException(
-                            "Base checkstyle configuration xml path is missing while patch "
-                                    + "configuration path is present");
-                }
-                if (paths.getBaseConfigPath() != null
-                        && !Files.isRegularFile(paths.getBaseConfigPath())) {
-                    throw new IllegalArgumentException(
-                            "Base checkstyle configuration xml file is missing: "
-                                    + paths.getBaseConfigPath());
-                }
+        if (options.getCompareMode() == CompareMode.XML) {
+            validateXmlMode(options);
+        }
+        else {
+            validateTextMode(options);
+        }
+    }
+
+    /**
+     * Performs validation of the options in XML compare mode.
+     *
+     * @param options
+     *            POJO holding all options.
+     * @throws IllegalArgumentException
+     *             on failure of any check.
+     */
+    private static void validateXmlMode(CliOptions options) {
+        if (!Files.isRegularFile(options.getPatchReportPath())) {
+            throw new IllegalArgumentException("Patch XML Report file doesn't exist: "
+                    + options.getPatchReportPath());
+        }
+        if (options.getPatchConfigPath() != null
+                && !Files.isRegularFile(options.getPatchConfigPath())) {
+            throw new IllegalArgumentException(
+                    "Patch checkstyle configuration xml file is missing: "
+                            + options.getPatchConfigPath());
+        }
+        if (options.getBaseReportPath() == null) {
+            if (options.getBaseConfigPath() != null) {
+                throw new IllegalArgumentException("Base checkstyle configuration xml path is "
+                        + "missing while base configuration path is present.");
             }
         }
         else {
-            if (paths.getBaseConfigPath() != null || paths.getPatchConfigPath() != null) {
+            if (!Files.isRegularFile(options.getBaseReportPath())) {
+                throw new IllegalArgumentException("Base XML Report file doesn't exist: "
+                        + options.getBaseReportPath());
+            }
+            if (options.getPatchReportPath().equals(options.getBaseReportPath())) {
                 throw new IllegalArgumentException(
-                        "Checkstyle configuration xml paths do not need to be present for "
-                                + "text mode.");
+                        "Both Base and Patch XML report files have the same path.");
             }
-            if (!Files.isDirectory(paths.getPatchReportPath())) {
-                throw new IllegalArgumentException("Patch Report directory doesn't exist: "
-                        + paths.getPatchReportPath());
+            if (options.getBaseConfigPath() != null && options.getPatchConfigPath() == null) {
+                throw new IllegalArgumentException(
+                        "Patch checkstyle configuration xml path is missing while base "
+                                + "configuration path is present");
             }
-            if (!Files.isDirectory(paths.getBaseReportPath())) {
-                throw new IllegalArgumentException("Base Report directory doesn't exist: "
-                        + paths.getBaseReportPath());
+            if (options.getPatchConfigPath() != null && options.getBaseConfigPath() == null) {
+                throw new IllegalArgumentException(
+                        "Base checkstyle configuration xml path is missing while patch "
+                                + "configuration path is present");
+            }
+            if (options.getBaseConfigPath() != null
+                    && !Files.isRegularFile(options.getBaseConfigPath())) {
+                throw new IllegalArgumentException(
+                        "Base checkstyle configuration xml file is missing: "
+                                + options.getBaseConfigPath());
             }
         }
     }
 
+    /**
+     * Performs validation of the options in Text compare mode.
+     *
+     * @param options
+     *            POJO holding all options.
+     * @throws IllegalArgumentException
+     *             on failure of any check.
+     */
+    private static void validateTextMode(CliOptions options) {
+        if (options.getBaseConfigPath() != null || options.getPatchConfigPath() != null) {
+            throw new IllegalArgumentException(
+                    "Checkstyle configuration xml paths do not need to be present for "
+                            + "text mode.");
+        }
+        if (!Files.isDirectory(options.getPatchReportPath())) {
+            throw new IllegalArgumentException("Patch Report directory doesn't exist: "
+                    + options.getPatchReportPath());
+        }
+        if (!Files.isDirectory(options.getBaseReportPath())) {
+            throw new IllegalArgumentException("Base Report directory doesn't exist: "
+                    + options.getBaseReportPath());
+        }
+    }
 }

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java
@@ -53,18 +53,25 @@ public final class Main {
      * Help message.
      */
     public static final String MSG_HELP = "This program creates symmetric difference "
-            + "from two checkstyle-result.xml reports\n" + "generated for checkstyle build.\n"
+            + "from two checkstyle-result.xml reports\n"
+            + "generated for checkstyle build.\n"
             + "Command line arguments:\n"
-            + "\t--baseReportPath - path to the base checkstyle-result.xml (optional, if absent "
+            + "--compareMode - type of comparison to do with the files; 'XML' parses the report "
+            + "files as Checkstyle XML files with violation results. 'TEXT' parses the report "
+            + "files as pure text files, line by line. (required argument); default: XML"
+            + "\t--baseReport - path to the base checkstyle-result.xml (optional, if absent "
             + "then only configuration and violations for patch will be in the report)\n"
-            + "\t--patchReportPath - path to the patch checkstyle-result.xml, "
+            + "\t--patchReport - path to the patch checkstyle-result.xml, "
             + "obligatory argument;\n"
-            + "\t--sourcePath - path to the data under check (optional, if absent then file "
-            + "structure for cross reference files won't be relativized, "
-            + "full paths will be used);\n"
+            + "\t--refFiles - path to the source files under check (optional)\n"
             + "\t--output - path to store the resulting diff report (optional, if absent then "
             + "default path will be used: ~/XMLDiffGen_report_yyyy.mm.dd_hh_mm_ss), remember, "
             + "if this folder exists its content will be purged;\n"
+            + "\t--baseConfig - path to the base checkstyle configuration xml file (optional)"
+            + "\t--patchConfig - path to the patch checkstyle configuration xml (optional)"
+            + "\t--shortFilePaths - Option to save report file paths as a shorter version to "
+            + "prevent long paths. This option is useful for Windows users where they are "
+            + "restricted to maximum directory depth. "
             + "\t-h - simply shows help message.";
 
     /**

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CheckstyleRecord.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CheckstyleRecord.java
@@ -235,6 +235,7 @@ public final class CheckstyleRecord implements Comparable<CheckstyleRecord> {
      * @return 0 if the objects are equal, a negative integer if this record is before the specified
      *         record, or a positive integer if this record is after the specified record.
      */
+    @Override
     public int compareTo(final CheckstyleRecord other) {
         int diff = Integer.compare(line, other.line);
         if (diff == 0) {
@@ -261,7 +262,7 @@ public final class CheckstyleRecord implements Comparable<CheckstyleRecord> {
      *         a value less than {@code 0} if severity1 should be first and
      *         a value greater than {@code 0} if severity2 should be first
      */
-    private int compareSeverity(String severity1, String severity2) {
+    private static int compareSeverity(String severity1, String severity2) {
         final int result;
         if (severity1.equals(severity2)) {
             result = 0;

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliOptions.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/CliOptions.java
@@ -22,11 +22,11 @@ package com.github.checkstyle.data;
 import java.nio.file.Path;
 
 /**
- * POJO class that hold input paths.
+ * POJO class that hold input CLI options.
  *
  * @author attatrol
  */
-public final class CliPaths {
+public final class CliOptions {
     /**
      * Option to control which type of diff comparison to do.
      */
@@ -88,7 +88,7 @@ public final class CliPaths {
      *           {@code true} if only short file names should be used with no paths.
      */
     // -@cs[ParameterNumber] Helper class to pass all CLI attributes around.
-    public CliPaths(CompareMode compareMode, Path baseReportPath, Path patchReportPath,
+    public CliOptions(CompareMode compareMode, Path baseReportPath, Path patchReportPath,
             Path refFilesPath, Path outputPath, Path baseConfigPath, Path patchConfigPath,
             boolean shortFilePaths) {
         this.compareMode = compareMode;

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/Statistics.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/data/Statistics.java
@@ -204,7 +204,7 @@ public class Statistics {
      * @param numDiffAddedMap map with added numbers.
      * @return statistics of records per severity.
      */
-    private Map<String, String> buildStatisticsMap(
+    private static Map<String, String> buildStatisticsMap(
         Map<String, BigInteger> numPatchMap,
         Map<String, BigInteger> numDiffRemovedMap,
         Map<String, BigInteger> numDiffAddedMap) {
@@ -289,7 +289,7 @@ public class Statistics {
      * @param addedNumber the added number.
      * @return the statistics string.
      */
-    private String buildStatisticsString(
+    private static String buildStatisticsString(
         BigInteger totalNumber, BigInteger removedNumber, BigInteger addedNumber) {
         final StringBuilder result = new StringBuilder();
         result.append(totalNumber);

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -33,7 +33,7 @@ import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 
 import com.github.checkstyle.Main;
 import com.github.checkstyle.data.CheckstyleRecord;
-import com.github.checkstyle.data.CliPaths;
+import com.github.checkstyle.data.CliOptions;
 import com.github.checkstyle.data.DiffReport;
 import com.github.checkstyle.data.MergedConfigurationModule;
 import com.github.checkstyle.data.Statistics;
@@ -75,26 +75,26 @@ public final class SiteGenerator {
      *        container with parsed data.
      * @param diffConfiguration
      *        merged configurations from both reports.
-     * @param paths
-     *        CLI paths.
+     * @param options
+     *        CLI options.
      * @throws IOException
      *         on failure to write site to disc.
      */
     public static void generate(DiffReport diffReport, MergedConfigurationModule diffConfiguration,
-            CliPaths paths) throws IOException {
+            CliOptions options) throws IOException {
         // setup thymeleaf engine
         final TemplateEngine tplEngine = getTemplateEngine();
         // setup xreference generator
-        final XrefGenerator xrefGenerator = new XrefGenerator(paths.getRefFilesPath(),
-                paths.getOutputPath().resolve(Main.XREF_FILEPATH), paths.getOutputPath());
+        final XrefGenerator xrefGenerator = new XrefGenerator(options.getRefFilesPath(),
+                options.getOutputPath().resolve(Main.XREF_FILEPATH), options.getOutputPath());
         // html generation
-        final Path sitepath = paths.getOutputPath().resolve(SITEPATH);
+        final Path sitepath = options.getOutputPath().resolve(SITEPATH);
         final FileWriter writer = new FileWriter(sitepath.toString());
         try {
             // write statistics
             generateHeader(tplEngine, writer, diffReport.getStatistics(), diffConfiguration);
             // write parsed content
-            generateBody(tplEngine, writer, diffReport, paths, xrefGenerator);
+            generateBody(tplEngine, writer, diffReport, options, xrefGenerator);
             // write html footer
             tplEngine.process("footer", new Context(), writer);
         }
@@ -147,16 +147,16 @@ public final class SiteGenerator {
      *        file writer.
      * @param diffReport
      *        difference between two checkstyle reports.
-     * @param paths
-     *        CLI paths.
+     * @param options
+     *        CLI options.
      * @param xrefGenerator
      *        xReference generator.
      */
     private static void generateBody(TemplateEngine tplEngine, FileWriter writer,
-            DiffReport diffReport, CliPaths paths, XrefGenerator xrefGenerator) {
+            DiffReport diffReport, CliOptions options, XrefGenerator xrefGenerator) {
         final AnchorCounter anchorCounter = new AnchorCounter();
 
-        final Path refFilesPath = paths.getRefFilesPath();
+        final Path refFilesPath = options.getRefFilesPath();
         for (Map.Entry<String, List<CheckstyleRecord>> entry : diffReport.getRecords().entrySet()) {
             final List<CheckstyleRecord> records = entry.getValue();
             String filename = entry.getKey();
@@ -165,7 +165,7 @@ public final class SiteGenerator {
 
             for (CheckstyleRecord checkstyleRecord : records) {
                 final String xreference = xrefGenerator.generateXref(checkstyleRecord.getXref(),
-                            paths.isShortFilePaths());
+                            options.isShortFilePaths());
                 checkstyleRecord.setXref(xreference);
             }
 

--- a/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
+++ b/patch-diff-report-tool/src/test/java/com/github/checkstyle/MainTest.java
@@ -35,20 +35,7 @@ public class MainTest extends AbstractTest {
         Main.main("-h");
 
         Assert.assertEquals("patch-diff-report-tool execution started.\n"
-                + "This program creates symmetric difference from two"
-                + " checkstyle-result.xml reports\n" + "generated for checkstyle build.\n"
-                + "Command line arguments:\n"
-                + "\t--baseReportPath - path to the base checkstyle-result.xml (optional, if "
-                + "absent then only configuration and violations for patch will be in the "
-                + "report)\n" + "\t--patchReportPath - path to the patch checkstyle-result.xml,"
-                + " obligatory argument;\n"
-                + "\t--sourcePath - path to the data under check (optional, if absent"
-                + " then file structure for cross reference files won't be relativized,"
-                + " full paths will be used);\n"
-                + "\t--output - path to store the resulting diff report (optional,"
-                + " if absent then default path will be used:"
-                + " ~/XMLDiffGen_report_yyyy.mm.dd_hh_mm_ss), remember, if this folder"
-                + " exists its content will be purged;\n" + "\t-h - simply shows help message.\n"
+                + Main.MSG_HELP + "\n"
                 + "patch-diff-report-tool execution finished.\n", getSystemOut());
     }
 


### PR DESCRIPTION
Added missing documentation.
Fixed eclipse errors.
Renamed `CliPaths` to `CliOptions` since it does currently contain something that is not a path and I was thinking of expanding it for a new option. Also renamed `checkPaths` to `validate` since they aren't paths anymore. Split validate method between XML and Text for easier separation.