### PR TITLE
config: copy config from main repo to sync on usage and config

### DIFF
--- a/releasenotes-builder/config/intellij-idea-inspections.xml
+++ b/releasenotes-builder/config/intellij-idea-inspections.xml
@@ -1,2363 +1,5249 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inspections version="1.0">
-    <option name="myName" value="Releasenotes builder" />
-    <inspection_tool class="AbsoluteAlignmentInUserInterface" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AbstractBeanReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AbstractClassExtendsConcreteClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AbstractClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*|Check" />
-        <option name="m_minLength" value="5" />
-    </inspection_tool>
-    <inspection_tool class="AbstractClassNeverImplemented" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AbstractClassWithOnlyOneDirectInheritor" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AbstractClassWithoutAbstractMethods" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AbstractMethodCallInConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AbstractMethodOverridesAbstractMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AbstractMethodOverridesConcreteMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AbstractMethodWithMissingImplementations" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AccessStaticViaInstance" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AccessToNonThreadSafeStaticFieldFromInstance" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="nonThreadSafeClasses">
-            <value />
-        </option>
-        <option name="nonThreadSafeTypes" value="" />
-    </inspection_tool>
-    <inspection_tool class="AccessToStaticFieldLockedOnInstance" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AlphaUnsortedPropertiesFile" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AmbiguousFieldAccess" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AmbiguousMethodCall" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="Annotation" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AnnotationClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AnnotationNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="8" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="Annotator" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="Anonymous2MethodRef" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AnonymousClassComplexity" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="AnonymousClassMethodCount" enabled="true" level="WARNING" enabled_by_default="false">
-        <scope name="Production" level="ERROR" enabled="true">
-            <option name="m_limit" value="1" />
-        </scope>
-        <option name="m_limit" value="1" />
-    </inspection_tool>
-    <inspection_tool class="AnonymousClassVariableHidesContainingMethodVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AnonymousFunctionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AnonymousInnerClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AnonymousInnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="AntDuplicateTargetsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AntMissingPropertiesFileInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AntResolveInspection" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ArgNamesErrorsInspection" enabled="true" level="TYPO" enabled_by_default="true" />
-    <inspection_tool class="ArgNamesWarningsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AroundAdviceStyleInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ArquillianClassEnabled" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ArquillianDeploymentAbsent" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ArquillianDeploymentReturnType" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ArquillianDeploymentSignature" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ArquillianTooManyDeployment" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ArrayEquality" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ArrayEquals" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ArrayHashCode" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ArrayLengthInLoopCondition" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ArrayObjectsEquals" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ArraysAsListWithZeroOrOneArgument" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertAsName" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertEqualsBetweenInconvertibleTypes" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertEqualsBetweenInconvertibleTypesTestNG" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertEqualsCalledOnArray" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertEqualsMayBeAssertSame" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertMessageNotString" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AssertStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertWithSideEffects" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertsWithoutMessages" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AssertsWithoutMessagesTestNG" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssignmentResultUsedJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssignmentToCatchBlockParameter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssignmentToCollectionFieldFromParameter" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignorePrivateMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="AssignmentToDateFieldFromParameter" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignorePrivateMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="AssignmentToForLoopParameter" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_checkForeachParameters" value="true" />
-    </inspection_tool>
-    <inspection_tool class="AssignmentToForLoopParameterJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssignmentToFunctionParameterJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssignmentToLambdaParameter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssignmentToMethodParameter" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreTransformationOfOriginalParameter" value="false" />
-    </inspection_tool>
-    <inspection_tool class="AssignmentToNull" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AssignmentToStaticFieldFromInstanceMethod" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AssignmentToSuperclassField" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssignmentUsedAsCondition" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AutoBoxing" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreAddedToCollection" value="false" />
-    </inspection_tool>
-    <inspection_tool class="AutoCloseableResource" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AutoUnboxing" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AutowiredDependenciesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AwaitNotInLoop" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AwaitWithoutCorrespondingSignal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="BadExceptionCaught" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="exceptionsString" value="" />
-        <option name="exceptions">
-            <value />
-        </option>
-    </inspection_tool>
-    <inspection_tool class="BadExceptionDeclared" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false">
-            <option name="exceptionsString" value="" />
-            <option name="exceptions">
-                <value />
-            </option>
-            <option name="ignoreTestCases" value="false" />
-            <option name="ignoreLibraryOverrides" value="false" />
-        </scope>
-        <option name="exceptionsString" value="" />
-        <option name="exceptions">
-            <value />
-        </option>
-        <option name="ignoreTestCases" value="false" />
-        <option name="ignoreLibraryOverrides" value="false" />
-    </inspection_tool>
-    <inspection_tool class="BadExceptionThrown" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="exceptionsString" value="" />
-        <option name="exceptions">
-            <value />
-        </option>
-    </inspection_tool>
-    <inspection_tool class="BadExpressionStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BadOddness" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashAddShebang" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashArrayUseOfSimple" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashBuiltInVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashDuplicateFunction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashEvaluateArithmeticExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashEvaluateExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashFixShebang" enabled="true" level="ERROR" enabled_by_default="true">
-        <shebang>/bin/bash</shebang>
-        <shebang>/bin/sh</shebang>
-    </inspection_tool>
-    <inspection_tool class="BashFloatArithmetic" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashGlobalLocalVarDef" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashInternalCommandFunctionOverride" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashMissingInclude" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashReadOnlyVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="BashRecursiveInclusion" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashReplaceWithBackquote" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashReplaceWithSubshell" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashSimpleArrayUse" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashSimpleVarUsage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashUnknownFileDescriptor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashUnregisterGlobalVariableInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashUnresolvedVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashUnusedFunction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashUnusedFunctionParams" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashWrapFunction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BashWrapWord" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BatchJobDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="BatchXmlDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="BeforeClassOrAfterClassIsPublicStaticVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BeforeOrAfterIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BigDecimalEquals" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BigDecimalLegacyMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BigDecimalMethodWithoutRoundingCalled" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BindingAnnotationWithoutInject" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BlockMarkerComments" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BlockStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BooleanConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BooleanMethodIsAlwaysInverted" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="BooleanMethodNameMustStartWithQuestion" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false">
-            <option name="ignoreBooleanMethods" value="false" />
-            <option name="ignoreInAnnotationInterface" value="true" />
-            <option name="onlyWarnOnBaseMethods" value="true" />
-            <option name="questionString" value="is,can,has,should,could,will,shall,check,contains,equals,add,put,remove,startsWith,endsWith" />
-        </scope>
-        <option name="ignoreBooleanMethods" value="false" />
-        <option name="ignoreInAnnotationInterface" value="true" />
-        <option name="onlyWarnOnBaseMethods" value="true" />
-        <option name="questionString" value="is,can,has,should,could,will,shall,check,contains,equals,add,put,remove,starts,ends,are,was,matches,start,must,accept" />
-    </inspection_tool>
-    <inspection_tool class="BooleanParameter" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="BooleanVariableAlwaysNegated" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="BoxingBoxedValue" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BreakStatement" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="BreakStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BreakStatementWithLabel" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BreakStatementWithLabelJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BusyWait" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="BvConfigDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="BvConstraintMappingsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CStyleArrayDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CachedNumberConstructorCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CallToNativeMethodWhileLocked" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CallToSimpleGetterInClass" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreGetterCallsOnOtherObjects" value="false" />
-        <option name="onlyReportPrivateGetter" value="false" />
-    </inspection_tool>
-    <inspection_tool class="CallToSimpleSetterInClass" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreSetterCallsOnOtherObjects" value="false" />
-        <option name="onlyReportPrivateSetter" value="false" />
-    </inspection_tool>
-    <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CallerJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CanBeFinal" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="REPORT_CLASSES" value="false" />
-        <option name="REPORT_METHODS" value="false" />
-        <option name="REPORT_FIELDS" value="true" />
-    </inspection_tool>
-    <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CastThatLosesPrecision" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreIntegerCharCasts" value="false" />
-    </inspection_tool>
-    <inspection_tool class="CastToConcreteClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CastToIncompatibleInterface" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CaughtExceptionImmediatelyRethrown" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CdiAlternativeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiDecoratorInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiDisposerMethodInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiDomBeans" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CdiInjectInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiInjectionPointsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CdiInterceptorInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiManagedBeanInconsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiNormalScopeInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CdiObservesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiScopeInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CdiSpecializesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiStereotypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiStereotypeRestrictionsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiTypedAnnotationInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CdiUnproxyableBeanTypesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CfmlFileReference" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CfmlReferenceInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ChainedEquality" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ChainedEqualityJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ChainedFunctionCallJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ChainedMethodCall" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreFieldInitializations" value="true" />
-        <option name="m_ignoreThisSuperCalls" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ChannelResource" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="insideTryAllowed" value="false" />
-    </inspection_tool>
-    <inspection_tool class="CharUsedInArithmeticContext" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CharacterComparison" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CheckDtdRefs" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CheckEmptyScriptTag" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CheckForOutOfMemoryOnLargeArrayAllocation" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_limit" value="64" />
-    </inspection_tool>
-    <inspection_tool class="CheckImageSize" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CheckNodeTest" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CheckStyle" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="CheckTagEmptyBody" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CheckValidXmlInScriptTagBody" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CheckXmlFileWithXercesValidator" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CheckedExceptionClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ClashingGetters" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ClashingTraitMethods" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ClassComplexity" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_limit" value="80" />
-    </inspection_tool>
-    <inspection_tool class="ClassCoupling" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_includeJavaClasses" value="false" />
-        <option name="m_includeLibraryClasses" value="false" />
-        <option name="m_limit" value="15" />
-    </inspection_tool>
-    <inspection_tool class="ClassEscapesItsScope" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClassHasNoToStringMethod" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="excludeClassNames" value="" />
-        <option name="excludeException" value="true" />
-        <option name="excludeDeprecated" value="true" />
-        <option name="excludeEnum" value="false" />
-        <option name="excludeAbstract" value="false" />
-        <option name="excludeTestCode" value="false" />
-        <option name="excludeInnerClasses" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ClassIndependentOfModule" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ClassInheritanceDepth" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_limit" value="2" />
-    </inspection_tool>
-    <inspection_tool class="ClassInitializer" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClassInitializerMayBeStatic" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ClassLoaderInstantiation" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ClassMayBeInterface" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClassNamePrefixedWithPackageName" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ClassNameSameAsAncestorName" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="3" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="ClassNestingDepth" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="1" />
-    </inspection_tool>
-    <inspection_tool class="ClassNewInstance" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClassOnlyUsedInOneModule" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ClassOnlyUsedInOnePackage" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ClassReferencesSubclass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ClassUnconnectedToPackage" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ClassWithMultipleLoggers" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="loggerNamesString" value="java.util.logging.Logger,org.slf4j.Logger,org.apache.commons.logging.Log,org.apache.log4j.Logger" />
-    </inspection_tool>
-    <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClassWithTooManyDependencies" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="limit" value="30" />
-    </inspection_tool>
-    <inspection_tool class="ClassWithTooManyDependents" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="limit" value="300" />
-    </inspection_tool>
-    <inspection_tool class="ClassWithTooManyTransitiveDependencies" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="limit" value="75" />
-    </inspection_tool>
-    <inspection_tool class="ClassWithTooManyTransitiveDependents" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="limit" value="500" />
-    </inspection_tool>
-    <inspection_tool class="ClassWithoutConstructor" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ClassWithoutLogger" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="loggerNamesString" value="java.util.logging.Logger,org.slf4j.Logger,org.apache.commons.logging.Log,org.apache.log4j.Logger" />
-        <option name="ignoreSuperLoggers" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ClassWithoutNoArgConstructor" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreClassesWithNoConstructors" value="true" />
-    </inspection_tool>
-    <inspection_tool class="CloneCallsConstructors" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CloneCallsSuperClone" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CloneDeclaresCloneNotSupported" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CloneInNonCloneableClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CloneReturnsClassType" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CloneableClassInSecureContext" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CloneableImplementsClone" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreCloneableDueToInheritance" value="false" />
-    </inspection_tool>
-    <inspection_tool class="CodeBlock2Expr" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptArgumentsOutsideFunction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptFunctionSignatures" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptInfiniteLoop" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptLiteralNotFunction" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptSillyAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptSwitchStatementWithNoDefaultBranch" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptUnnecessaryReturn" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CoffeeScriptUnusedLocalSymbols" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CollectionAddAllCanBeReplacedWithConstructor" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CollectionAddedToSelf" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CollectionContainsUrl" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CollectionsFieldAccessReplaceableByMethodCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CollectionsMustHaveInitialCapacity" enabled="false" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="CommaExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ComparatorMethodParameterNotUsed" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ComparatorNotSerializable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ComparisonToNaN" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConditionalExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreSimpleAssignmentsAndReturns" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ConditionalExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConditionalExpressionWithIdenticalBranches" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConditionalExpressionWithIdenticalBranchesJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConflictingAnnotations" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConfusingElse" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="reportWhenNoStatementFollow" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ConfusingFloatingPointLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConfusingFloatingPointLiteralJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConfusingOctalEscape" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConfusingPlusesOrMinusesJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConnectionResource" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConstantConditionalExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantConditionalExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantConditions" enabled="false" level="WARNING" enabled_by_default="false">
-        <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
-        <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ConstantDeclaredInAbstractClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ConstantDeclaredInInterface" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConstantIfStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantIfStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantJUnitAssertArgument" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantMathCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="onlyCheckImmutables" value="false" />
-        <option name="m_regex" value="[A-Z][A-Z_\d]*" />
-        <option name="m_minLength" value="2" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="ConstantOnLHSOfComparison" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantOnLHSOfComparisonJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantOnWrongSideOfComparison" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ConstantOnWrongSideOfComparisonJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantStringIntern" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstantValueVariableUse" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstraintValidatorCreator" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConstructorCount" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreDeprecatedConstructors" value="false" />
-        <option name="m_limit" value="5" />
-    </inspection_tool>
-    <inspection_tool class="ContextComponentScanInconsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ContextJavaBeanUnresolvedMethodsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ContinueOrBreakFromFinallyBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ContinueOrBreakFromFinallyBlockJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ContinueStatement" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ContinueStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ContinueStatementWithLabel" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ContinueStatementWithLabelJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Contract" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2Diamond" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2Lambda" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2MethodRef" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2streamapi" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConvertAnnotations" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConvertJavadoc" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ConvertOldAnnotations" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CovariantCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CovariantEquals" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CriteriaApiResolveInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssConvertColorToHexInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssConvertColorToRgbInspection" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CssFloatPxLength" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidAtRule" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidCharsetRule" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidElement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidFunction" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidHtmlTagReference" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidImport" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidMediaFeature" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidPropertyValue" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssInvalidPseudoSelector" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssMissingComma" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssMissingSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssNegativeValue" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssNoGenericFontName" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssOptimizeSimilarProperties" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssOverwrittenProperties" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssRedundantUnit" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssUnitlessNumber" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CssUnknownProperty" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="myCustomPropertiesEnabled" value="false" />
-        <option name="myIgnoreVendorSpecificProperties" value="false" />
-        <option name="myCustomPropertiesList">
-            <value>
-                <list size="0" />
-            </value>
-        </option>
-    </inspection_tool>
-    <inspection_tool class="CssUnknownTarget" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CssUnusedSymbol" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CucumberExamplesColon" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CucumberJavaStepDefClassInDefaultPackage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CucumberJavaStepDefClassIsPublic" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CucumberMissedExamples" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CucumberTableInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CucumberUndefinedStep" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CustomClassloader" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CustomSecurityManager" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CyclicClassDependency" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CyclicPackageDependency" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CyclomaticComplexity" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_limit" value="10" />
-    </inspection_tool>
-    <inspection_tool class="CyclomaticComplexityJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="10" />
-    </inspection_tool>
-    <inspection_tool class="DanglingJavadoc" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="DataProviderReturnType" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DateToString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DebuggerStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DeclareCollectionAsInterface" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreLocalVariables" value="false" />
-        <option name="ignorePrivateMethodsAndFields" value="false" />
-    </inspection_tool>
-    <inspection_tool class="DeclareParentsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DefaultFileTemplate" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="CHECK_FILE_HEADER" value="true" />
-        <option name="CHECK_TRY_CATCH_SECTION" value="true" />
-        <option name="CHECK_METHOD_BODY" value="true" />
-    </inspection_tool>
-    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DefaultNotLastCaseInSwitchJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DelegatesTo" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Dependency" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DeprecatedClassUsageInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="Deprecation" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="DeserializableClassInSecureContext" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="DesignForExtension" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="DialogTitleCapitalization" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DisjointPackage" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="DivideByZero" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DivideByZeroJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DocumentWriteJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DoubleBraceInitialization" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DoubleCheckedLocking" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreOnVolatileVariables" value="false" />
-    </inspection_tool>
-    <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DoubleNegation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DriverManagerGetConnection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DuplicateBooleanBranch" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DuplicateCaseLabelJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DuplicateCondition" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreMethodCalls" value="false" />
-    </inspection_tool>
-    <inspection_tool class="DuplicateConditionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DuplicatePropertyInspection" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="CURRENT_FILE" value="true" />
-        <option name="MODULE_WITH_DEPENDENCIES" value="false" />
-        <option name="CHECK_DUPLICATE_VALUES" value="true" />
-        <option name="CHECK_DUPLICATE_KEYS" value="true" />
-        <option name="CHECK_DUPLICATE_KEYS_WITH_DIFFERENT_VALUES" value="true" />
-    </inspection_tool>
-    <inspection_tool class="DuplicateStringLiteralInspection" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="MIN_STRING_LENGTH" value="5" />
-        <option name="IGNORE_PROPERTY_KEYS" value="false" />
-    </inspection_tool>
-    <inspection_tool class="DuplicateThrows" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DuplicatedBeanNamesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DuplicatedDataProviderNames" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DuplicatedCode" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="DynamicRegexReplaceableByCompiledPattern" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="DynamicallyGeneratedCodeJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ELDeferredExpressionsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ELMethodSignatureInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ELSpecValidationInJSP" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ELValidationInJSP" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ES6Validation" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbClassBasicInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbClassWarningsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EjbDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbEntityClassInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbEntityHomeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbEntityInterfaceInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbEnvironmentInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbInterceptorInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbInterceptorWarningsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EjbInterfaceMethodInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbInterfaceSignatureInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbProhibitedPackageUsageInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EjbQlInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbRemoteRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbSessionHomeInterfaceInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EjbStaticAccessInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EjbThisExpressionInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EmptyCatchBlock" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_includeComments" value="true" />
-        <option name="m_ignoreTestCases" value="true" />
-        <option name="m_ignoreIgnoreParameter" value="true" />
-    </inspection_tool>
-    <inspection_tool class="EmptyCatchBlockJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EmptyClass" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignorableAnnotations">
-            <value />
-        </option>
-        <option name="ignoreClassWithParameterization" value="false" />
-        <option name="ignoreThrowables" value="true" />
-    <option name="commentsAreContent" value="true" />
-    </inspection_tool>
-    <inspection_tool class="EmptyDirectory" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EmptyFinallyBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EmptyFinallyBlockJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EmptyInitializer" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EmptyMethod" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="EmptyStatementBody" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_reportEmptyBlocks" value="true" />
-    </inspection_tool>
-    <inspection_tool class="EmptyStatementBodyJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_reportEmptyBlocks" value="false" />
-    </inspection_tool>
-    <inspection_tool class="EmptySynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EmptyTryBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EmptyTryBlockJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EmptyWebServiceClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EnumAsName" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EnumClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreSwitchStatementsWithDefault" value="false" />
-    </inspection_tool>
-    <inspection_tool class="EnumeratedClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="EnumeratedConstantNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Z_\d]*" />
-        <option name="m_minLength" value="2" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="EnumerationCanBeIteration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EqualityComparisonWithCoercionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EqualsAndHashcode" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EqualsBetweenInconvertibleTypes" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EqualsCalledOnEnumConstant" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EqualsHashCodeCalledOnUrl" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EqualsReplaceableByObjectsCall" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="EqualsUsesNonFinalVariable" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="EqualsWhichDoesntCheckParameterClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="EqualsWithItself" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ErrorRethrown" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="Eslint" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="ExceptionCaughtLocallyJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExceptionFromCatchWhichDoesntWrap" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreGetMessage" value="false" />
-        <option name="ignoreCantWrap" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ExceptionNameDoesntEndWithException" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ExpectedExceptionNeverThrown" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExpectedExceptionNeverThrownTestNG" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExplicitGet" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExtendsAnnotation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExtendsConcreteCollection" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ExtendsObject" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExtendsThread" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ExtendsThrowable" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ExtendsUtilityClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExternalizableWithSerializationMethods" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ExternalizableWithoutPublicNoArgConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FacesModelInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FallThroughInSwitchStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FallthruInSwitchStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FeatureEnvy" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreTestCases" value="false" />
-    </inspection_tool>
-    <inspection_tool class="FieldAccessNotGuarded" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FieldAccessedSynchronizedAndUnsynchronized" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="countGettersAndSetters" value="false" />
-    </inspection_tool>
-    <inspection_tool class="FieldCanBeLocal" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FieldCount" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_countConstantFields" value="false" />
-        <option name="m_considerStaticFinalFieldsConstant" value="false" />
-        <option name="myCountEnumConstants" value="false" />
-        <option name="m_limit" value="10" />
-    </inspection_tool>
-    <inspection_tool class="FieldHasSetterButNoGetter" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="FieldHidesSuperclassField" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_ignoreInvisibleFields" value="true" />
-    </inspection_tool>
-    <inspection_tool class="FieldMayBeFinal" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FieldNotUsedInToString" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="FieldRepeatedlyAccessed" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreFinalFields" value="false" />
-    </inspection_tool>
-    <inspection_tool class="FinalClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="FinalMethod" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="FinalMethodInFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FinalPrivateMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FinalStaticMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Finalize" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreTrivialFinalizers" value="true" />
-    </inspection_tool>
-    <inspection_tool class="FinalizeCallsSuperFinalize" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreObjectSubclasses" value="false" />
-        <option name="ignoreTrivialFinalizers" value="true" />
-    </inspection_tool>
-    <inspection_tool class="FinalizeNotProtected" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FinallyBlockCannotCompleteNormally" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FloatingPointEquality" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FlowRequiredBeanTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ForCanBeForeach" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="REPORT_INDEXED_LOOP" value="true" />
-        <option name="ignoreUntypedCollections" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ForLoopReplaceableByWhile" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreLoopsWithoutConditions" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ForLoopReplaceableByWhileJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreLoopsWithoutConditions" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ForLoopThatDoesntUseLoopVariableJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ForLoopWithMissingComponent" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreCollectionLoops" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ForeachStatement" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="FtlCallsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FtlDeprecatedBuiltInsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FtlFileReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FtlImportCallInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FtlReferencesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FtlTypesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FtlWellformednessInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FunctionNamingConventionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="FunctionWithInconsistentReturnsJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FunctionWithMultipleLoopsJS" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="FunctionWithMultipleReturnPointsJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GherkinBrokenTableInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="GherkinMisplacedBackground" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="GjsLint" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="GrDeprecatedAPIUsage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GrEqualsBetweenInconvertibleTypes" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GrFieldAlreadyDefined" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GrFinalVariableAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GrMethodMayBeStatic" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GrPackage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GrReassignedInClosureLocalVar" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GrUnresolvedAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyAccessToStaticFieldLockedOnInstance" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyAccessibility" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyAnnotationNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="8" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="GroovyAssignabilityCheck" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyAssignmentCanBeOperatorAssignment" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreLazyOperators" value="true" />
-        <option name="ignoreObscureOperators" value="false" />
-    </inspection_tool>
-    <inspection_tool class="GroovyAssignmentToForLoopParameter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyAssignmentToMethodParameter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyBreak" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyBusyWait" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyClassNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="8" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="GroovyConditional" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyConditionalCanBeConditionalCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyConditionalCanBeElvis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyConditionalWithIdenticalBranches" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyConstantConditional" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyConstantIfStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyConstantNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z\d]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="GroovyConstructorNamedArguments" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyContinue" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyContinueOrBreakFromFinallyBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyDivideByZero" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyDocCheck" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="GroovyDoubleCheckedLocking" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreOnVolatileVariables" value="false" />
-    </inspection_tool>
-    <inspection_tool class="GroovyDoubleNegation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyDuplicateSwitchBranch" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyEmptyCatchBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyEmptyFinallyBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyEmptyStatementBody" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyEmptySyncBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyEmptyTryBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyEnumerationNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="8" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="GroovyFallthrough" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyIfStatementWithIdenticalBranches" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyIfStatementWithTooManyBranches" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="GroovyInArgumentCheck" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyInfiniteLoopStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyInfiniteRecursion" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyInstanceMethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="GroovyInstanceVariableNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="m_[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="1" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="GroovyInterfaceNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="8" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="GroovyLabeledStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyListGetCanBeKeyedAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyListSetCanBeKeyedAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyLocalVariableNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="GroovyLoopStatementThatDoesntLoop" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyMapGetCanBeKeyedAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyMapPutCanBeKeyedAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyMethodParameterCount" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="5" />
-    </inspection_tool>
-    <inspection_tool class="GroovyMethodWithMoreThanThreeNegations" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyMissingReturnStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyMultipleReturnPointsPerMethod" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="1" />
-    </inspection_tool>
-    <inspection_tool class="GroovyNegatedConditional" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyNegatedIf" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyNestedAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyNestedConditional" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyNestedSwitch" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyNestedSynchronizedStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyNonShortCircuitBoolean" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyNotifyWhileNotSynchronized" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyOctalInteger" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyOverlyComplexArithmeticExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="GroovyOverlyComplexBooleanExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="GroovyOverlyComplexMethod" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="10" />
-    </inspection_tool>
-    <inspection_tool class="GroovyOverlyLongMethod" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="30" />
-    </inspection_tool>
-    <inspection_tool class="GroovyOverlyNestedMethod" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="5" />
-    </inspection_tool>
-    <inspection_tool class="GroovyParameterNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="GroovyPointlessArithmetic" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyPointlessBoolean" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyPublicFieldAccessedInSynchronizedContext" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyRangeTypeCheck" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyResultOfAssignmentUsed" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyResultOfIncrementOrDecrementUsed" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyResultOfObjectAllocationIgnored" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyReturnFromClosureCanBeImplicit" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyReturnFromFinallyBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovySillyAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovySingletonAnnotation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyStaticMethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="GroovyStaticVariableNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="s_[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="4" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="GroovySwitchStatementWithNoDefault" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovySynchronizationOnNonFinalField" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovySynchronizationOnThis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovySynchronizationOnVariableInitializedWithLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovySynchronizedMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovySystemRunFinalizersOnExit" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyThreadStopSuspendResume" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyThrowFromFinallyBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyTrivialConditional" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyTrivialIf" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUncheckedAssignmentOfMemberOfRawType" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnconditionalWait" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnnecessaryContinue" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnnecessaryReturn" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnreachableStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnsynchronizedMethodOverridesSynchronizedMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUntypedAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnusedAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnusedCatchParameter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnusedDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyUnusedIncOrDec" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyVariableCanBeFinal" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyVariableNotAssigned" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyWaitCallNotInLoop" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyWaitWhileNotSynchronized" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="GroovyWhileLoopSpinsOnField" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreNonEmtpyLoops" value="false" />
-    </inspection_tool>
-    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="GuavaFluentIterable" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="HardCodedStringLiteral" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreForAssertStatements" value="true" />
-        <option name="ignoreForExceptionConstructors" value="true" />
-        <option name="ignoreForSpecifiedExceptionConstructors" value="" />
-        <option name="ignoreForJUnitAsserts" value="true" />
-        <option name="ignoreForClassReferences" value="true" />
-        <option name="ignoreForPropertyKeyReferences" value="true" />
-        <option name="ignoreForNonAlpha" value="true" />
-        <option name="ignoreAssignedToConstants" value="false" />
-        <option name="ignoreToString" value="false" />
-        <option name="nonNlsCommentPattern" value="NON-NLS" />
-    </inspection_tool>
-    <inspection_tool class="HardcodedFileSeparators" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_recognizeExampleMediaType" value="false" />
-    </inspection_tool>
-    <inspection_tool class="HardcodedLineSeparators" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="HardwiredNamespacePrefix" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HashCodeUsesNonFinalVariable" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="HibernateConfigDomFacetInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HibernateConfigDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="HibernateMappingDatasourceDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="HibernateMappingDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="HibernateResource" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="insideTryAllowed" value="false" />
-    </inspection_tool>
-    <inspection_tool class="HtmlDeprecatedTag" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HtmlExtraClosingTag" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="HtmlFormInputWithoutLabel" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HtmlNonExistentInternetResource" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HtmlPresentationalElement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="HtmlUnknownAnchorTarget" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="myValues">
-            <value>
-                <list size="0" />
-            </value>
-        </option>
-        <option name="myCustomValuesEnabled" value="true" />
-    </inspection_tool>
-    <inspection_tool class="HtmlUnknownBooleanAttribute" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="HtmlUnknownTag" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="myValues">
-            <value>
-                <list size="6">
-                    <item index="0" class="java.lang.String" itemvalue="nobr" />
-                    <item index="1" class="java.lang.String" itemvalue="noembed" />
-                    <item index="2" class="java.lang.String" itemvalue="comment" />
-                    <item index="3" class="java.lang.String" itemvalue="noscript" />
-                    <item index="4" class="java.lang.String" itemvalue="embed" />
-                    <item index="5" class="java.lang.String" itemvalue="script" />
-                </list>
-            </value>
-        </option>
-        <option name="myCustomValuesEnabled" value="true" />
-    </inspection_tool>
-    <inspection_tool class="HtmlUnknownTarget" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="IOResource" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false">
-            <option name="ignoredTypesString" value="java.io.ByteArrayOutputStream,java.io.ByteArrayInputStream,java.io.StringBufferInputStream,java.io.CharArrayWriter,java.io.CharArrayReader,java.io.StringWriter,java.io.StringReader" />
-            <option name="insideTryAllowed" value="false" />
-        </scope>
-        <option name="ignoredTypesString" value="java.io.ByteArrayOutputStream,java.io.ByteArrayInputStream,java.io.StringBufferInputStream,java.io.CharArrayWriter,java.io.CharArrayReader,java.io.StringWriter,java.io.StringReader" />
-        <option name="insideTryAllowed" value="false" />
-    </inspection_tool>
-    <inspection_tool class="IfCanBeSwitch" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="minimumBranches" value="3" />
-        <option name="suggestIntSwitches" value="false" />
-        <option name="suggestEnumSwitches" value="false" />
-    </inspection_tool>
-    <inspection_tool class="IfMayBeConditional" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="IfNullToElvis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IfStatementWithIdenticalBranches" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IfStatementWithIdenticalBranchesJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IfStatementWithTooManyBranches" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="8" />
-    </inspection_tool>
-    <inspection_tool class="IfStatementWithTooManyBranchesJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="IfThenToElvis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IfThenToSafeAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IgnoreCoverEntry" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IgnoreDuplicateEntry" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="IgnoreIncorrectEntry" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="IgnoreRelativeEntry" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="IgnoreResultOfCall" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_reportAllNonLibraryCalls" value="false" />
-        <option name="callCheckString" value="java.io.InputStream,read|skip|available|markSupported,java.io.Writer,read|skip|ready|markSupported,java.lang.Boolean,.*,java.lang.Byte,.*,java.lang.Character,.*,java.lang.Double,.*,java.lang.Float,.*,java.lang.Long,.*,java.lang.Math,.*,java.lang.Object,equals|hashCode|toString,java.lang.Short,.*,java.lang.StrictMath,.*,java.lang.String,.*,java.math.BigInteger,.*,java.math.BigDecimal,.*,java.net.InetAddress,.*,java.net.URI,.*,java.util.UUID,.*" />
-    </inspection_tool>
-    <inspection_tool class="IgnoreSyntaxEntry" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="IgnoreUnusedEntry" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="IgnoredJUnitTest" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ImplicitArrayToString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ImplicitCallToSuper" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreForObjectSubclasses" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ImplicitDefaultCharsetUsage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ImplicitNumericConversion" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreWideningConversions" value="false" />
-        <option name="ignoreCharConversions" value="false" />
-        <option name="ignoreConstantConversions" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ImplicitTypeConversion" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="BITS" value="1720" />
-        <option name="FLAG_EXPLICIT_CONVERSION" value="true" />
-        <option name="IGNORE_NODESET_TO_BOOLEAN_VIA_STRING" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ImplicitlyExposedWebServiceMethods" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IncompatibleMask" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IncompatibleMaskJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InconsistentLanguageLevel" enabled="true" level="ERROR" enabled_by_default="true" />
-    <!-- till https://youtrack.jetbrains.com/issue/IDEA-200207 -->
-    <inspection_tool class="InconsistentLineSeparators" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InconsistentResourceBundle" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="IncorrectOnMessageMethodsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="IncrementDecrementResultUsedJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IndexOfReplaceableByContains" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IndexZeroUsage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InfiniteLoopJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InfiniteLoopStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InfiniteRecursion" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InfiniteRecursionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InjectedReferences" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InjectionNotApplicable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InjectionValueTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InnerClassOnInterface" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_ignoreInnerInterfaces" value="false" />
-    </inspection_tool>
-    <inspection_tool class="InnerClassReferencedViaSubclass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InnerClassVariableHidesOuterClassVariable" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_ignoreInvisibleFields" value="true" />
-    </inspection_tool>
-    <inspection_tool class="InnerHTMLJS" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="InstanceGuardedByStatic" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InstanceMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="3" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="InstanceVariableInitialization" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignorePrimitives" value="false" />
-    </inspection_tool>
-    <inspection_tool class="InstanceVariableNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="2" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="InstanceVariableOfConcreteClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="InstanceVariableUninitializedUse" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignorePrimitives" value="false" />
-        <option name="annotationNamesString" value="" />
-    </inspection_tool>
-    <inspection_tool class="InstanceofCatchParameter" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InstanceofChain" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreInstanceofOnLibraryClasses" value="false" />
-    </inspection_tool>
-    <inspection_tool class="InstanceofIncompatibleInterface" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InstanceofInterfaces" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="InstanceofThis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InstantiatingObjectToGetClassObject" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InstantiationOfUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="IntLiteralMayBeLongLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IntegerDivisionInFloatingPointContext" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IntegerMultiplicationImplicitCastToLong" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreNonOverflowingCompileTimeConstants" value="true" />
-    </inspection_tool>
-    <inspection_tool class="InterceptionAnnotationWithoutRuntimeRetention" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InterfaceMayBeAnnotatedFunctional" enabled="false" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InterfaceNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="6" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="InterfaceNeverImplemented" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreInterfacesThatOnlyDeclareConstants" value="false" />
-    </inspection_tool>
-    <inspection_tool class="InterfaceWithOnlyOneDirectInheritor" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="IntroduceWhenSubject" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InvalidImplementedBy" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InvalidProvidedBy" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="InvalidRequestParameters" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IteratorHasNextCallsIteratorNext" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="IteratorNextDoesNotThrowNoSuchElementException" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JDBCExecuteWithNonConstantString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JDBCPrepareStatementWithNonConstantString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JDBCResource" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="insideTryAllowed" value="false" />
-    </inspection_tool>
-    <inspection_tool class="JNDIResource" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="insideTryAllowed" value="false" />
-    </inspection_tool>
-    <inspection_tool class="JSAccessibilityCheck" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSBitwiseOperatorUsage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSCheckFunctionSignatures" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSClosureCompilerSyntax" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSCommentMatchesSignature" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSComparisonWithNaN" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSConsecutiveCommasInArrayLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSConstructorReturnsPrimitive" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSDeclarationsAtScopeStart" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="JSDeprecatedSymbols" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSDuplicatedDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSFileReferences" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSHint" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="JSJQueryEfficiency" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSLastCommaInArrayLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSLastCommaInObjectLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSLint" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="JSMethodCanBeStatic" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSMismatchedCollectionQueryUpdate" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="queries" value="trace,write,forEach" />
-        <option name="updates" value="pop,push,shift,splice,unshift" />
-    </inspection_tool>
-    <inspection_tool class="JSPotentiallyInvalidConstructorUsage" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="myConsiderUppercaseFunctionsToBeConstructors" value="true" />
-    </inspection_tool>
-    <inspection_tool class="JSPotentiallyInvalidTargetOfIndexedPropertyAccess" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSPotentiallyInvalidUsageOfThis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSPrimitiveTypeWrapperUsage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSReferencingMutableVariableFromClosure" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSSuspiciousNameCombination" enabled="true" level="ERROR" enabled_by_default="true">
-        <group names="x,width,left,right" />
-        <group names="y,height,top,bottom" />
-        <exclude classes="Math" />
-    </inspection_tool>
-    <inspection_tool class="JSTypeOfValues" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUndeclaredVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUndefinedPropertyAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnfilteredForInLoop" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnnecessarySemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnresolvedFunction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnresolvedLibraryURL" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnresolvedVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnusedAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnusedGlobalSymbols" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSUnusedLocalSymbols" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSValidateJSDoc" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JSValidateTypes" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JUnit3MethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JUnit3StyleTestMethodInJUnit4Class" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JUnit4AnnotatedMethodInJUnit3TestCase" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JUnit4MethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_maxLength" value="80" />
-    </inspection_tool>
-    <inspection_tool class="JUnitAbstractTestClassNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*TestCase" />
-        <option name="m_minLength" value="12" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="JUnitDatapoint" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JUnitRule" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JUnitTestClassNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*Test" />
-        <option name="m_minLength" value="8" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="JUnitTestNG" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="JavaDoc" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="TOP_LEVEL_CLASS_OPTIONS">
-            <value>
-                <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
-                <option name="REQUIRED_TAGS" value="" />
-            </value>
-        </option>
-        <option name="INNER_CLASS_OPTIONS">
-            <value>
-                <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
-                <option name="REQUIRED_TAGS" value="" />
-            </value>
-        </option>
-        <option name="METHOD_OPTIONS">
-            <value>
-                <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
-                <option name="REQUIRED_TAGS" value="@return@param@throws or @exception" />
-            </value>
-        </option>
-        <option name="FIELD_OPTIONS">
-            <value>
-                <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
-                <option name="REQUIRED_TAGS" value="" />
-            </value>
-        </option>
-        <option name="IGNORE_DEPRECATED" value="false" />
-        <option name="IGNORE_JAVADOC_PERIOD" value="true" />
-        <option name="IGNORE_DUPLICATED_THROWS" value="false" />
-        <option name="IGNORE_POINT_TO_ITSELF" value="false" />
-        <option name="myAdditionalJavadocTags" value="" />
-    </inspection_tool>
-    <inspection_tool class="JavaFxDefaultTag" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JavaFxUnresolvedFxIdReference" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JavaFxUnresolvedStyleClassReference" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JavaFxUnusedImports" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JavaLangImport" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JavaLangReflect" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JavaStylePropertiesInvocation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JavacQuirks" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JavadocReference" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JavaeeApplicationDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JdkProxiedBeanTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaAttributeMemberSignatureInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaAttributeTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaConfigDomFacetInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JpaDataSourceORMDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaDataSourceORMInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaEntityListenerInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaEntityListenerWarningsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JpaMissingIdInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaModelReferenceInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaORMDomInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaObjectClassSignatureInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaQlInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JpaQueryApiInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="Jscs" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="JsfJamExtendsClassInconsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JsfManagedBeansInconsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JsonDuplicatePropertyKeys" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JsonStandardCompliance" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JspAbsolutePathInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JspDirectiveInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JspPropertiesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JspTagBodyContent" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JspUnescapedEl" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="KDocUnresolvedReference" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="KeySetIterationMayUseEntrySet" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="KotlinDeprecation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LabeledStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LabeledStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LambdaParameterHidingMemberVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="LambdaParameterNamingConvention" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="LanguageMismatch" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="CHECK_NON_ANNOTATED_REFERENCES" value="true" />
-    </inspection_tool>
-    <inspection_tool class="LawOfDemeter" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreLibraryCalls" value="true" />
-    </inspection_tool>
-    <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="LengthOneStringsInConcatenation" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="LessResolvedByNameOnly" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LessUnresolvedMixin" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LessUnresolvedVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LimitedScopeInnerClass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ListIndexOfReplaceableByContains" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ListenerMayUseAdapter" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="checkForEmptyMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="LiteralAsArgToStringEquals" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LoadLibraryWithNonConstantString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LocalCanBeFinal" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="REPORT_VARIABLES" value="true" />
-        <option name="REPORT_PARAMETERS" value="true" />
-    </inspection_tool>
-    <inspection_tool class="LocalVariableHidingMemberVariable" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_ignoreInvisibleFields" value="true" />
-        <option name="m_ignoreStaticMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="LocalVariableNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_ignoreForLoopParameters" value="false" />
-        <option name="m_ignoreCatchParameters" value="false" />
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="1" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="LocalVariableNamingConventionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z]*" />
-        <option name="m_minLength" value="1" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="LocalVariableOfConcreteClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="LogStatementGuardedByLogCondition" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LoggerInitializedWithForeignClass" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
-        <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
-    </inspection_tool>
-    <inspection_tool class="LoggingConditionDisagreesWithLogStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LongLine" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="LongLiteralsEndingWithLowercaseL" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LoopConditionNotUpdatedInsideLoop" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreIterators" value="false" />
-    </inspection_tool>
-    <inspection_tool class="LoopStatementThatDoesntLoopJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LoopStatementsThatDontLoop" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LoopWithImplicitTerminationCondition" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="LossyEncoding" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MVCPathVariableInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MagicCharacter" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MagicConstant" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="MagicNumber" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MagicNumberJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MalformedFormatString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MalformedRegex" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MalformedXPath" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ManagedBeanClassInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ManualArrayCopy" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ManualArrayToCollectionCopy" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MapReplaceableByEnumMap" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MarkerInterface" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MathRandomCastToInt" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MavenDuplicateDependenciesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MavenDuplicatePluginInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MavenModelInspection" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MavenRedundantGroupId" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MethodCallInLoopCondition" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MethodCanBeVariableArityMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MethodCount" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_limit" value="20" />
-        <option name="ignoreGettersAndSetters" value="false" />
-        <option name="ignoreOverridingMethods" value="false" />
-    </inspection_tool>
-    <inspection_tool class="MethodCoupling" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_includeJavaClasses" value="false" />
-        <option name="m_includeLibraryClasses" value="false" />
-        <option name="m_limit" value="25" />
-    </inspection_tool>
-    <inspection_tool class="MethodMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false">
-            <option name="m_onlyPrivateOrFinal" value="false" />
-            <option name="m_ignoreEmptyMethods" value="true" />
-        </scope>
-        <option name="m_onlyPrivateOrFinal" value="false" />
-        <option name="m_ignoreEmptyMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="MethodMayBeSynchronized" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodNameSameAsClassName" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MethodNameSameAsParentName" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodNamesDifferOnlyByCase" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MethodOnlyUsedFromInnerClass" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreMethodsAccessedFromAnonymousClass" value="false" />
-        <option name="ignoreStaticMethodsFromNonStaticInnerClass" value="false" />
-        <option name="onlyReportStaticMethods" value="false" />
-    </inspection_tool>
-    <inspection_tool class="MethodOverloadsParentMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodOverridesPackageLocalMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodOverridesPrivateMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodOverridesStaticMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodReturnOfConcreteClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MethodWithMultipleLoops" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MimeType" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MinMaxValuesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MismatchedArrayReadWrite" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MismatchedCollectionQueryUpdate" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false">
-            <option name="queryNames">
-                <value />
-            </option>
-            <option name="updateNames">
-                <value />
-            </option>
-        </scope>
-        <option name="queryNames">
-            <value />
-        </option>
-        <option name="updateNames">
-            <value />
-        </option>
-    </inspection_tool>
-    <inspection_tool class="MismatchedStringBuilderQueryUpdate" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MisorderedAssertEqualsArgumentsTestNG" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MisorderedAssertEqualsParameters" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MissedExecutable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MissingAspectjAutoproxyInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MissingDeprecatedAnnotation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MissingFinalNewline" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreObjectMethods" value="true" />
-        <option name="ignoreAnonymousClassMethods" value="false" />
-    </inspection_tool>
-    <inspection_tool class="MissingPackageInfo" enabled="false" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="MissortedModifiers" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_requireAnnotationsFirst" value="true" />
-    </inspection_tool>
-    <inspection_tool class="MisspelledCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MisspelledEquals" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MisspelledHashcode" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MisspelledHeader" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MisspelledSetUp" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MisspelledTearDown" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MisspelledToString" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ModuleWithTooFewClasses" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="limit" value="10" />
-    </inspection_tool>
-    <inspection_tool class="ModuleWithTooManyClasses" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="limit" value="100" />
-    </inspection_tool>
-    <inspection_tool class="MultipleBindingAnnotations" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MultipleDeclaration" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreForLoopDeclarations" value="true" />
-    </inspection_tool>
-    <inspection_tool class="MultipleExceptionsDeclaredOnTestMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MultipleInjectedConstructorsForClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MultipleMethodDesignatorsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MultipleRepositoryUrls" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MultipleReturnPointsPerMethod" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreGuardClauses" value="false" />
-        <option name="ignoreEqualsMethod" value="false" />
-        <option name="m_limit" value="1" />
-    </inspection_tool>
-    <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MultipleTypedDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MultiplyOrDivideByPowerOfTwo" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="checkDivision" value="false" />
-    </inspection_tool>
-    <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NativeMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NativeMethods" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NegatedConditional" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreNegatedNullComparison" value="true" />
-    </inspection_tool>
-    <inspection_tool class="NegatedConditionalExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NegatedConditionalExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NegatedEqualityExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NegatedIfElse" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreNegatedNullComparison" value="true" />
-        <option name="m_ignoreNegatedZeroComparison" value="false" />
-    </inspection_tool>
-    <inspection_tool class="NegatedIfStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NegativelyNamedBooleanVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NestedAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NestedAssignmentJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NestedConditionalExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NestedConditionalExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NestedFunctionCallJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NestedFunctionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_includeAnonymousFunctions" value="false" />
-    </inspection_tool>
-    <inspection_tool class="NestedMethodCall" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreFieldInitializations" value="true" />
-    </inspection_tool>
-    <inspection_tool class="NestedSwitchStatement" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="NestedSwitchStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NestedSynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NestedTryStatement" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="NestingDepth" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="5" />
-    </inspection_tool>
-    <inspection_tool class="NestingDepthJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="5" />
-    </inspection_tool>
-    <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NewInstanceOfSingleton" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NewStringBufferWithCharArgument" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NoExplicitFinalizeCalls" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonAtomicOperationOnVolatileField" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonBlockStatementBodyJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonBooleanMethodNameMayNotStartWithQuestion" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="questionString" value="is,can,has,could,will,shall,contains,equals,startsWith,endsWith" />
-        <option name="ignoreBooleanMethods" value="false" />
-        <option name="onlyWarnOnBaseMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="NonCommentSourceStatements" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_limit" value="30" />
-    </inspection_tool>
-    <inspection_tool class="NonExceptionNameEndsWithException" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonFinalClone" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonFinalFieldInEnum" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonFinalFieldInImmutable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonFinalFieldOfException" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonFinalGuard" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonFinalStaticVariableUsedInClassInitialization" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonJaxWsWebServices" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonProtectedConstructorInAbstractClass" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreNonPublicClasses" value="false" />
-    </inspection_tool>
-    <inspection_tool class="NonPublicClone" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonReproducibleMathCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonSerializableFieldInSerializableClass" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignorableAnnotations">
-            <value />
-        </option>
-        <option name="ignoreAnonymousInnerClasses" value="false" />
-        <option name="superClassString" value="" />
-    </inspection_tool>
-    <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonShortCircuitBooleanExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NonStaticFinalLogger" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="loggerClassName" value="" />
-    </inspection_tool>
-    <inspection_tool class="NonStaticInnerClassInSecureContext" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="NonSynchronizedMethodOverridesSynchronizedMethod" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="NonThreadSafeLazyInitialization" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NoopMethodInAbstractClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="NotifyCalledOnCondition" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NotifyNotInSynchronizedContext" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NotifyWithoutCorrespondingWait" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NullArgumentToVariableArgMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NullThrown" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NullableProblems" enabled="false" level="WARNING" enabled_by_default="false">
-        <option name="REPORT_NULLABLE_METHOD_OVERRIDES_NOTNULL" value="true" />
-        <option name="REPORT_NOT_ANNOTATED_METHOD_OVERRIDES_NOTNULL" value="true" />
-        <option name="REPORT_NOTNULL_PARAMETER_OVERRIDES_NULLABLE" value="true" />
-        <option name="REPORT_NOT_ANNOTATED_PARAMETER_OVERRIDES_NOTNULL" value="true" />
-        <option name="REPORT_NOT_ANNOTATED_GETTER" value="true" />
-        <option name="REPORT_NOT_ANNOTATED_SETTER_PARAMETER" value="true" />
-        <option name="REPORT_ANNOTATION_NOT_PROPAGATED_TO_OVERRIDERS" value="true" />
-        <option name="REPORT_NULLS_PASSED_TO_NON_ANNOTATED_METHOD" value="true" />
-    </inspection_tool>
-    <inspection_tool class="NumberEquality" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NumericOverflow" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="NumericToString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ObjectAllocationIgnoredJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ObjectAllocationInLoop" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ObjectEquality" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreEnums" value="true" />
-        <option name="m_ignoreClassObjects" value="false" />
-        <option name="m_ignorePrivateConstructors" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ObjectEqualsNull" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ObjectNotify" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ObjectToString" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ObsoleteCollection" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreRequiredObsoleteCollectionTypes" value="false" />
-    </inspection_tool>
-    <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="OctalIntegerJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="OctalLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="OnDemandImport" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="OneWayWebMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <!-- suppressed till GSoC project completion .... -->
-    <inspection_tool class="OptionalIsPresent" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="OverloadedMethodsWithSameNumberOfParameters" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreInconvertibleTypes" value="true" />
-    </inspection_tool>
-    <inspection_tool class="OverloadedVarargsMethod" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="OverlyComplexArithmeticExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="6" />
-    </inspection_tool>
-    <inspection_tool class="OverlyComplexArithmeticExpressionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="6" />
-    </inspection_tool>
-    <inspection_tool class="OverlyComplexBooleanExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="8" />
-        <option name="m_ignorePureConjunctionsDisjunctions" value="true" />
-    </inspection_tool>
-    <inspection_tool class="OverlyComplexBooleanExpressionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="OverlyLargePrimitiveArrayInitializer" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="64" />
-    </inspection_tool>
-    <inspection_tool class="OverlyStrongTypeCast" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreInMatchingInstanceof" value="false" />
-    </inspection_tool>
-    <inspection_tool class="OverridableMethodCallDuringObjectConstruction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="OverriddenMethodCallDuringObjectConstruction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PackageDirectoryMismatch" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PackageInMultipleModules" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PackageInfoWithoutPackage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <!-- Disabled till issue with rendering exact list of violation is resolved on TC service -->
-    <inspection_tool class="PackageNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
-        <option name="m_regex" value="[a-z0-9]*" />
-        <option name="m_minLength" value="3" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="PackageVisibleField" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="PackageVisibleInnerClass" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreEnums" value="false" />
-        <option name="ignoreInterfaces" value="false" />
-    </inspection_tool>
-    <inspection_tool class="PackageWithTooFewClasses" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="PackageWithTooManyClasses" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="limit" value="10" />
-    </inspection_tool>
-    <inspection_tool class="ParameterCanBeLocal" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ParameterHidingMemberVariable" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreInvisibleFields" value="true" />
-        <option name="m_ignoreStaticMethodParametersHidingInstanceFields" value="false" />
-        <option name="m_ignoreForConstructors" value="false" />
-        <option name="m_ignoreForPropertySetters" value="false" />
-        <option name="m_ignoreForAbstractMethods" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ParameterNameDiffersFromOverriddenParameter" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false">
-            <option name="m_ignoreSingleCharacterNames" value="false" />
-            <option name="m_ignoreOverridesOfLibraryMethods" value="true" />
-        </scope>
-        <option name="m_ignoreSingleCharacterNames" value="false" />
-        <option name="m_ignoreOverridesOfLibraryMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ParameterNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="1" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="ParameterNamingConventionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z]*" />
-        <option name="m_minLength" value="1" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="ParameterOfConcreteClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ParameterTypePreventsOverriding" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ParameterizedParametersStaticCollection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ParametersPerConstructor" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ParametersPerFunctionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="5" />
-    </inspection_tool>
-    <inspection_tool class="ParametersPerMethod" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="5" />
-    </inspection_tool>
-    <inspection_tool class="PathAnnotation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PatternNotApplicable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="PatternOverriddenByNonAnnotatedMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PatternValidation" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="CHECK_NON_CONSTANT_VALUES" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PlaceholderCountMatchesArgumentCount" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PlatformDetectionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PlayCustomTagNameInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PlayPropertyInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PointcutMethodStyleInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PointlessArithmeticExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreExpressionsContainingConstants" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PointlessArithmeticExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PointlessBinding" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PointlessBitwiseExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreExpressionsContainingConstants" value="false" />
-    </inspection_tool>
-    <inspection_tool class="PointlessBitwiseExpressionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreExpressionsContainingConstants" value="false" />
-    </inspection_tool>
-    <inspection_tool class="PointlessBooleanExpression" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreExpressionsContainingConstants" value="false" />
-    </inspection_tool>
-    <inspection_tool class="PointlessBooleanExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PointlessNullCheck" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PrivateMemberAccessBetweenOuterAndInnerClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ProblematicVarargsMethodOverride" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ProblematicWhitespace" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PropertyValueSetToItself" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ProtectedField" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ProtectedInnerClass" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreEnums" value="false" />
-        <option name="ignoreInterfaces" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ProtectedMemberInFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="PublicConstructor" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="PublicConstructorInNonPublicClass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="PublicField" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreEnums" value="false" />
-        <option name="ignorableAnnotations">
-            <value>
-                <item value="org.junit.Rule" />
-                <item value="org.junit.ClassRule" />
-            </value>
-        </option>
-    </inspection_tool>
-    <inspection_tool class="PublicFieldAccessedInSynchronizedContext" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="PublicInnerClass" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false">
-            <option name="ignoreEnums" value="false" />
-            <option name="ignoreInterfaces" value="false" />
-        </scope>
-        <option name="ignoreEnums" value="false" />
-        <option name="ignoreInterfaces" value="false" />
-    </inspection_tool>
-    <inspection_tool class="PublicMethodNotExposedInInterface" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignorableAnnotations">
-            <value />
-        </option>
-        <option name="onlyWarnIfContainingClassImplementsAnInterface" value="false" />
-    </inspection_tool>
-    <inspection_tool class="PublicMethodWithoutLogging" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="loggerClassName" value="" />
-    </inspection_tool>
-    <inspection_tool class="PublicStaticArrayField" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PublicStaticCollectionField" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="QuestionableName" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="nameString" value="aa,abc,bad,bar,bar2,baz,baz1,baz2,baz3,bb,blah,bogus,bool,cc,dd,defau1t,dummy,dummy2,ee,fa1se,ff,foo,foo1,foo2,foo3,foobar,four,fred,fred1,fred2,gg,hh,hello,hello1,hello2,hello3,ii,nu11,one,silly,silly2,string,two,that,then,three,whi1e,var" />
-    </inspection_tool>
-    <inspection_tool class="RSReferenceInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RandomDoubleForRandomInteger" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="RawUseOfParameterizedType" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReadObjectAndWriteObjectPrivate" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReadObjectInitialization" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReadResolveAndWriteReplaceProtected" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RecordStoreResource" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantArrayCreation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantCast" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantFieldInitialization" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantImplements" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreSerializable" value="false" />
-        <option name="ignoreCloneable" value="false" />
-    </inspection_tool>
-    <inspection_tool class="RedundantMethodOverride" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="RedundantScopeBinding" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantStringFormatCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantSuppression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantThrows" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantThrowsDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantToBinding" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantToProviderBinding" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantTypeArguments" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RedundantTypeConversion" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="CHECK_ANY" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ReferencesToClassesFromDefaultPackagesInJSPFile" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ReflectionForUnavailableAnnotation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReflectionNotFound" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RefusedBequest" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreEmptySuperMethods" value="false" />
-        <option name="onlyReportWhenAnnotated" value="true" />
-    </inspection_tool>
-    <inspection_tool class="RemoveExplicitTypeArguments" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReplaceAllDot" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreLazyOperators" value="true" />
-        <option name="ignoreObscureOperators" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ReplaceAssignmentWithOperatorAssignmentJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReplaceDeprecatedFunctionClassUsages" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReplaceWithOperatorAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RequiredArtifactTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="RequiredAttributes" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="myAdditionalRequiredHtmlAttributes" value="" />
-    </inspection_tool>
-    <inspection_tool class="RequiredBeanTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ReservedWordUsedAsNameJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RestWrongDefaultValueInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="false" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="ResultSetIndexZero" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ReturnFromFinallyBlock" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReturnFromFinallyBlockJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReturnNull" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_reportObjectMethods" value="true" />
-        <option name="m_reportArrayMethods" value="true" />
-        <option name="m_reportCollectionMethods" value="true" />
-        <option name="m_ignorePrivateMethods" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ReturnOfCollectionField" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignorePrivateMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ReturnOfDateField" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ReturnOfInnerClass" enabled="true" level="WARNING" enabled_by_default="true" >
-        <option name="ignoreNonPublic" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ReturnThis" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ReuseOfLocalVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ReuseOfLocalVariableJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RuntimeExec" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="RuntimeExecWithNonConstantString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SSBasedInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SafeLock" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SafeVarargsDetector" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SamePackageImport" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SameParameterValue" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SameReturnValue" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="SecondUnsafeCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SelfIncludingJspFiles" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SerializableClassInSecureContext" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreAnonymousInnerClasses" value="false" />
-        <option name="superClassString" value="" />
-    </inspection_tool>
-    <inspection_tool class="SerializableHasSerializationMethods" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreAnonymousInnerClasses" value="false" />
-        <option name="superClassString" value="" />
-    </inspection_tool>
-    <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreAnonymousInnerClasses" value="false" />
-        <option name="superClassString" value="" />
-    </inspection_tool>
-    <inspection_tool class="SerializableInnerClassWithNonSerializableOuterClass" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreAnonymousInnerClasses" value="false" />
-        <option name="superClassString" value="" />
-    </inspection_tool>
-    <inspection_tool class="SerializableStoresNonSerializable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SerializableWithUnconstructableAncestor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ServerEndpointInconsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ServletWithoutMappingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SessionScopedInjectsRequestScoped" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SetReplaceableByEnumSet" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SetupCallsSuperSetup" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SetupIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SharedThreadLocalRandom" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ShiftOutOfRange" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ShiftOutOfRangeJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SignalWithoutCorrespondingAwait" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SillyAssignment" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SillyAssignmentJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SimpleDateFormatWithoutLocale" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SimplifiableAnnotation" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SimplifiableConditionalExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SimplifiableEqualsExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SimplifiableIfStatement" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SimplifiableJUnitAssertion" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SimplifyNegatedBinaryExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <!-- suppressed till GSoC project completion .... -->
-    <inspection_tool class="SimplifyStreamApiCallChains" enabled="false" level="WARNING" enabled_by_default="false" />
-    <!-- suppressed till GSoC project completion .... -->
-    <inspection_tool class="SingleCharAlternation" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SingleCharacterStartsWith" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SingleClassImport" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="Singleton" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SingletonInjectsScoped" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SleepWhileHoldingLock" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SocketResource" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="insideTryAllowed" value="false" />
-    </inspection_tool>
-    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
-        <option name="processCode" value="true" />
-        <option name="processLiterals" value="true" />
-        <option name="processComments" value="true" />
-    </inspection_tool>
-    <inspection_tool class="SpringAopErrorsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringAopWarningsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringBatchModel" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringBeanAttributesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringBeanAutowiringInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringBeanConstructorArgInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringBeanDepedencyCheckInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringBeanInstantiationInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringBeanLookupMethodInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringBeanNameConventionInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringBootAdditionalConfig" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringBootApplicationProperties" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringBootApplicationYaml" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringComponentScan" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringContextConfigurationInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringDataJpaMethodInconsistencyInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringElInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringElStaticFieldInjectionInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringFacetCodeInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringFacetInspection" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="checkTestFiles" value="false" />
-    </inspection_tool>
-    <inspection_tool class="SpringFacetProgrammaticInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringFactoryMethodInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringHandlersSchemasHighlighting" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringInactiveProfileHighlightingInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringIncorrectResourceTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringInjectionValueConsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringInjectionValueStyleInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringIntegrationDeprecations21" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringIntegrationModel" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringJavaAutowiredMembersInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringJavaAutowiringInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringJavaConfigExternalBeansErrorInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringJavaConfigInconsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringMVCInitBinder" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringMVCViewInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringMessageDispatcherWebXmlInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringModelInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringOsgiElementsInconsistencyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringOsgiListenerInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringOsgiServiceCommonInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringPlaceholdersInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringPublicFactoryMethodInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringRequiredAnnotationInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringRequiredPropertyInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringScopesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringSecurityDebugActivatedInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringSecurityFiltersConfiguredInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringSecurityModelInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringStaticMembersAutowiringInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringTransactionalComponentInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringWebServiceAnnotationsInconsistencyInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SpringWebServicesConfigurationsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SpringWebSocketConfigurationInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SqlAddNotNullColumnInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlAmbiguousColumnInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlAutoIncrementDuplicateInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlCheckUsingColumnsInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlConstantConditionInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlDeprecateTypeInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlDerivedTableAliasInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlDialectInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlDropIndexedColumnInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlIdentifierInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlInsertValuesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlNoDataSourceInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlNullComparisonInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlPostgresqlSelectFromProcedureInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlResolveInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlShouldBeInGroupByInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SqlTypeInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StandardVariableNames" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreParameterNameSameAsSuper" value="true" />
-    </inspection_tool>
-    <inspection_tool class="StatementsPerFunctionJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="30" />
-    </inspection_tool>
-    <inspection_tool class="StaticCallOnSubclass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StaticCollection" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_ignoreWeakCollections" value="false" />
-    </inspection_tool>
-    <inspection_tool class="StaticFieldReferenceOnSubclass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StaticGuardedByInstance" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StaticImport" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="StaticInheritance" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StaticMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="3" />
-        <option name="m_maxLength" value="64" />
-    </inspection_tool>
-    <inspection_tool class="StaticMethodOnlyUsedInOneClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StaticNonFinalField" enabled="false" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StaticSuite" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StaticVariableInitialization" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignorePrimitives" value="false" />
-    </inspection_tool>
-    <inspection_tool class="StaticVariableNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="checkMutableFinals" value="false" />
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="5" />
-        <option name="m_maxLength" value="32" />
-    </inspection_tool>
-    <inspection_tool class="StaticVariableOfConcreteClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StaticVariableUninitializedUse" enabled="false" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false">
-            <option name="m_ignorePrimitives" value="false" />
-        </scope>
-        <option name="m_ignorePrimitives" value="false" />
-    </inspection_tool>
-    <inspection_tool class="StringBufferField" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StringBufferMustHaveInitialCapacity" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StringBufferReplaceableByString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringBufferReplaceableByStringBuilder" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StringCompareTo" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StringConcatenation" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreAsserts" value="false" />
-        <option name="ignoreSystemOuts" value="false" />
-        <option name="ignoreSystemErrs" value="false" />
-        <option name="ignoreThrowableArguments" value="false" />
-        <option name="ignoreConstantInitializers" value="false" />
-        <option name="ignoreInTestCode" value="false" />
-        <option name="ignoreInToString" value="false" />
-    </inspection_tool>
-    <inspection_tool class="StringConcatenationArgumentToLogCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StringConcatenationInLoops" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_ignoreUnlessAssigned" value="true" />
-    </inspection_tool>
-    <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StringConcatenationInsideStringBufferAppend" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringConcatenationMissingWhitespace" enabled="false" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="StringConstructor" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreSubstringArguments" value="false" />
-    </inspection_tool>
-    <inspection_tool class="StringEquality" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringEquals" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StringEqualsIgnoreCase" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StringLiteralBreaksHTMLJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="onlyWarnOnLoop" value="true" />
-    </inspection_tool>
-    <inspection_tool class="StringToString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringToUpperWithoutLocale" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="StringTokenizer" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StringTokenizerDelimiter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SubstringZero" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SuperClassHasFrequentlyUsedInheritors" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SuperTearDownInFinally" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SuppressionAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="myAllowedSuppressions">
-            <list>
-                <option value="deprecation" />
-                <option value="unchecked" />
-                <option value="rawtypes" />
-            </list>
-        </option>
-    </inspection_tool>
-    <inspection_tool class="SuspiciousArrayCast" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="SuspiciousGetterSetter" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="onlyWarnWhenFieldPresent" value="true" />
-    </inspection_tool>
-    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SuspiciousLiteralUnderscore" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SuspiciousLocalesLanguages" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SuspiciousMethodCalls" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="REPORT_CONVERTIBLE_METHOD_CALLS" value="true" />
-    </inspection_tool>
-    <inspection_tool class="SuspiciousNameCombination" enabled="true" level="ERROR" enabled_by_default="true">
-        <group names="x,width,left,right" />
-        <group names="y,height,top,bottom" />
-    </inspection_tool>
-    <inspection_tool class="SuspiciousSystemArraycopy" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SuspiciousToArrayCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SwitchStatement" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SwitchStatementDensity" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="20" />
-    </inspection_tool>
-    <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SwitchStatementWithNoDefaultBranchJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="2" />
-    </inspection_tool>
-    <inspection_tool class="SwitchStatementWithTooManyBranches" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_limit" value="10" />
-    </inspection_tool>
-    <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreFullyCoveredEnums" value="true" />
-    </inspection_tool>
-    <inspection_tool class="SynchronizationOnLocalVariableOrMethodParameter" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="reportLocalVariables" value="true" />
-        <option name="reportMethodParameters" value="true" />
-    </inspection_tool>
-    <inspection_tool class="SynchronizationOnStaticField" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SynchronizeOnLock" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SynchronizeOnNonFinalField" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SynchronizeOnThis" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SynchronizedMethod" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_includeNativeMethods" value="true" />
-        <option name="ignoreSynchronizedSuperMethods" value="true" />
-    </inspection_tool>
-    <inspection_tool class="SynchronizedOnLiteralObject" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SyntaxError" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SystemExit" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SystemGC" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SystemGetenv" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="SystemOutErr" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SystemProperties" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="SystemRunFinalizersOnExit" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SystemSetSecurityManager" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TaglibDomModelInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="TailRecursion" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="TailRecursionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TeardownCallsSuperTeardown" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TeardownIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TestCaseInProductCode" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TestCaseWithConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TestCaseWithNoTestMethods" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreSupers" value="false" />
-    </inspection_tool>
-    <inspection_tool class="TestMethodInProductCode" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TestMethodIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TestMethodWithoutAssertion" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="assertionMethods" value="org.junit.Assert,assert.*|fail.*,junit.framework.Assert,assert.*|fail.*,org.mockito.Mockito,verify.*,org.mockito.InOrder,verify,org.junit.rules.ExpectedException,expect.*,org.hamcrest.MatcherAssert,assertThat" />
-        <option name="assertKeywordIsAssertion" value="false" />
-    </inspection_tool>
-    <inspection_tool class="TestNGDataProvider" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TestNGMethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TestOnlyProblems" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TextLabelInSwitchStatement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="TextLabelInSwitchStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThisEscapedInConstructor" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ThisExpressionReferencesGlobalObjectJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThreadDeathRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadDumpStack" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThreadLocalNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadPriority" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadRun" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadStartInConstruction" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadStopSuspendResume" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadWithDefaultRunMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadYield" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreeNegationsPerFunctionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThreeNegationsPerMethod" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreInEquals" value="true" />
-        <option name="ignoreInAssert" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ThrowCaughtLocally" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreRethrownExceptions" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ThrowFromFinallyBlock" enabled="true" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ThrowFromFinallyBlockJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThrowableInstanceNeverThrown" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThrowablePrintedToSystemOut" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThrowableResultOfMethodCallIgnored" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_limit" value="3" />
-    </inspection_tool>
-    <inspection_tool class="ThrowsRuntimeException" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThymeleafMessagesResolveInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThymeleafVariablesResolveInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="TimeToString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ToArrayCallWithZeroLengthArrayArgument" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TodoComment" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="TooBroadCatch" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="TooBroadScope" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_allowConstructorAsInitializer" value="false" />
-        <option name="m_onlyLookAtBlocks" value="false" />
-    </inspection_tool>
-    <inspection_tool class="TooBroadThrows" enabled="false" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="TrailingSpacesInProperty" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TransientFieldNotInitialized" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="TrivialConditionalJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TrivialIf" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TrivialIfJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="TryWithIdenticalCatches" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TsLint" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="TypeCustomizer" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TypeMayBeWeakened" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true" />
-        <option name="useParameterizedTypeForCollectionMethods" value="true" />
-        <option name="doNotWeakenToJavaLangObject" value="true" />
-        <option name="onlyWeakentoInterface" value="true" />
-    </inspection_tool>
-    <inspection_tool class="TypeParameterExtendsFinalClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TypeParameterExtendsObject" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TypeParameterHidesVisibleType" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TypeParameterNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
-        <option name="m_minLength" value="1" />
-        <option name="m_maxLength" value="1" />
-    </inspection_tool>
-    <inspection_tool class="TypeScriptAccessibilityCheck" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TypeScriptCheckFunctionSignatures" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TypeScriptUnresolvedFunction" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="TypeScriptUnresolvedVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UNCHECKED_WARNING" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnaryPlus" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UncheckedExceptionClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnclearBinaryExpression" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnconditionalWait" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnconstructableTestCase" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UndeclaredTests" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnhandledExceptionInJSP" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UninstantiableBinding" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UninstantiableImplementedByClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UninstantiableProvidedByClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnknownGuard" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnknownLanguage" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnnecessarilyQualifiedInnerClassAccess" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreReferencesNeedingImport" value="true" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessarilyQualifiedStaticUsage" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreStaticFieldAccesses" value="false" />
-        <option name="m_ignoreStaticMethodCalls" value="false" />
-        <option name="m_ignoreStaticAccessFromStaticContext" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessarilyQualifiedStaticallyImportedElement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryBlockStatement" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreSwitchBranches" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessaryBoxing" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryBreak" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryCallToStringValueOf" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryConditionalExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryConstantArrayCreationExpression" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryContinue" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryContinueJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryDefault" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnnecessaryEnumModifier" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryExplicitNumericCast" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryFinalOnLocalVariableOrParameter" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnnecessaryFullyQualifiedName" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreJavadoc" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessaryInheritDoc" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryInterfaceModifier" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryJavaDocLink" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreInlineLinkToSuper" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessaryLabelJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryLabelOnBreakStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryLabelOnContinueStatement" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryLocalVariable" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
-        <option name="m_ignoreAnnotatedVariables" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessaryLocalVariableJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
-        <option name="m_ignoreAnnotatedVariables" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessaryParentheses" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreClarifyingParentheses" value="false" />
-        <option name="ignoreParenthesesOnConditionals" value="false" />
-        <option name="ignoreParenthesesOnLambdaParameter" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnnecessaryQualifiedReference" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryReturn" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryReturnJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessarySemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryStaticInjection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessarySuperConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessarySuperQualifier" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryTemporaryOnConversionFromString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryTemporaryOnConversionToString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryThis" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryToStringCall" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryUnaryMinus" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryUnboxing" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryUnicodeEscape" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnparsedCustomBeanInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnpredictableBigDecimalConstructorCall" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreReferences" value="true" />
-        <option name="ignoreComplexLiterals" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnqualifiedFieldAccess" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignoreReferencesToLocalInnerClasses" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnqualifiedMethodAccess" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnqualifiedStaticUsage" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="m_ignoreStaticFieldAccesses" value="false" />
-        <option name="m_ignoreStaticMethodCalls" value="false" />
-        <option name="m_ignoreStaticAccessFromStaticContext" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnreachableCodeJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnresolvedMessageChannel" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnresolvedPropertyKey" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnresolvedReference" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnterminatedStatementJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="ignoreSemicolonAtEndOfBlock" value="true" />
-    </inspection_tool>
-    <inspection_tool class="UnusedAssignment" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="REPORT_PREFIX_EXPRESSIONS" value="false" />
-        <option name="REPORT_POSTFIX_EXPRESSIONS" value="true" />
-        <option name="REPORT_REDUNDANT_INITIALIZER" value="true" />
-    </inspection_tool>
-    <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Tests" level="WARNING" enabled="false">
-            <option name="m_ignoreCatchBlocksWithComments" value="false" />
-            <option name="m_ignoreTestCases" value="false" />
-        </scope>
-        <option name="m_ignoreCatchBlocksWithComments" value="false" />
-        <option name="m_ignoreTestCases" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnusedCatchParameterJS" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="m_ignoreCatchBlocksWithComments" value="false" />
-    </inspection_tool>
-    <inspection_tool class="UnusedDefine" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnusedImport" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnusedLabel" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnusedMessageFormatParameter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnusedParameters" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false" />
-    </inspection_tool>
-    <inspection_tool class="UnusedProperty" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UnusedReceiverParameter" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UnusedReturnValue" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="UnusedSymbol" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UseOfAWTPeerClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UseOfAnotherObjectsPrivateField" enabled="false" level="WARNING" enabled_by_default="false">
-        <option name="ignoreSameClass" value="true" />
-        <option name="ignoreEquals" value="true" />
-    </inspection_tool>
-    <inspection_tool class="UseOfClone" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UseOfJDBCDriverClass" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UseOfObsoleteAssert" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UseOfObsoleteDateTimeApi" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UseOfProcessBuilder" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UseOfPropertiesAsHashtable" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UseOfSunClasses" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="UtilSchemaInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UtilityClass" enabled="false" level="ERROR" enabled_by_default="false">
-        <option name="ignorableAnnotations">
-            <value />
-        </option>
-    </inspection_tool>
-    <inspection_tool class="UtilityClassCanBeEnum" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="UtilityClassWithPublicConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UtilityClassWithoutPrivateConstructor" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignorableAnnotations">
-            <value />
-        </option>
-        <option name="ignoreClassesWithOnlyMain" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ValidExternallyBoundObject" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="VarargParameter" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="VariableNotUsedInsideIf" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="VoidExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="VoidMethodAnnotatedWithGET" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="VolatileArrayField" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="VolatileLongOrDoubleField" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="VtlReferencesInspection" enabled="true" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="W3CssValidation" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="myCssVersion" value="css3" />
-        <option name="myIgnoreVendorSpecificProperties" value="false" />
-    </inspection_tool>
-    <inspection_tool class="WSReferenceInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="WaitCalledOnCondition" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WaitNotInLoop" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WaitNotInSynchronizedContext" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WaitOrAwaitWithoutTimeout" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WaitWhileHoldingTwoLocks" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WaitWithoutCorrespondingNotify" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WeakerAccess" enabled="false" level="WARNING" enabled_by_default="false">
-        <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true" />
-        <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="true" />
-        <option name="SUGGEST_PRIVATE_FOR_INNERS" value="false" />
-    </inspection_tool>
-    <inspection_tool class="WebProperties" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WebWarnings" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="WebflowConfigModelInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WebflowModelInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WebflowSetupInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WhileCanBeForeach" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="WhileLoopSpinsOnField" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="ignoreNonEmtpyLoops" value="false" />
-    </inspection_tool>
-    <inspection_tool class="WithStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="WrongPackageStatement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WrongPropertyKeyValueDelimiter" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="WsdlHighlightingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="XHTMLIncompatabilitiesJS" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="XmlDuplicatedId" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="XmlHighlighting" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="XmlInvalidId" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="XmlPathReference" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="XmlUnboundNsPrefix" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="XmlUnusedNamespaceDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="XmlWrongRootElement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="XsltDeclarations" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="XsltTemplateInvocation" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="XsltUnusedDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="XsltVariableShadowing" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ZeroLengthArrayInitialization" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="dependsOnMethodTestNG" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="groupsTestNG" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="groups">
-            <value>
-                <list size="0" />
-            </value>
-        </option>
-    </inspection_tool>
-    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false">
-        <option name="LOCAL_VARIABLE" value="true" />
-        <option name="FIELD" value="true" />
-        <option name="METHOD" value="true" />
-        <option name="CLASS" value="true" />
-        <option name="PARAMETER" value="true" />
-        <option name="REPORT_PARAMETER_FOR_PUBLIC_METHODS" value="true" />
-        <option name="ADD_MAINS_TO_ENTRIES" value="true" />
-        <option name="ADD_APPLET_TO_ENTRIES" value="true" />
-        <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
-        <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
-    </inspection_tool>
-</inspections>
+<profile version="1.0">
+  <option name="myName" value="Checkstyle"/>
+  <inspection_tool class="AbsoluteAlignmentInUserInterface" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AbstractBeanReferencesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AbstractClassExtendsConcreteClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AbstractClassNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*|Check"/>
+    <option name="m_minLength" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="AbstractClassNeverImplemented" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we are not limited in resources
+         and we are a library so there are more usages outside of our code -->
+  <inspection_tool class="AbstractClassWithOnlyOneDirectInheritor" enabled="false" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AbstractClassWithoutAbstractMethods" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AbstractMethodCallInConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AbstractMethodOverridesAbstractMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AbstractMethodOverridesConcreteMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AbstractMethodWithMissingImplementations" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AccessStaticViaInstance" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AccessToNonThreadSafeStaticFieldFromInstance" enabled="true"
+                   level="WARNING" enabled_by_default="true">
+    <option name="nonThreadSafeClasses">
+      <value/>
+    </option>
+    <option name="nonThreadSafeTypes" value=""/>
+  </inspection_tool>
+  <inspection_tool class="AccessToStaticFieldLockedOnInstance" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AddVarianceModifier" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AlphaUnsortedPropertiesFile" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AmbiguousFieldAccess" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AmbiguousMethodCall" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AndroidDomInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidElementNotAllowed" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAaptCrash" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAccidentalOctal" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAdapterViewChildren" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAddJavascriptInterface" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAllCaps" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAllowAllHostnameVerifier" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAllowBackup" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAlwaysShowAction" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAnimatorKeep" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAppCompatCustomView" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAppCompatMethod" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAppCompatResource" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAppLinkUrlError" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintApplySharedPref" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAssert" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintAuthLeak" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintBadHostnameVerifier" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintBatteryLife" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintButtonCase" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintButtonOrder" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintButtonStyle" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintByteOrderMark" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintCheckResult" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintClickableViewAccessibility" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintCommitPrefEdits" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintCommitTransaction" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintContentDescription" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintCustomViewStyleable" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintCutPasteId" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDefaultLocale" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDeprecated" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDevModeObsolete" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDeviceAdmin" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDisableBaselineAlignment" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDrawAllocation" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDuplicateActivity" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDuplicateDefinition" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDuplicateDivider" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDuplicateIds" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDuplicateIncludedIds" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDuplicatePlatformClasses" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintDuplicateUsesFeature" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintEllipsizeMaxLines" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintEnforceUTF8" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintExifInterface" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintExportedContentProvider" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintExportedPreferenceActivity" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintExportedReceiver" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintExportedService" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintExtraText" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintExtraTranslation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintFindViewByIdCast" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintFloatMath" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintFontValidationError" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintFontValidationWarning" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintFullBackupContent" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGetContentDescriptionOverride" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGetInstance" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGetLocales" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGifUsage" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGoogleAppIndexingWarning" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradleCompatible" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradleDependency" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradleDeprecated" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradleDynamicVersion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradleGetter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradleIdeError" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradleOverrides" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradlePath" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGradlePluginVersion" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGrantAllUris" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintGridLayout" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintHandlerLeak" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintHardcodedDebugMode" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintHardcodedText" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintHardwareIds" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintHighAppVersionCode" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconColors" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconDensities" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconDipSize" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconDuplicates" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconDuplicatesConfig" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconExtension" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconLauncherShape" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconLocation" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconMissingDensityFolder" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconMixedNinePatch" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconNoDpi" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIconXmlAndPng" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIllegalResourceRef" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintImpliedQuantity" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintImpliedTouchscreenHardware" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInOrMmUsage" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIncludeLayoutParam" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintIncompatibleMediaBrowserServiceCompatVersion" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInconsistentArrays" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInconsistentLayout" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInefficientWeight" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInflateParams" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInlinedApi" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInnerclassSeparator" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInstantApps" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidAnalyticsName" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidId" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidImeActionId" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidPermission" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidResourceFolder" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidUsesTagAttribute" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidVectorPath" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintInvalidWearFeatureAttribute" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintJavascriptInterface" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintJobSchedulerService" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintKeyboardInaccessibleWidget" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintLabelFor" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintLibraryCustomView" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintLintBaseline" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintLocalSuppress" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintLocaleFolder" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintLogTagMismatch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintLongLogTag" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintManifestOrder" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintManifestResource" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMenuTitle" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMergeMarker" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMergeRootFrame" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMinSdkTooLow" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMipmapIcons" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingApplicationIcon" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingBackupPin" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingConstraints" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingFirebaseInstanceTokenRefresh" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingId" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingIntentFilterForMediaSearch" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingLeanbackLauncher" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingLeanbackSupport" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingMediaBrowserServiceIntentFilter" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingOnPlayFromSearch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingPermission" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingPrefix" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingQuantity" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingSuperCall" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingTranslation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingTvBanner" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMissingVersion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMockLocation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintMultipleUsesSdk" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNamespaceTypo" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNestedScrolling" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNestedWeights" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNetworkSecurityConfig" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNewApi" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNfcTechWhitespace" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNotInterpolated" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintNotSibling" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintObjectAnimatorBinding" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintObsoleteLayoutParam" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintObsoleteSdkInt" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintOldTargetApi" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintOnClick" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintOrientation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintOverdraw" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintOverride" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintOverrideAbstract" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPackageManagerGetSignatures" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPackagedPrivateKey" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintParcelClassLoader" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintParcelCreator" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPendingBindings" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPermissionImpliesUnsupportedHardware" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPinSetExpiry" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPluralsCandidate" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPrivateApi" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPrivateResource" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintProguard" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintProguardSplit" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPropertyEscape" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintProtectedPermissions" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintPxUsage" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRange" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRecycle" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRecyclerView" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintReferenceType" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRegistered" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRelativeOverlap" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRequiredSize" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintResAuto" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintResourceAsColor" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintResourceCycle" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintResourceName" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintResourceType" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRestrictedApi" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRtlCompat" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRtlEnabled" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRtlHardcoded" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintRtlSymmetry" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSQLiteString" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSSLCertificateSocketFactoryCreateSocket" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSSLCertificateSocketFactoryGetInsecure" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintScrollViewCount" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintScrollViewSize" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSdCardPath" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSecureRandom" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintServiceCast" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSetJavaScriptEnabled" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSetTextI18n" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSetWorldReadable" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSetWorldWritable" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintShiftFlags" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintShortAlarm" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintShowToast" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSignatureOrSystemPermissions" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSimpleDateFormat" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSmallSp" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSpUsage" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintStateListReachable" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintStaticFieldLeak" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintStringEscaping" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintStringFormatCount" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintStringFormatInvalid" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintStringFormatMatches" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintStringShouldBeInt" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSupportAnnotationUsage" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSuspicious0dp" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSuspiciousImport" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintSwitchIntDef" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTestAppLink" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTextFields" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTextViewEdits" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTooDeepLayout" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTooManyViews" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTrustAllX509TrustManager" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTypographyDashes" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTypographyEllipsis" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTypographyFractions" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTypographyOther" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintTypos" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUniqueConstants" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUniquePermission" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnknownId" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnknownIdInLayout" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnlocalizedSms" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnpackedNativeCode" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnprotectedSMSBroadcastReceiver" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnsafeDynamicallyLoadedCode" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnsafeNativeCodeLocation" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnsafeProtectedBroadcastReceiver" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnsupportedTvHardware" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnusedAttribute" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnusedQuantity" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUnusedResources" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUseAlpha2" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUseCheckPermission" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUseCompoundDrawables" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUseOfBundledGooglePlayServices" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUseSparseArrays" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUseValueOf" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUselessLeaf" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUselessParent" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUsesMinSdkAttributes" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintUsingHttp" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintValidFragment" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintValidRestrictions" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintVectorDrawableCompat" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintVectorPath" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintVectorRaster" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintViewConstructor" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintViewHolder" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintViewTag" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintVisibleForTests" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWakelockTimeout" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWearStandaloneAppFlag" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWearableBindListener" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWebViewLayout" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWebpUnsupported" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWifiManagerLeak" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWifiManagerPotentialLeak" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWorldReadableFiles" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWorldWriteableFiles" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWrongCall" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWrongCase" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWrongConstant" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWrongFolder" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWrongRegion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWrongThread" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidLintWrongViewCast" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidMissingOnClickHandler" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidNonConstantResIdsInSwitch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AndroidUnknownAttribute" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- this rule is inspection is only for old java, we are ok to use annotations -->
+  <inspection_tool class="Annotation" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="AnnotationClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AnnotationNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="8"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="Annotator" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="Anonymous2MethodRef" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AnonymousClassComplexity" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="3"/>
+  </inspection_tool>
+  <!-- false-positives on test code even with an option method count set to 3 -->
+  <inspection_tool class="AnonymousClassMethodCount" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AnonymousClassVariableHidesContainingMethodVariable" enabled="true"
+                   level="WARNING" enabled_by_default="true"/>
+  <!-- Anonymous Javascript functions are good for self executing and callbacks. -->
+  <inspection_tool class="AnonymousFunctionJS" enabled="false" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AnonymousHasLambdaAlternative" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- we are ok with anonymous classes -->
+  <inspection_tool class="AnonymousInnerClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AnonymousInnerClassMayBeStatic" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="AntDuplicateTargetsInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AntMissingPropertiesFileInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- maven and ant are used in the same build, no options in inspection to adjust -->
+  <inspection_tool class="AntResolveInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AppEngineForbiddenCode" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ArgNamesErrorsInspection" enabled="true" level="TYPO"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArgNamesWarningsInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AroundAdviceStyleInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArquillianClassEnabled" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArquillianDeploymentAbsent" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArquillianDeploymentReturnType" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArquillianDeploymentSignature" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArquillianTooManyDeployment" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArrayEquality" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArrayEquals" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ArrayHashCode" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ArrayInDataClass" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <!-- we see no harm for us for such usages -->
+  <inspection_tool class="ArrayLengthInLoopCondition" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ArrayObjectsEquals" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ArraysAsListWithZeroOrOneArgument" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertAsName" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="AssertEqualsBetweenInconvertibleTypes" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertEqualsBetweenInconvertibleTypesTestNG" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="AssertEqualsCalledOnArray" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertEqualsMayBeAssertSame" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertMessageNotString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertWithSideEffects" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertsWithoutMessages" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssertsWithoutMessagesTestNG" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentOrReturnOfFieldWithMutableType" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentResultUsedJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentToCatchBlockParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentToCollectionFieldFromParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignorePrivateMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="AssignmentToDateFieldFromParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignorePrivateMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="AssignmentToForLoopParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_checkForeachParameters" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="AssignmentToForLoopParameterJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentToFunctionParameterJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentToLambdaParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentToMethodParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreTransformationOfOriginalParameter" value="false"/>
+  </inspection_tool>
+  <!-- we are legacy library with log history, too many items to fix, usage of Option
+    does not do the code any better in some cases. May be fixed some day in future -->
+  <inspection_tool class="AssignmentToNull" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="AssignmentToStaticFieldFromInstanceMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <scope name="Tests" level="ERROR" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="AssignmentToSuperclassField" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AssignmentUsedAsCondition" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AsyncMethodInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- we are ok to use auto-boxing as we use modern java -->
+  <inspection_tool class="AutoBoxing" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="AutoCloseableResource" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <!-- These classes do not contain any resources that need to be closed. -->
+    <option name="ignoredTypes"
+            value="java.io.ByteArrayOutputStream,
+        ,java.util.stream.Stream,
+        ,java.util.stream.IntStream,
+        ,java.util.stream.LongStream,
+        ,java.util.stream.DoubleStream,
+        ,com.puppycrawl.tools.checkstyle.internal.utils.CloseAndFlushTestByteArrayOutputStream"/>
+    <!-- False positives for the Closable returned from a builder method (which return "this").
+             Mock stubs shouldn't be closed. -->
+    <option name="METHOD_MATCHER_CONFIG"
+            value="java.util.Formatter,format, ,
+                        ,java.io.Writer,append, ,
+                        ,com.google.common.base.Preconditions,checkNotNull, ,
+                        ,org.hibernate.Session,close, ,
+                        ,java.io.PrintWriter,printf, ,
+                        ,org.mockito.Mockito,mock|verify, ,
+                        ,org.mockito.stubbing.Stubber,when"/>
+  </inspection_tool>
+  <!-- we are ok to use auto-unboxing as we use modern java -->
+  <inspection_tool class="AutoUnboxing" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="AutowiredDependenciesInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AwaitNotInLoop" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="AwaitWithoutCorrespondingSignal" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BadExceptionCaught" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="exceptionsString" value=""/>
+    <option name="exceptions">
+      <value/>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="BadExceptionDeclared" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false">
+      <option name="exceptionsString" value=""/>
+      <option name="exceptions">
+        <value/>
+      </option>
+      <option name="ignoreTestCases" value="false"/>
+      <option name="ignoreLibraryOverrides" value="false"/>
+    </scope>
+    <option name="exceptionsString" value=""/>
+    <option name="exceptions">
+      <value/>
+    </option>
+    <option name="ignoreTestCases" value="false"/>
+    <option name="ignoreLibraryOverrides" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="BadExceptionThrown" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="exceptionsString" value=""/>
+    <option name="exceptions">
+      <value/>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="BadExpressionStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BadOddness" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="BashAddShebang" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="BashArrayUseOfSimple" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashBuiltInVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashDuplicateFunction" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashEvaluateArithmeticExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashEvaluateExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashFixShebang" enabled="true" level="ERROR" enabled_by_default="true">
+    <shebang>/bin/bash</shebang>
+    <shebang>/bin/sh</shebang>
+  </inspection_tool>
+  <inspection_tool class="BashFloatArithmetic" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashGlobalLocalVarDef" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashInternalCommandFunctionOverride" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashMissingInclude" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashReadOnlyVariable" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashRecursiveInclusion" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashReplaceWithBackquote" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashReplaceWithSubshell" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashSimpleArrayUse" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashSimpleVarUsage" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashUnknownFileDescriptor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashUnregisterGlobalVariableInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashUnresolvedVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashUnusedFunction" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashUnusedFunctionParams" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashWrapFunction" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BashWrapWord" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="BatchJobDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="BatchXmlDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="BeforeClassOrAfterClassIsPublicStaticVoidNoArg" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="BeforeOrAfterIsPublicVoidNoArg" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BigDecimalEquals" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BigDecimalLegacyMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BigDecimalMethodWithoutRoundingCalled" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BindingAnnotationWithoutInject" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="BlockMarkerComments" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BlockStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BooleanConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- even it is always negated,
+         it is better than possible negation/inversion of negated term -->
+  <inspection_tool class="BooleanMethodIsAlwaysInverted" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="BooleanMethodNameMustStartWithQuestion" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Production" level="WARNING" enabled="false">
+      <option name="ignoreBooleanMethods" value="false"/>
+      <option name="ignoreInAnnotationInterface" value="true"/>
+      <option name="onlyWarnOnBaseMethods" value="true"/>
+      <option name="questionString"
+              value="is,can,has,should,could,will,shall,check,
+                          ,contains,equals,add,put,remove,startsWith,endsWith"/>
+    </scope>
+    <option name="ignoreBooleanMethods" value="false"/>
+    <option name="ignoreInAnnotationInterface" value="true"/>
+    <option name="onlyWarnOnBaseMethods" value="true"/>
+    <option name="questionString"
+            value="is,can,has,should,could,will,shall,check,contains,equals,add,put,
+                      ,remove,starts,ends,are,was,matches,start,must,accept"/>
+  </inspection_tool>
+  <inspection_tool class="BooleanParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- even it is always negated,
+         it is better than possible negation/inversion of negated term -->
+  <inspection_tool class="BooleanVariableAlwaysNegated" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="BoxingBoxedValue" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BpmnConfigDomInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we like breaks to be in code -->
+  <inspection_tool class="BreakStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="BreakStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BreakStatementWithLabel" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BreakStatementWithLabelJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="BusyWait" enabled="true" level="WARNING" enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="BvConfigDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="BvConstraintMappingsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CStyleArrayDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CachedNumberConstructorCall" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CallToNativeMethodWhileLocked" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CallToSimpleGetterInClass" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreGetterCallsOnOtherObjects" value="false"/>
+    <option name="onlyReportPrivateGetter" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="CallToSimpleSetterInClass" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignoreSetterCallsOnOtherObjects" value="false"/>
+    <option name="onlyReportPrivateSetter" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CallerJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <!-- disabled till https://youtrack.jetbrains.com/issue/IDEA-203424 -->
+  <inspection_tool class="CanBeFinal" enabled="false" level="ERROR" enabled_by_default="true">
+    <option name="REPORT_CLASSES" value="false"/>
+    <option name="REPORT_METHODS" value="false"/>
+    <option name="REPORT_FIELDS" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="CanBeParameter" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CanBePrimaryConstructorProperty" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CanBeVal" enabled="false" level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="CascadeIf" enabled="false" level="INFO" enabled_by_default="false"/>
+  <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CastThatLosesPrecision" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreIntegerCharCasts" value="false"/>
+    <option name="ignoreOverflowingByteCasts" value="false"/>
+  </inspection_tool>
+  <!-- this is valid but there are many false-positives as we use reflection to load modules
+     after recheck by instanceof and we restricted in by existing api types, but some cases
+     are valid, inspection lack of properties to make it less demanding -->
+  <inspection_tool class="CastToConcreteClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CastToIncompatibleInterface" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CatchMayIgnoreException" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="true"/>
+    <option name="m_ignoreCatchBlocksWithComments" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="CaughtExceptionImmediatelyRethrown" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CdiAlternativeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiDecoratorInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiDisposerMethodInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiDomBeans" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="CdiInjectInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiInjectionPointsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiInterceptorInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiManagedBeanInconsistencyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiNormalScopeInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiObservesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiScopeInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiSpecializesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiStereotypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiStereotypeRestrictionsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiTypedAnnotationInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CdiUnknownProducersForDisposerMethodInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="CdiUnproxyableBeanTypesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CfmlFileReference" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CfmlReferenceInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ChainedEquality" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ChainedEqualityJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ChainedFunctionCallJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- it is too demanding, with no choice limits of chain size etc -->
+  <inspection_tool class="ChainedMethodCall" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ChangeToMethod" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ChangeToOperator" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ChannelResource" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="insideTryAllowed" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="CharUsedInArithmeticContext" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CharacterComparison" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CheckDtdRefs" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="CheckEmptyScriptTag" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CheckForOutOfMemoryOnLargeArrayAllocation" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="1024"/>
+  </inspection_tool>
+  <inspection_tool class="CheckImageSize" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="CheckNodeTest" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="CheckStyle" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="CheckTagEmptyBody" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CheckValidXmlInScriptTagBody" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CheckXmlFileWithXercesValidator" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CheckedExceptionClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClashingGetters" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ClashingTraitMethods" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we use design model to keep all logic for class in one file.
+    So, we have a lot of completely isolated classes and we cannot put them to
+    separate package as it will affect users configs -->
+  <inspection_tool class="ClassComplexity" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="80"/>
+  </inspection_tool>
+  <!-- we control this by checkstyle/pmd that have better suppression options -->
+  <inspection_tool class="ClassCoupling" enabled="false" level="ERROR" enabled_by_default="false">
+    <option name="m_includeJavaClasses" value="false"/>
+    <option name="m_includeLibraryClasses" value="false"/>
+    <option name="m_limit" value="15"/>
+  </inspection_tool>
+  <!-- we do not need that -->
+  <inspection_tool class="ClassHasNoToStringMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="excludeClassNames" value=""/>
+    <option name="excludeException" value="true"/>
+    <option name="excludeDeprecated" value="true"/>
+    <option name="excludeEnum" value="false"/>
+    <option name="excludeAbstract" value="false"/>
+    <option name="excludeTestCode" value="false"/>
+    <option name="excludeInnerClasses" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ClassInDefaultPackage" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- disabled till https://youtrack.jetbrains.com/issue/IDEA-203424 -->
+  <inspection_tool class="ClassIndependentOfModule" enabled="false" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassInheritanceDepth" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="6"/>
+  </inspection_tool>
+  <inspection_tool class="ClassInitializer" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassInitializerMayBeStatic" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassLoaderInstantiation" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassMayBeInterface" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- names of Checks are public to users, we do care about clear name for user
+    without information in what package it is placed. Check name is unique in the whole project -->
+  <inspection_tool class="ClassNamePrefixedWithPackageName" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ClassNameSameAsAncestorName" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="3"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="ClassNestingDepth" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="1"/>
+  </inspection_tool>
+  <inspection_tool class="ClassNewInstance" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassOnlyUsedInOneModule" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- packages should be where we define.
+         we are a library project and other projects might use them. -->
+  <inspection_tool class="ClassOnlyUsedInOnePackage" enabled="false" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassReferencesSubclass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we are library(interfaces are used outside of our code base)
+         we can not follow this rule -->
+  <inspection_tool class="ClassUnconnectedToPackage" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ClassWithMultipleLoggers" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="loggerNamesString"
+            value="java.util.logging.Logger,
+                        ,org.slf4j.Logger,
+                        ,org.apache.commons.logging.Log,
+                        ,org.apache.log4j.Logger"/>
+  </inspection_tool>
+  <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ClassWithTooManyDependencies" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="limit" value="37"/>
+  </inspection_tool>
+  <!-- disabled till https://youtrack.jetbrains.com/issue/IDEA-203424 -->
+  <inspection_tool class="ClassWithTooManyDependents" enabled="false" level="ERROR"
+                   enabled_by_default="true">
+    <option name="limit" value="300"/>
+  </inspection_tool>
+  <!-- suppressed till problem is resolved .... -->
+  <inspection_tool class="ClassWithTooManyTransitiveDependencies" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="limit" value="75"/>
+  </inspection_tool>
+  <!-- suppressed till problem is resolved .... -->
+  <inspection_tool class="ClassWithTooManyTransitiveDependents" enabled="true" level="ERROR"
+                   enabled_by_default="false">
+    <option name="limit" value="500"/>
+  </inspection_tool>
+  <!-- we do not like suggested style -->
+  <inspection_tool class="ClassWithoutConstructor" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we do not need logging by loggers in all places -->
+  <inspection_tool class="ClassWithoutLogger" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="loggerNamesString"
+            value="java.util.logging.Logger,
+                        ,org.slf4j.Logger,
+                        ,org.apache.commons.logging.Log,
+                        ,org.apache.log4j.Logger"/>
+    <option name="ignoreSuperLoggers" value="false"/>
+  </inspection_tool>
+  <!-- we do not like suggested style -->
+  <inspection_tool class="ClassWithoutNoArgConstructor" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_ignoreClassesWithNoConstructors" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="CloneCallsConstructors" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CloneCallsSuperClone" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CloneDeclaresCloneNotSupported" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CloneInNonCloneableClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CloneReturnsClassType" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- this inspection is not for us -->
+  <inspection_tool class="CloneableClassInSecureContext" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CloneableImplementsClone" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreCloneableDueToInheritance" value="true"/>
+  </inspection_tool>
+  <!-- decision to suppress was only a matter of habit to see code in more old style
+         with extra curly braces, we might change our mind in the future. -->
+  <inspection_tool class="CodeBlock2Expr" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CoffeeScriptArgumentsOutsideFunction" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CoffeeScriptFunctionSignatures" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CoffeeScriptInfiniteLoop" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CoffeeScriptLiteralNotFunction" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CoffeeScriptSillyAssignment" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CoffeeScriptSwitchStatementWithNoDefaultBranch" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="CoffeeScriptUnnecessaryReturn" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CoffeeScriptUnusedLocalSymbols" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CollectionAddAllCanBeReplacedWithConstructor" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="CollectionAddedToSelf" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CollectionContainsUrl" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CollectionsFieldAccessReplaceableByMethodCall" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="CommaExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true"
+                   level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="ComparatorMethodParameterNotUsed" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ComparatorNotSerializable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ComparisonToNaN" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ComponentNotRegistered" enabled="false" level="WARNING"
+                   enabled_by_default="false">
+    <option name="CHECK_ACTIONS" value="true"/>
+    <option name="IGNORE_NON_PUBLIC" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="ComponentRegistrationProblems" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConditionSignal" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConditionalExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConditionalExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConditionalExpressionWithIdenticalBranches" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConditionalExpressionWithIdenticalBranchesJS" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ConflictingAnnotations" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConflictingExtensionProperty" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConfusingElse" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="reportWhenNoStatementFollow" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ConfusingFloatingPointLiteral" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConfusingFloatingPointLiteralJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConfusingOctalEscape" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConfusingPlusesOrMinusesJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConnectionResource" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstPropertyName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantConditionIf" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConstantConditionalExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantConditionalExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- We cannot use IF_ELSE as it will force us to make code coverage
+         and we will not find Input to satisfy coverage,
+         creation of non-real test case is against our policy of testing. -->
+  <inspection_tool class="ConstantConditions" enabled="false" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+    <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false"/>
+    <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false"/>
+  </inspection_tool>
+  <!-- we are ok with constants in classes and do not like constants in interfaces -->
+  <inspection_tool class="ConstantDeclaredInAbstractClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConstantDeclaredInInterface" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantIfStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantIfStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantJUnitAssertArgument" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantMathCall" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="onlyCheckImmutables" value="false"/>
+    <option name="m_regex" value="[A-Z][A-Z_\d]*"/>
+    <option name="m_minLength" value="2"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="ConstantOnLHSOfComparison" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantOnLHSOfComparisonJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we do like constants on the right side, it is more readable,
+         placing constant on the left does not give benefit -->
+  <inspection_tool class="ConstantOnWrongSideOfComparison" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConstantOnWrongSideOfComparisonJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantStringIntern" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstantValueVariableUse" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConstraintValidatorCreator" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConstructorCount" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreDeprecatedConstructors" value="false"/>
+    <option name="m_limit" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="ContextComponentScanInconsistencyInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="ContextJavaBeanUnresolvedMethodsInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="ContinueOrBreakFromFinallyBlock" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ContinueOrBreakFromFinallyBlockJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we like continue statements to be in code -->
+  <inspection_tool class="ContinueStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ContinueStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ContinueStatementWithLabel" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ContinueStatementWithLabelJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="Contract" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="Convert2Diamond" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="Convert2Lambda" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="Convert2MethodRef" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- on the moment of review we were not a big fans of functional style,
+         none of code coverage tools can distinguish that body of lambda is executed.
+         When this problem is resolved we could reconsider disablement. -->
+  <inspection_tool class="Convert2streamapi" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConvertAnnotations" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConvertJavadoc" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ConvertLambdaToReference" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConvertOldAnnotations" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ConvertReferenceToLambda" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConvertSecondaryConstructorToPrimary" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConvertToStringTemplate" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConvertTryFinallyToUseCall" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ConvertTwoComparisonsToRangeCheck" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CopyWithoutNamedArguments" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CovariantCompareTo" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CovariantEquals" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssConvertColorToHexInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we like hex format of color -->
+  <inspection_tool class="CssConvertColorToRgbInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CssFloatPxLength" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidAtRule" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidCharsetRule" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidElement" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidFunction" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidHtmlTagReference" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidImport" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidMediaFeature" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidPropertyValue" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssInvalidPseudoSelector" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssMissingComma" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssMissingSemicolon" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssNegativeValue" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssNoGenericFontName" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssOptimizeSimilarProperties" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssOverwrittenProperties" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssRedundantUnit" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssUnitlessNumber" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CssUnknownProperty" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="myCustomPropertiesEnabled" value="false"/>
+    <option name="myIgnoreVendorSpecificProperties" value="false"/>
+    <option name="myCustomPropertiesList">
+      <value>
+        <list size="0"/>
+      </value>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="CssUnknownTarget" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- most found cases are used in xml files that are source for html pages -->
+  <inspection_tool class="CssUnusedSymbol" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CucumberExamplesColon" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CucumberJavaStepDefClassInDefaultPackage" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CucumberJavaStepDefClassIsPublic" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CucumberMissedExamples" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CucumberTableInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CucumberUndefinedStep" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="CustomClassloader" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="CustomSecurityManager" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we can not afford this now, api cleanup is in progress and it is hard and takes time for
+     deprecation process -->
+  <inspection_tool class="CyclicClassDependency" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we can not afford this now, api cleanup is in progress and it hard and takes time for
+     deprecation process -->
+  <inspection_tool class="CyclicPackageDependency" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we use our own CyclomaticComplexityCheck and counts SWITCH in special way -->
+  <inspection_tool class="CyclomaticComplexity" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="10"/>
+  </inspection_tool>
+  <inspection_tool class="CyclomaticComplexityJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="10"/>
+  </inspection_tool>
+  <inspection_tool class="DanglingJavadoc" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DataClassPrivateConstructor" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DataProviderReturnType" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DateToString" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="DebuggerStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DeclareCollectionAsInterface" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreLocalVariables" value="false"/>
+    <option name="ignorePrivateMethodsAndFields" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="DeclareParentsInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DefaultFileTemplate" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="CHECK_FILE_HEADER" value="true"/>
+    <option name="CHECK_TRY_CATCH_SECTION" value="true"/>
+    <option name="CHECK_METHOD_BODY" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DefaultNotLastCaseInSwitchJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DelegatesTo" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="Dependency" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DeprecatedClassUsageInspection" enabled="true" level="WARNING"
+                   enabled_by_default="false">
+    <scope name="Production" level="WARNING" enabled="true"/>
+  </inspection_tool>
+  <inspection_tool class="DeprecatedGradleDependency" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DeprecatedIsStillUsed" enabled="true" level="WARNING"
+                   enabled_by_default="false">
+    <scope name="Production" level="WARNING" enabled="true"/>
+  </inspection_tool>
+  <inspection_tool class="DeprecatedMavenDependency" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="Deprecation" enabled="true" level="ERROR" enabled_by_default="false">
+    <scope name="Production" level="ERROR" enabled="true"/>
+  </inspection_tool>
+  <!-- this inspection is not for us -->
+  <inspection_tool class="DeserializableClassInSecureContext" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we have the same Check , and it is disabled too,
+     as amount of old code and old design is too big
+     to do any breaking compatibility fixes in favor to avoid violations from this inspection -->
+  <inspection_tool class="DesignForExtension" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DestructuringWrongName" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DialogTitleCapitalization" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DifferentKotlinGradleVersion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DifferentKotlinMavenVersion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DifferentMavenStdlibVersion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DifferentStdlibGradleVersion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- we against of over decomposition -->
+  <inspection_tool class="DisjointPackage" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <scope name="Checkstyle Inspection Scope" level="ERROR" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="DivideByZero" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="DivideByZeroJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="DocumentWriteJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DollarSignInName" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DontUsePairConstructor" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DoubleBraceInitialization" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DoubleCheckedLocking" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignoreOnVolatileVariables" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DoubleNegation" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="DriverManagerGetConnection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- the only violation found is false-positive at AvoidEscapedUnicodeCharactersCheck -->
+  <inspection_tool class="DuplicateAlternationBranch" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DuplicateBooleanBranch" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DuplicateCaseLabelJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DuplicateCondition" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreSideEffectConditions" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="DuplicateConditionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DuplicatePropertyInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="CURRENT_FILE" value="true"/>
+    <option name="MODULE_WITH_DEPENDENCIES" value="false"/>
+    <!-- Different properties could have the same value, but could change at any time. -->
+    <option name="CHECK_DUPLICATE_VALUES" value="false"/>
+    <option name="CHECK_DUPLICATE_KEYS" value="true"/>
+    <option name="CHECK_DUPLICATE_KEYS_WITH_DIFFERENT_VALUES" value="true"/>
+  </inspection_tool>
+  <!-- it will result in too many dependencies between classes, some cases are only have the
+    same value by chance, too much wont-fixes -->
+  <inspection_tool class="DuplicateStringLiteralInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DuplicateThrows" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="DuplicatedBeanNamesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="DuplicatedDataProviderNames" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- this duplication algorithm generate too much we won't fix -->
+  <inspection_tool class="DuplicatedCode" enabled="false" level="ERROR" enabled_by_default="true">
+    <scope name="Tests" level="ERROR" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="DynamicRegexReplaceableByCompiledPattern" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="DynamicallyGeneratedCodeJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ELDeferredExpressionsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ELMethodSignatureInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ELSpecValidationInJSP" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ELValidationInJSP" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- not all browsers support this yet, no need for us to follow this -->
+  <inspection_tool class="ES6ConvertVarToLetConst" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false" />
+  <inspection_tool class="ES6Validation" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbClassBasicInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbClassWarningsInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbDomInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbEntityClassInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbEntityHomeInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbEntityInterfaceInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbEnvironmentInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbInterceptorInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbInterceptorWarningsInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbInterfaceMethodInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbInterfaceSignatureInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbProhibitedPackageUsageInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbQlInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbRemoteRequirementsInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbSessionHomeInterfaceInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbStaticAccessInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EjbThisExpressionInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EmptyCatchBlock" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="m_includeComments" value="true"/>
+    <option name="m_ignoreTestCases" value="true"/>
+    <option name="m_ignoreIgnoreParameter" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="EmptyCatchBlockJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EmptyClass" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignorableAnnotations">
+      <value/>
+    </option>
+    <option name="ignoreClassWithParameterization" value="false"/>
+    <option name="ignoreThrowables" value="true"/>
+    <option name="commentsAreContent" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="EmptyDirectory" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="EmptyEventHandler" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="EmptyFinallyBlock" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EmptyFinallyBlockJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EmptyInitializer" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EmptyMethod" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="EXCLUDE_ANNOS">
+      <value>
+        <list size="0"/>
+      </value>
+    </option>
+    <option name="commentsAreContent" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="EmptyRange" enabled="false" level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="EmptyStatementBody" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_reportEmptyBlocks" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="EmptyStatementBodyJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_reportEmptyBlocks" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="EmptySynchronizedStatement" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EmptyTryBlock" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="EmptyTryBlockJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EmptyWebServiceClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="EnumAsName" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <!-- we are ok to use enumeration as we use modern java -->
+  <inspection_tool class="EnumClass" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="EnumEntryName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreSwitchStatementsWithDefault" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="EnumeratedClassNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="EnumeratedConstantNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Z_\d]*"/>
+    <option name="m_minLength" value="2"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="EnumerationCanBeIteration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualityComparisonWithCoercionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualsAndHashcode" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualsBetweenInconvertibleTypes" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualsCalledOnEnumConstant" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualsHashCodeCalledOnUrl" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualsOrHashCode" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="EqualsReplaceableByObjectsCall" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="checkNotNull" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="EqualsUsesNonFinalVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualsWhichDoesntCheckParameterClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="EqualsWithItself" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- there is false-positive, and rest cases are result of our loading modules by reflection
+    that throws Error. Error is not always jvm problem,
+    a bunch of libraries throw Error instead of Exception -->
+  <inspection_tool class="ErrorRethrown" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we do not use this tool -->
+  <inspection_tool class="Eslint" enabled="false" level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="ExceptionCaughtLocallyJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExceptionFromCatchWhichDoesntWrap" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignoreGetMessage" value="false"/>
+    <option name="ignoreCantWrap" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ExceptionNameDoesntEndWithException" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExpectedExceptionNeverThrown" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExpectedExceptionNeverThrownTestNG" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExplicitGet" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ExplicitThis" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ExtendsAnnotation" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExtendsConcreteCollection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExtendsObject" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ExtendsThread" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExtendsThrowable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExtendsUtilityClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExternalizableWithSerializationMethods" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ExternalizableWithoutPublicNoArgConstructor" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="FacesModelInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FakeJvmFieldConstant" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FallThroughInSwitchStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FallthruInSwitchStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we use DetailAST heavily and that that is on purpose and not a problem,
+         no ways to adjust this inspection -->
+  <inspection_tool class="FeatureEnvy" enabled="false" level="ERROR" enabled_by_default="false">
+    <option name="ignoreTestCases" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="FieldAccessNotGuarded" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FieldAccessedSynchronizedAndUnsynchronized" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="countGettersAndSetters" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="FieldCanBeLocal" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- it is hard to follow this rule as most cases are configuration related fields of Checks -->
+  <inspection_tool class="FieldCount" enabled="false" level="ERROR" enabled_by_default="false">
+    <option name="m_countConstantFields" value="false"/>
+    <option name="m_considerStaticFinalFieldsConstant" value="false"/>
+    <option name="myCountEnumConstants" value="false"/>
+    <option name="m_limit" value="10"/>
+  </inspection_tool>
+  <!-- we do not like suggested style -->
+  <inspection_tool class="FieldHasSetterButNoGetter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FieldHidesSuperclassField" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_ignoreInvisibleFields" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="FieldMayBeFinal" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FieldNotUsedInToString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FieldRepeatedlyAccessed" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreFinalFields" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="FileEqualsUsage" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- we are library - we do this on purpose as clear signal to users -->
+  <inspection_tool class="FinalClass" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <!-- we are library - we do this on purpose as clear signal to users -->
+  <inspection_tool class="FinalMethod" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="FinalMethodInFinalClass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FinalPrivateMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FinalStaticMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="Finalize" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="ignoreTrivialFinalizers" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="FinalizeCallsSuperFinalize" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreObjectSubclasses" value="false"/>
+    <option name="ignoreTrivialFinalizers" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="FinalizeNotProtected" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FinallyBlockCannotCompleteNormally" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FlexUnitClassInProductSourceInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitClassVisibilityInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitClassWithNoTestsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitEmptySuiteInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitMethodHasParametersInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitMethodInSuiteInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitMethodIsPropertyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitMethodIsStaticInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitMethodReturnTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitMethodVisibilityInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitMixedAPIInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FlexUnitSuiteWithNoRunnerInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FloatingPointEquality" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="FlowRequiredBeanTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FoldInitializerAndIfToElvis" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ForCanBeForeach" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="REPORT_INDEXED_LOOP" value="true"/>
+    <option name="ignoreUntypedCollections" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ForLoopReplaceableByWhile" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreLoopsWithoutConditions" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ForLoopReplaceableByWhileJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreLoopsWithoutConditions" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ForLoopThatDoesntUseLoopVariableJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ForLoopWithMissingComponent" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreCollectionLoops" value="true"/>
+  </inspection_tool>
+  <!-- we are ok to use for-each as we use modern java -->
+  <inspection_tool class="ForeachStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FtlCallsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FtlDeprecatedBuiltInsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FtlFileReferencesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FtlImportCallInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FtlReferencesInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FtlTypesInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FtlWellformednessInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FunctionName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FunctionNamingConventionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z][A-Za-z]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="FunctionWithInconsistentReturnsJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we do not see a harm from such style -->
+  <inspection_tool class="FunctionWithMultipleLoopsJS" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="FunctionWithMultipleReturnPointsJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="GWTRemoteServiceAsyncCheck" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GWTStyleCheck" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="Geronimo" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GherkinBrokenTableInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GherkinMisplacedBackground" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GjsLint" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="Glassfish" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GrDeprecatedAPIUsage" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrEqualsBetweenInconvertibleTypes" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrFieldAlreadyDefined" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="GrFinalVariableAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrMethodMayBeStatic" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrPackage" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GrReassignedInClosureLocalVar" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrUnnecessaryAlias" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrUnnecessaryDefModifier" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrUnnecessaryPublicModifier" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrUnnecessarySemicolon" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GrUnresolvedAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- disabled until #11592 -->
+  <inspection_tool class="GrazieInspection" enabled="false" level="TYPO"
+                   enabled_by_default="false" />
+  <inspection_tool class="GroovyAccessToStaticFieldLockedOnInstance" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyAccessibility" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyAnnotationNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="8"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyAssignabilityCheck" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyAssignmentCanBeOperatorAssignment" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="ignoreLazyOperators" value="true"/>
+    <option name="ignoreObscureOperators" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyAssignmentToForLoopParameter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyAssignmentToMethodParameter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyBreak" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GroovyBusyWait" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyClassNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="8"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyConditional" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyConditionalCanBeConditionalCall" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyConditionalCanBeElvis" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyConditionalWithIdenticalBranches" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyConstantConditional" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyConstantIfStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyConstantNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_regex" value="[A-Z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyConstructorNamedArguments" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyContinue" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyContinueOrBreakFromFinallyBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyDivideByZero" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyDocCheck" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyDoubleCheckedLocking" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="ignoreOnVolatileVariables" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyDoubleNegation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyDuplicateSwitchBranch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyEmptyCatchBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyEmptyFinallyBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyEmptyStatementBody" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyEmptySyncBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyEmptyTryBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyEnumerationNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="8"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyFallthrough" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyGStringKey" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyIfStatementWithIdenticalBranches" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyIfStatementWithTooManyBranches" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="3"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyInArgumentCheck" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyInfiniteLoopStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyInfiniteRecursion" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyInstanceMethodNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyInstanceVariableNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_regex" value="m_[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="1"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyInterfaceNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="8"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyLabeledStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyListGetCanBeKeyedAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyListSetCanBeKeyedAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyLocalVariableNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyLoopStatementThatDoesntLoop" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyMapGetCanBeKeyedAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyMapPutCanBeKeyedAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyMethodParameterCount" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyMethodWithMoreThanThreeNegations" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyMissingReturnStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyMultipleReturnPointsPerMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="1"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyNegatedConditional" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyNegatedIf" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyNestedAssignment" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyNestedConditional" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyNestedSwitch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyNestedSynchronizedStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyNonShortCircuitBoolean" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyNotifyWhileNotSynchronized" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyOctalInteger" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyOverlyComplexArithmeticExpression" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="3"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyOverlyComplexBooleanExpression" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="3"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyOverlyComplexMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="10"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyOverlyLongMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="30"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyOverlyNestedMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyParameterNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyPointlessArithmetic" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyPointlessBoolean" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyPublicFieldAccessedInSynchronizedContext" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GroovyRangeTypeCheck" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyResultOfAssignmentUsed" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyResultOfIncrementOrDecrementUsed" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyResultOfObjectAllocationIgnored" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyReturnFromClosureCanBeImplicit" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyReturnFromFinallyBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovySillyAssignment" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovySingletonAnnotation" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="GroovyStaticMethodNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="GroovyStaticVariableNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_regex" value="s_[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="GroovySwitchStatementWithNoDefault" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovySynchronizationOnNonFinalField" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovySynchronizationOnThis" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovySynchronizationOnVariableInitializedWithLiteral" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GroovySynchronizedMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovySystemRunFinalizersOnExit" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyThreadStopSuspendResume" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyThrowFromFinallyBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyTrivialConditional" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyTrivialIf" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUncheckedAssignmentOfMemberOfRawType" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnconditionalWait" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnnecessaryContinue" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnnecessaryReturn" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnreachableStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnsynchronizedMethodOverridesSynchronizedMethod" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GroovyUntypedAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnusedAssignment" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnusedCatchParameter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnusedDeclaration" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyUnusedIncOrDec" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyVariableCanBeFinal" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyVariableNotAssigned" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyWaitCallNotInLoop" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyWaitWhileNotSynchronized" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GroovyWhileLoopSpinsOnField" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="ignoreNonEmtpyLoops" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="GspInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GtkPreferredJComboBoxRenderer" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GuavaFluentIterable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="GwtClientClassFromNonInheritedModule" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtCssResourceErrors" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtDefaultPackageNotRegistered" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtDeprecatedEventListeners" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtDeprecatedPropertyKeyJavadocTag" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtInconsistentI18nInterface" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtInconsistentSerializableClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtIncorrectArgumentOfGwtCreateMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtJavaFromJSMethodCalls" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtJavaScriptReferences" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtMethodWithParametersInConstantsInterface" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="GwtObsoleteTypeArgsJavadocTag" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtOverlayTypeRestrictionsViolated" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtServiceNotRegistered" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtSetServiceEntryPointCalls" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtToHtmlReferences" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtUiBinderErrors" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtUiFieldAssignment" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtUiFieldErrors" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtUiHandlerErrors" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="GwtUiXmlReferences" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HamlNestedTagContent" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- we like it, it is not performance issue for us -->
+  <inspection_tool class="HardCodedStringLiteral" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HardcodedActionUrl" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- there are too much false positives in RegExps
+         and javadoc start/end symbols in paths from classpath etc. -->
+  <inspection_tool class="HardcodedFileSeparators" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- there are too much false positives in RegExps
+         and javadoc start/end symbols in paths from classpath etc. -->
+  <inspection_tool class="HardcodedLineSeparators" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HardwiredNamespacePrefix" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HasPlatformType" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HashCodeUsesNonFinalVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HibernateConfigDomFacetInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HibernateConfigDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HibernateMappingDatasourceDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HibernateMappingDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="HibernateResource" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="insideTryAllowed" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="HtmlDeprecatedTag" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HtmlFormInputWithoutLabel" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HtmlNonExistentInternetResource" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HtmlPresentationalElement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HtmlUnknownAnchorTarget" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="myValues">
+      <value>
+        <list size="0"/>
+      </value>
+    </option>
+    <option name="myCustomValuesEnabled" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="HtmlUnknownBooleanAttribute" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="HtmlUnknownTag" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="myValues">
+      <value>
+        <list size="6">
+          <item index="0" class="java.lang.String" itemvalue="nobr"/>
+          <item index="1" class="java.lang.String" itemvalue="noembed"/>
+          <item index="2" class="java.lang.String" itemvalue="comment"/>
+          <item index="3" class="java.lang.String" itemvalue="noscript"/>
+          <item index="4" class="java.lang.String" itemvalue="embed"/>
+          <item index="5" class="java.lang.String" itemvalue="script"/>
+        </list>
+      </value>
+    </option>
+    <option name="myCustomValuesEnabled" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="HtmlUnknownTarget" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- all links are to general web sites, we can not use https -->
+  <inspection_tool class="HttpUrlsUsage" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false" />
+  <inspection_tool class="IOResource" enabled="true" level="WARNING" enabled_by_default="true">
+    <scope name="Production" level="WARNING" enabled="true">
+      <option name="ignoredTypesString"
+              value="java.io.ByteArrayOutputStream,
+                            ,java.io.ByteArrayInputStream,
+                            ,java.io.StringBufferInputStream,
+                            ,java.io.CharArrayWriter,
+                            ,java.io.CharArrayReader,
+                            ,java.io.StringWriter,
+                            ,java.io.StringReader"/>
+      <option name="insideTryAllowed" value="true"/>
+    </scope>
+    <option name="ignoredTypesString"
+            value="java.io.ByteArrayOutputStream,
+                        ,java.io.ByteArrayInputStream,
+                        ,java.io.StringBufferInputStream,
+                        ,java.io.CharArrayWriter,
+                        ,java.io.CharArrayReader,
+                        ,java.io.StringWriter,
+                        ,java.io.StringReader"/>
+    <option name="insideTryAllowed" value="true"/>
+  </inspection_tool>
+  <!-- till we switch to jacoco
+         we cannot use this as it conflicts with policy of 100% coverage -->
+  <inspection_tool class="IfCanBeSwitch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we do not conditional expressions, we like more verbose code -->
+  <inspection_tool class="IfMayBeConditional" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="IfNullToElvis" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="IfStatementWithIdenticalBranches" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IfStatementWithIdenticalBranchesJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IfStatementWithTooManyBranches" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="8"/>
+  </inspection_tool>
+  <inspection_tool class="IfStatementWithTooManyBranchesJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="3"/>
+  </inspection_tool>
+  <inspection_tool class="IfThenToElvis" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="IfThenToSafeAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="IgnoreCoverEntry" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IgnoreDuplicateEntry" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IgnoreIncorrectEntry" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IgnoreRelativeEntry" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IgnoreResultOfCall" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_reportAllNonLibraryCalls" value="false"/>
+    <option name="callCheckString"
+            value="java.io.InputStream,read|skip|available|markSupported, ,
+                        ,java.io.Writer,read|skip|ready|markSupported, ,
+                        ,java.lang.Boolean,.*, ,
+                        ,java.lang.Byte,.*, ,
+                        ,java.lang.Character,.*, ,
+                        ,java.lang.Double,.*, ,
+                        ,java.lang.Float,.*, ,
+                        ,java.lang.Long,.*, ,
+                        ,java.lang.Math,.*, ,
+                        ,java.lang.Object,equals|hashCode|toString, ,
+                        ,java.lang.Short,.*, ,
+                        ,java.lang.StrictMath,.*, ,
+                        ,java.lang.String,.*, ,
+                        ,java.math.BigInteger,.*, ,
+                        ,java.math.BigDecimal,.*, ,
+                        ,java.net.InetAddress,.*, ,
+                        ,java.net.URI,.*, ,
+                        ,java.util.UUID,.*, ,
+                        ,com.google.common.truth.StandardSubjectBuilder,.*"/>
+  </inspection_tool>
+  <inspection_tool class="IgnoreSyntaxEntry" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IgnoreUnusedEntry" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IgnoredJUnitTest" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IllegalIdentifier" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ImplicitArrayToString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we do not like this style, but we could change our mind in future -->
+  <inspection_tool class="ImplicitCallToSuper" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ImplicitDefaultCharsetUsage" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ImplicitNullableNothingType" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ImplicitNumericConversion" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreWideningConversions" value="true"/>
+    <option name="ignoreCharConversions" value="false"/>
+    <option name="ignoreConstantConversions" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="ImplicitThis" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ImplicitTypeConversion" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="BITS" value="1720"/>
+    <option name="FLAG_EXPLICIT_CONVERSION" value="true"/>
+    <option name="IGNORE_NODESET_TO_BOOLEAN_VIA_STRING" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="ImplicitlyExposedWebServiceMethods" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="IncompatibleMask" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IncompatibleMaskJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InconsistentLanguageLevel" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- there are false positives on constant string values
+         that have to contain different line separators -->
+  <inspection_tool class="InconsistentLineSeparators" enabled="false" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IncorrectOnMessageMethodsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="IncrementDecrementResultUsedJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IndexOfReplaceableByContains" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IndexZeroUsage" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="InfiniteLoopJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="InfiniteLoopStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InfiniteRecursion" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InfiniteRecursionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InjectedReferences" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InjectionNotApplicable" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InjectionValueTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InnerClassOnInterface" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_ignoreInnerInterfaces" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="InnerClassReferencedViaSubclass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InnerClassVariableHidesOuterClassVariable" enabled="true"
+                   level="WARNING" enabled_by_default="true">
+    <option name="m_ignoreInvisibleFields" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="InnerHTMLJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="InspectionDescriptionNotFoundInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InspectionMappingConsistency" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InspectionUniqueToolbarId" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InspectionUsingGrayColors" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InstanceGuardedByStatic" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InstanceMethodNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="3"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <!-- we use methods like notifyBegin to (re)initialize,
+         so c-tor or field declaration initialization
+         is not good place for us. -->
+  <inspection_tool class="InstanceVariableInitialization" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_ignorePrimitives" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="InstanceVariableNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="2"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <!-- this is valid but there are many false-positives as we use reflection
+         to load modules after recheck by instanceof -->
+  <inspection_tool class="InstanceVariableOfConcreteClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InstanceVariableUninitializedUse" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignorePrimitives" value="false"/>
+    <option name="annotationNamesString" value=""/>
+  </inspection_tool>
+  <inspection_tool class="InstanceofCatchParameter" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- we do reflection for testing -->
+  <inspection_tool class="InstanceofChain" enabled="true" level="ERROR" enabled_by_default="true">
+    <scope name="Tests" level="ERROR" enabled="false">
+      <option name="ignoreInstanceofOnLibraryClasses" value="false"/>
+    </scope>
+    <option name="ignoreInstanceofOnLibraryClasses" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="InstanceofIncompatibleInterface" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- unfortunate , but there are multiple cases where instanceof is required
+         due to loading classes from config file and usage of reflection -->
+  <inspection_tool class="InstanceofInterfaces" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InstanceofThis" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="InstantiatingObjectToGetClassObject" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InstantiationOfUtilityClass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IntLiteralMayBeLongLiteral" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IntegerDivisionInFloatingPointContext" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IntegerMultiplicationImplicitCastToLong" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreNonOverflowingCompileTimeConstants" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="IntentionDescriptionNotFoundInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InterceptionAnnotationWithoutRuntimeRetention" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="InterfaceMayBeAnnotatedFunctional" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="InterfaceNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="6"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="InterfaceNeverImplemented" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreInterfacesThatOnlyDeclareConstants" value="false"/>
+  </inspection_tool>
+  <!-- we are a library, we do not know all third-party implementations -->
+  <inspection_tool class="InterfaceWithOnlyOneDirectInheritor" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="IntroduceWhenSubject" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InvalidI18nProperty" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InvalidImplementedBy" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InvalidProvidedBy" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="InvalidRequestParameters" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="IteratorHasNextCallsIteratorNext" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="IteratorNextDoesNotThrowNoSuchElementException" enabled="true"
+                   level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="JBoss" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="JDBCExecuteWithNonConstantString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JDBCPrepareStatementWithNonConstantString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JDBCResource" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="insideTryAllowed" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="JNDIResource" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="insideTryAllowed" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="JSAccessibilityCheck" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSBitwiseOperatorUsage" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSCheckFunctionSignatures" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSClosureCompilerSyntax" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSCommentMatchesSignature" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSComparisonWithNaN" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSConsecutiveCommasInArrayLiteral" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSConstructorReturnsPrimitive" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we like the style when declaration comes close to first usage -->
+  <inspection_tool class="JSDeclarationsAtScopeStart" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JSDeprecatedSymbols" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSDuplicatedDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSFileReferences" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSHint" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="JSJQueryEfficiency" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSLastCommaInArrayLiteral" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSLastCommaInObjectLiteral" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSLint" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="JSMethodCanBeStatic" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSMismatchedCollectionQueryUpdate" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="queries" value="trace,write,forEach"/>
+    <option name="updates" value="pop,push,shift,splice,unshift"/>
+  </inspection_tool>
+  <inspection_tool class="JSPotentiallyInvalidConstructorUsage" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="myConsiderUppercaseFunctionsToBeConstructors" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="JSPotentiallyInvalidTargetOfIndexedPropertyAccess" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="JSPotentiallyInvalidUsageOfThis" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSPrimitiveTypeWrapperUsage" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSReferencingMutableVariableFromClosure" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSSuspiciousNameCombination" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <group names="x,width,left,right"/>
+    <group names="y,height,top,bottom"/>
+    <exclude classes="Math"/>
+  </inspection_tool>
+  <inspection_tool class="JSTypeOfValues" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="JSUndeclaredVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUndefinedPropertyAssignment" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUnfilteredForInLoop" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUnnecessarySemicolon" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUnresolvedFunction" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- it produces false positives on references of globally available libraries -->
+  <inspection_tool class="JSUnresolvedLibraryURL" enabled="false" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUnresolvedVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUnusedAssignment" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUnusedGlobalSymbols" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSUnusedLocalSymbols" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSValidateJSDoc" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JSValidateTypes" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JUnit3MethodNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JUnit3StyleTestMethodInJUnit4Class" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JUnit4AnnotatedMethodInJUnit3TestCase" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JUnit4MethodNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_maxLength" value="80"/>
+  </inspection_tool>
+  <inspection_tool class="JUnitAbstractTestClassNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*TestCase"/>
+    <option name="m_minLength" value="12"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="JUnitDatapoint" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="JUnitRule" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="JUnitTestClassNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*Test"/>
+    <option name="m_minLength" value="8"/>
+    <option name="m_maxLength" value="65"/>
+  </inspection_tool>
+  <!-- we need to stay on junit -->
+  <inspection_tool class="JUnitTestNG" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <!-- on the moment of review we were not a big fans of functional style,
+         none of code coverage tools can distinguish that body of lambda is executed.
+         When this problem is resolved we could reconsider disablement. -->
+  <inspection_tool class="Java8MapApi" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaCollectionsStaticMethod" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaDoc" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="TOP_LEVEL_CLASS_OPTIONS">
+      <value>
+        <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none"/>
+        <option name="REQUIRED_TAGS" value=""/>
+      </value>
+    </option>
+    <option name="INNER_CLASS_OPTIONS">
+      <value>
+        <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none"/>
+        <option name="REQUIRED_TAGS" value=""/>
+      </value>
+    </option>
+    <option name="METHOD_OPTIONS">
+      <value>
+        <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none"/>
+        <option name="REQUIRED_TAGS" value="@return@param@throws or @exception"/>
+      </value>
+    </option>
+    <option name="FIELD_OPTIONS">
+      <value>
+        <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none"/>
+        <option name="REQUIRED_TAGS" value=""/>
+      </value>
+    </option>
+    <option name="IGNORE_DEPRECATED" value="false"/>
+    <option name="IGNORE_JAVADOC_PERIOD" value="true"/>
+    <option name="IGNORE_DUPLICATED_THROWS" value="false"/>
+    <option name="IGNORE_POINT_TO_ITSELF" value="false"/>
+    <option name="myAdditionalJavadocTags" value=""/>
+  </inspection_tool>
+  <inspection_tool class="JavaFxColorRgb" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaFxDefaultTag" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaFxEventHandler" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaFxRedundantPropertyValue" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaFxResourcePropertyValue" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaFxUnresolvedFxIdReference" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaFxUnresolvedStyleClassReference" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaFxUnusedImports" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavaLangImport" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JavaLangReflect" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JavaStylePropertiesInvocation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JavacQuirks" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="JavadocReference" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JavaeeApplicationDomInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JdkProxiedBeanTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JoinDeclarationAndAssignment" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaAttributeMemberSignatureInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaAttributeTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaConfigDomFacetInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaDataSourceORMDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaDataSourceORMInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaEntityListenerInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaEntityListenerWarningsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaMissingIdInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaModelReferenceInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaORMDomInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaObjectClassSignatureInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaQlInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpaQueryApiInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JpdlModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="Jscs" enabled="false" level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="JsfJamExtendsClassInconsistencyInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="JsfManagedBeansInconsistencyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JsonDuplicatePropertyKeys" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JsonStandardCompliance" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="JspAbsolutePathInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JspDirectiveInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JspPropertiesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JspTagBodyContent" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="JspUnescapedEl" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KDocUnresolvedReference" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KeySetIterationMayUseEntrySet" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="KotlinDeprecation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinDoubleNegation" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinInternalInJava" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinInvalidBundleOrProperty" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinMavenPluginPhase" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinRedundantOverride" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinSpringComponentScan" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinSpringFacetCode" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinTestJUnit" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="KotlinUnusedImport" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LabeledStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LabeledStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LambdaParameterHidingMemberVariable" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LambdaParameterNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_maxLength" value="25"/>
+  </inspection_tool>
+  <inspection_tool class="LanguageMismatch" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="CHECK_NON_ANNOTATED_REFERENCES" value="true"/>
+  </inspection_tool>
+  <!-- it is impossible to follow this Law for us as most violation are caused by fact
+         that we do logic not only on token that come to visitToken,
+         but by extra traversing over subtree -->
+  <inspection_tool class="LawOfDemeter" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="LeakingThis" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- it is not critical parts of our application and benefit is minimal
+         and only for special applications that use such concatenations alot -
+         https://stackoverflow.com/questions/24859500/concatenate-char-literal-x-vs-single-char-string-literal-x
+    -->
+  <inspection_tool class="LengthOneStringsInConcatenation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LessResolvedByNameOnly" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LessUnresolvedMixin" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LessUnresolvedVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LiftReturnOrAssignment" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LimitedScopeInnerClass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ListIndexOfReplaceableByContains" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ListenerMayUseAdapter" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="checkForEmptyMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="LiteralAsArgToStringEquals" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LoadLibraryWithNonConstantString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- finds false positives and we already have our own FinalLocalVariableCheck
+         for this purpose -->
+  <inspection_tool class="LocalCanBeFinal" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LocalVariableHidingMemberVariable" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_ignoreInvisibleFields" value="true"/>
+    <option name="m_ignoreStaticMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="LocalVariableName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LocalVariableNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_ignoreForLoopParameters" value="false"/>
+    <option name="m_ignoreCatchParameters" value="false"/>
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="1"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="LocalVariableNamingConventionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z][A-Za-z]*"/>
+    <option name="m_minLength" value="1"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <!-- we like concrete types in concrete logic, inspection is not practical
+         and lack more options to skip cases -->
+  <inspection_tool class="LocalVariableOfConcreteClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LogStatementGuardedByLogCondition" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LoggerInitializedWithForeignClass" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger"/>
+  </inspection_tool>
+  <inspection_tool class="LoggingConditionDisagreesWithLogStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- no ability to skip import/package lines, wrapping them is not what we want -->
+  <inspection_tool class="LongLine" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="LongLiteralsEndingWithLowercaseL" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LoopConditionNotUpdatedInsideLoop" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreIterators" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="LoopStatementThatDoesntLoopJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LoopStatementsThatDontLoop" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LoopToCallChain" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="LoopWithImplicitTerminationCondition" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="LossyEncoding" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="MVCPathVariableInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we do a lot of String processing : we have lexer and parser,
+         we do not have java class that contains
+         all lexer tokens with their text values(RPAREN vs ')') -->
+  <inspection_tool class="MagicCharacter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- false positive is reported, we have enough of MagicNumber validations -->
+  <inspection_tool class="MagicConstant" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MagicNumber" enabled="true" level="ERROR" enabled_by_default="true">
+    <scope name="Tests" level="ERROR" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="MagicNumberJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="MalformedFormatString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MalformedRegex" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="MalformedXPath" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ManagedBeanClassInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ManualArrayCopy" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ManualArrayToCollectionCopy" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MapReplaceableByEnumMap" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MarkerInterface" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MathRandomCastToInt" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MavenDuplicateDependenciesInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MavenDuplicatePluginInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- behavior is different from local execution, no violations on local -->
+  <inspection_tool class="MavenModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we use maven plugin for this and github action bot -->
+  <inspection_tool class="MavenPackageUpdate" enabled="false" level="WARNING"
+                   enabled_by_default="false" />
+  <inspection_tool class="MavenRedundantGroupId" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MayBeConstant" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MemberVisibilityCanBePrivate" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <!-- this rule is too severe, it requires some options to
+         skip well known simple methods like string.length() etc. -->
+  <inspection_tool class="MethodCallInLoopCondition" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MethodCanBeVariableArityMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- it is hard to follow this rule as it is better to keep whole logic in one Check class,
+    we do follow cyclomatic complexity for methods -->
+  <inspection_tool class="MethodCount" enabled="false" level="ERROR" enabled_by_default="false">
+    <option name="m_limit" value="20"/>
+    <option name="ignoreGettersAndSetters" value="false"/>
+    <option name="ignoreOverridingMethods" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="MethodCoupling" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="m_includeJavaClasses" value="false"/>
+    <option name="m_includeLibraryClasses" value="false"/>
+    <option name="m_limit" value="25"/>
+  </inspection_tool>
+  <inspection_tool class="MethodMayBeStatic" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Production" level="WARNING" enabled="true">
+      <option name="m_onlyPrivateOrFinal" value="true"/>
+      <option name="m_ignoreEmptyMethods" value="true"/>
+    </scope>
+    <option name="m_onlyPrivateOrFinal" value="true"/>
+    <option name="m_ignoreEmptyMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="MethodMayBeSynchronized" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MethodNameSameAsClassName" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MethodNameSameAsParentName" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MethodNamesDifferOnlyByCase" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MethodOnlyUsedFromInnerClass" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <!-- Better to keep anonymous classes as small as possible. -->
+    <option name="ignoreMethodsAccessedFromAnonymousClass" value="true"/>
+    <option name="ignoreStaticMethodsFromNonStaticInnerClass" value="false"/>
+    <option name="onlyReportStaticMethods" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="MethodOverloadsParentMethod" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MethodOverridesPackageLocalMethod" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MethodOverridesPrivateMethod" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MethodOverridesStaticMethod" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- it is too demanding, event violated private methods.
+         Nothing is bad to be exact inside custom logic,
+         might be good for api classes validation, but setup of this is too heavy for us -->
+  <inspection_tool class="MethodReturnOfConcreteClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- nonsense in our context -->
+  <inspection_tool class="MethodWithMultipleLoops" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MigrateDiagnosticSuppression" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MimeType" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="MinMaxValuesInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MismatchedArrayReadWrite" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MismatchedCollectionQueryUpdate" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="true">
+      <option name="queryNames">
+        <value/>
+      </option>
+      <option name="updateNames">
+        <value/>
+      </option>
+      <option name="ignoredClasses">
+        <value/>
+      </option>
+    </scope>
+    <option name="queryNames">
+      <value/>
+    </option>
+    <option name="updateNames">
+      <value/>
+    </option>
+    <option name="ignoredClasses">
+      <value/>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="MismatchedStringBuilderQueryUpdate" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisorderedAssertEqualsArgumentsTestNG" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisorderedAssertEqualsParameters" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MissedExecutable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MissingAspectjAutoproxyInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MissingDeprecatedAnnotation" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MissingFinalNewline" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreObjectMethods" value="true"/>
+    <option name="ignoreAnonymousClassMethods" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="MissortedModifiers" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_requireAnnotationsFirst" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="MisspelledCompareTo" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisspelledEquals" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisspelledHashcode" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisspelledHeader" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisspelledSetUp" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisspelledTearDown" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MisspelledToString" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ModuleWithTooFewClasses" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="limit" value="10"/>
+  </inspection_tool>
+  <!-- we are a single jar project by design, at least in the near future -->
+  <inspection_tool class="ModuleWithTooManyClasses" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="limit" value="100"/>
+  </inspection_tool>
+  <inspection_tool class="MoveSuspiciousCallableReferenceIntoParentheses" enabled="false"
+                   level="WEAK WARNING" enabled_by_default="false"/>
+  <inspection_tool class="MultipleBindingAnnotations" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MultipleDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreForLoopDeclarations" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="MultipleExceptionsDeclaredOnTestMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MultipleInjectedConstructorsForClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MultipleMethodDesignatorsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MultipleRepositoryUrls" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="MultipleReturnPointsPerMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreGuardClauses" value="false"/>
+    <option name="ignoreEqualsMethod" value="true"/>
+    <option name="m_limit" value="1"/>
+  </inspection_tool>
+  <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MultipleTypedDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="MultiplyOrDivideByPowerOfTwo" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="checkDivision" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="MysqlParsingInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="NativeMethodNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NativeMethods" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="NegatedConditional" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreNegatedNullComparison" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="NegatedConditionalExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NegatedConditionalExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NegatedEqualityExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NegatedIfElse" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="m_ignoreNegatedNullComparison" value="true"/>
+    <option name="m_ignoreNegatedZeroComparison" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="NegatedIfStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NegativelyNamedBooleanVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedAssignment" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedAssignmentJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedConditionalExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedConditionalExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedFunctionCallJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedFunctionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_includeAnonymousFunctions" value="false"/>
+  </inspection_tool>
+  <!-- we like nested method calls -->
+  <inspection_tool class="NestedMethodCall" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NestedSwitchStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedSwitchStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedSynchronizedStatement" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NestedTryStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <scope name="Tests" level="ERROR" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="NestingDepth" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="m_limit" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="NestingDepthJS" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="m_limit" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NewGroovyClassNamingConvention" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <extension name="GroovyAnnotationNamingConvention" enabled="true"/>
+    <extension name="GroovyClassNamingConvention" enabled="true"/>
+    <extension name="GroovyEnumerationNamingConvention" enabled="true"/>
+    <extension name="GroovyInterfaceNamingConvention" enabled="true"/>
+    <extension name="JUnitAbstractTestClassNamingConvention" enabled="true"/>
+  </inspection_tool>
+  <inspection_tool class="NewInstanceOfSingleton" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NewStringBufferWithCharArgument" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NoExplicitFinalizeCalls" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonBlockStatementBodyJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonBooleanMethodNameMayNotStartWithQuestion" enabled="true"
+                   level="WARNING" enabled_by_default="true">
+    <option name="questionString"
+            value="is,can,has,could,will,shall,contains,equals,startsWith,endsWith"/>
+    <option name="ignoreBooleanMethods" value="false"/>
+    <option name="onlyWarnOnBaseMethods" value="true"/>
+  </inspection_tool>
+  <!-- we use MethodLengthCheck that supported by better suppression model -->
+  <inspection_tool class="NonCommentSourceStatements" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_limit" value="30"/>
+  </inspection_tool>
+  <inspection_tool class="NonExceptionNameEndsWithException" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonFinalClone" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="NonFinalFieldInEnum" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonFinalFieldInImmutable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonFinalFieldOfException" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonFinalGuard" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="NonFinalStaticVariableUsedInClassInitialization" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonJREEmulationClassesInClientCode" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NonJaxWsWebServices" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NonOsgiMavenDependency" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NonProtectedConstructorInAbstractClass" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreNonPublicClasses" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="NonPublicClone" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="NonReproducibleMathCall" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonSerializableFieldInSerializableClass" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignorableAnnotations">
+      <value/>
+    </option>
+    <option name="ignoreAnonymousInnerClasses" value="false"/>
+    <option name="superClassString" value=""/>
+  </inspection_tool>
+  <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonSerializableServiceParameters" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonShortCircuitBooleanExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NonStaticFinalLogger" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="loggerClassName" value=""/>
+  </inspection_tool>
+  <!-- this inspection is not for us -->
+  <inspection_tool class="NonStaticInnerClassInSecureContext" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NonSynchronizedMethodOverridesSynchronizedMethod" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="NonThreadSafeLazyInitialization" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NoopMethodInAbstractClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NotifyCalledOnCondition" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NotifyNotInSynchronizedContext" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NotifyWithoutCorrespondingWait" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NullArgumentToVariableArgMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NullChecksToSafeCall" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="NullThrown" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="NullableBooleanElvis" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <!-- we are not ready to use extra dependency com.google.code.findbugs:jsr305 in our API -->
+  <inspection_tool class="NullableProblems" enabled="false" level="WARNING"
+                   enabled_by_default="false">
+    <option name="REPORT_NULLABLE_METHOD_OVERRIDES_NOTNULL" value="true"/>
+    <option name="REPORT_NOT_ANNOTATED_METHOD_OVERRIDES_NOTNULL" value="true"/>
+    <option name="REPORT_NOTNULL_PARAMETER_OVERRIDES_NULLABLE" value="true"/>
+    <option name="REPORT_NOT_ANNOTATED_PARAMETER_OVERRIDES_NOTNULL" value="true"/>
+    <option name="REPORT_NOT_ANNOTATED_GETTER" value="true"/>
+    <option name="REPORT_NOT_ANNOTATED_SETTER_PARAMETER" value="true"/>
+    <option name="REPORT_ANNOTATION_NOT_PROPAGATED_TO_OVERRIDERS" value="true"/>
+    <option name="REPORT_NULLS_PASSED_TO_NON_ANNOTATED_METHOD" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="NumberEquality" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="NumericOverflow" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="NumericToString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ObjectAllocationIgnoredJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- no options in inspection, there are number of wontfix cases: creation of wrappers etc. -->
+  <inspection_tool class="ObjectAllocationInLoop" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we like comparison of DetailAst by ==, probably one day we will be punished for this -->
+  <inspection_tool class="ObjectEquality" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ObjectEqualsNull" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ObjectLiteralToLambda" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ObjectNotify" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="ObjectPropertyName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ObjectToString" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ObsoleteCollection" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreRequiredObsoleteCollectionTypes" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="OctalIntegerJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="OctalLiteral" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="OnDemandImport" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="OneWayWebMethod" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- on the moment of review we were not a big fans of functional style,
+         none of code coverage tools can distinguish that body of lambda is executed.
+         When this problem is resolved we could reconsider disablement. -->
+  <inspection_tool class="OptionalIsPresent" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="OverloadedMethodsWithSameNumberOfParameters" enabled="true"
+                   level="WARNING" enabled_by_default="true">
+    <option name="ignoreInconvertibleTypes" value="true"/>
+  </inspection_tool>
+  <!-- design problem in inspection
+         as it is not considering diff in argument types before varargs -->
+  <inspection_tool class="OverloadedVarargsMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="OverlyComplexArithmeticExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="6"/>
+  </inspection_tool>
+  <inspection_tool class="OverlyComplexArithmeticExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="6"/>
+  </inspection_tool>
+  <inspection_tool class="OverlyComplexBooleanExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="8"/>
+    <option name="m_ignorePureConjunctionsDisjunctions" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="OverlyComplexBooleanExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="3"/>
+  </inspection_tool>
+  <inspection_tool class="OverlyLargePrimitiveArrayInitializer" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="64"/>
+  </inspection_tool>
+  <inspection_tool class="OverlyStrongTypeCast" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreInMatchingInstanceof" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="OverridableMethodCallDuringObjectConstruction" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="OverriddenMethodCallDuringObjectConstruction" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="OverridingDeprecatedMember" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PackageAccessibility" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PackageDirectoryMismatch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PackageInMultipleModules" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PackageInfoWithoutPackage" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PackageName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PackageNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z0-9\.]*"/>
+    <option name="m_minLength" value="3"/>
+    <option name="m_maxLength" value="100"/>
+  </inspection_tool>
+  <inspection_tool class="PackageVisibleField" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PackageVisibleInnerClass" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignoreEnums" value="false"/>
+    <option name="ignoreInterfaces" value="false"/>
+  </inspection_tool>
+  <!-- suppressed as packges are not easily to change in library project
+         that breaks compatibility -->
+  <inspection_tool class="PackageWithTooFewClasses" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="limit" value="3"/>
+  </inspection_tool>
+  <!-- suppressed as packges are not easily to change in library project
+         that breaks compatibility -->
+  <inspection_tool class="PackageWithTooManyClasses" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="limit" value="10"/>
+  </inspection_tool>
+  <inspection_tool class="PageflowModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PagesFileModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PagesModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ParameterCanBeLocal" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ParameterHidingMemberVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreInvisibleFields" value="true"/>
+    <option name="m_ignoreStaticMethodParametersHidingInstanceFields" value="true"/>
+    <option name="m_ignoreForConstructors" value="true"/>
+    <option name="m_ignoreForPropertySetters" value="true"/>
+    <option name="m_ignoreForAbstractMethods" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ParameterNameDiffersFromOverriddenParameter" enabled="true"
+                   level="WARNING" enabled_by_default="true">
+    <scope name="Production" level="WARNING" enabled="false">
+      <option name="m_ignoreSingleCharacterNames" value="false"/>
+      <option name="m_ignoreOverridesOfLibraryMethods" value="true"/>
+    </scope>
+    <option name="m_ignoreSingleCharacterNames" value="false"/>
+    <option name="m_ignoreOverridesOfLibraryMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="ParameterNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="1"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <inspection_tool class="ParameterNamingConventionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z][A-Za-z]*"/>
+    <option name="m_minLength" value="1"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <!-- we like implementation to be concrete, we do not like a lot of abstractions -->
+  <inspection_tool class="ParameterOfConcreteClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ParameterTypePreventsOverriding" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ParameterizedParametersStaticCollection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ParametersPerConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="7"/>
+  </inspection_tool>
+  <inspection_tool class="ParametersPerFunctionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="ParametersPerMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="5"/>
+  </inspection_tool>
+  <inspection_tool class="PathAnnotation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PatternNotApplicable" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PatternOverriddenByNonAnnotatedMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PatternValidation" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="CHECK_NON_CONSTANT_VALUES" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="PlaceholderCountMatchesArgumentCount" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PlatformDetectionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PlatformExtensionReceiverOfInline" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PlayCustomTagNameInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PlayPropertyInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PluginXmlValidity" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PointcutMethodStyleInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PointlessArithmeticExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreExpressionsContainingConstants" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="PointlessArithmeticExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PointlessBinding" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PointlessBitwiseExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreExpressionsContainingConstants" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="PointlessBitwiseExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreExpressionsContainingConstants" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="PointlessBooleanExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreExpressionsContainingConstants" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="PointlessBooleanExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PointlessNullCheck" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PostfixTemplateDescriptionNotFound" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PresentationAnnotation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we do not like suggested style, but we could change out mind in future -->
+  <inspection_tool class="PrivateMemberAccessBetweenOuterAndInnerClass" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="PrivatePropertyName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ProblematicVarargsMethodOverride" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ProblematicWhitespace" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PropertyName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PropertyValueSetToItself" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ProtectedField" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ProtectedInFinal" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ProtectedInnerClass" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreEnums" value="false"/>
+    <option name="ignoreInterfaces" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ProtectedMemberInFinalClass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PsiElementConcatenation" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- we do not need to force all to have static factory methods -->
+  <inspection_tool class="PublicConstructor" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="PublicConstructorInNonPublicClass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PublicField" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreEnums" value="false"/>
+    <option name="ignorableAnnotations">
+      <value>
+        <item value="org.junit.Rule"/>
+        <item value="org.junit.ClassRule"/>
+        <item value="org.junit.jupiter.api.io.TempDir"/>
+      </value>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="PublicFieldAccessedInSynchronizedContext" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- we are not fanatics of interfaces, we use concept 'the less abstractions the better -->
+  <inspection_tool class="PublicMethodNotExposedInInterface" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="ignorableAnnotations">
+      <value/>
+    </option>
+    <option name="onlyWarnIfContainingClassImplementsAnInterface" value="false"/>
+  </inspection_tool>
+  <!-- we do not need logging by loggers in all places -->
+  <inspection_tool class="PublicMethodWithoutLogging" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="loggerClassName" value=""/>
+  </inspection_tool>
+  <inspection_tool class="PublicStaticArrayField" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="PublicStaticCollectionField" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="QuestionableName" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="nameString"
+            value="aa,abc,bad,bar,bar2,baz,baz1,baz2,baz3,bb,blah,bogus,bool,cc,
+                        ,dd,defau1t,dummy,dummy2,ee,fa1se,ff,foo,foo1,foo2,foo3,foobar,four,fred,
+                        ,fred1,fred2,gg,hh,hello,hello1,hello2,hello3,ii,nu11,one,silly,silly2,
+                        ,string,two,that,then,three,var"/>
+  </inspection_tool>
+  <inspection_tool class="QuickFixGetFamilyNameViolation" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RSReferenceInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RandomDoubleForRandomInteger" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RawUseOfParameterizedType" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReadObjectAndWriteObjectPrivate" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReadObjectInitialization" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReadResolveAndWriteReplaceProtected" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RecordStoreResource" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RecursiveEqualsCall" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RecursivePropertyAccessor" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantArrayCreation" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantCast" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="RedundantExplicitType" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantFieldInitialization" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantGetter" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantIf" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantImplements" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreSerializable" value="false"/>
+    <option name="ignoreCloneable" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="RedundantLambdaArrow" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantMethodOverride" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantModalityModifier" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantObjectTypeCheck" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantSamConstructor" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantScopeBinding" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantSemicolon" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantSetter" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantStringFormatCall" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantSuppression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantSuspendModifier" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantThrows" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantThrowsDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantToBinding" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantToProviderBinding" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantTypeArguments" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RedundantTypeConversion" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="CHECK_ANY" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="RedundantUnitExpression" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantUnitReturnType" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RedundantVisibilityModifier" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReferencesToClassesFromDefaultPackagesInJSPFile" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="ReflectionForUnavailableAnnotation" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReflectionNotFound" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RefusedBequest" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="ignoreEmptySuperMethods" value="false"/>
+    <option name="onlyReportWhenAnnotated" value="true"/>
+  </inspection_tool>
+  <!-- temporal suppression until #11590 -->
+  <inspection_tool class="RegExpDuplicateCharacterInClass" enabled="false" level="WARNING"
+                   enabled_by_default="false" />
+  <inspection_tool class="RemoveCurlyBracesFromTemplate" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveEmptyClassBody" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveEmptyParenthesesFromLambdaCall" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveEmptyPrimaryConstructor" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveEmptySecondaryConstructorBody" enabled="false"
+                   level="WEAK WARNING" enabled_by_default="false"/>
+  <inspection_tool class="RemoveExplicitSuperQualifier" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveExplicitTypeArguments" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveForLoopIndices" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveRedundantBackticks" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveRedundantCallsOfConversionMethods" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveRedundantSpreadOperator" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveSetterParameterType" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveSingleExpressionStringTemplate" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RemoveToStringInStringTemplate" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceAllDot" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ReplaceArrayEqualityOpWithArraysEquals" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceArrayOfWithLiteral" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreLazyOperators" value="true"/>
+    <option name="ignoreObscureOperators" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ReplaceAssignmentWithOperatorAssignmentJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReplaceCallWithBinaryOperator" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceDeprecatedFunctionClassUsages" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReplaceGetOrSet" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplacePutWithAssignment" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceRangeToWithUntil" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceSingleLineLet" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceSizeCheckWithIsNotEmpty" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceSizeZeroCheckWithIsEmpty" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceToWithInfixForm" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReplaceWithOperatorAssignment" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RequiredArtifactTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RequiredAttributes" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="myAdditionalRequiredHtmlAttributes" value=""/>
+  </inspection_tool>
+  <inspection_tool class="RequiredBeanTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ReservedWordUsedAsNameJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RestParamTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RestResourceMethodInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="RestWrongDefaultValueInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="ResultSetIndexZero" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReturnFromFinallyBlock" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReturnFromFinallyBlockJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we are not ready to migrate to java.util.Optional for now -->
+  <inspection_tool class="ReturnNull" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="ReturnOfCollectionField" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignorePrivateMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="ReturnOfDateField" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReturnOfInnerClass" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignoreNonPublic" value="true"/>
+  </inspection_tool>
+  <!-- all cases are false positives -->
+  <inspection_tool class="ReturnThis" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="ReuseOfLocalVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ReuseOfLocalVariableJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="RuntimeExec" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="RuntimeExecWithNonConstantString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SSBasedInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SafeLock" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="SafeVarargsDetector" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SamePackageImport" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- too much false positives as it does not consider fact that public method is called
+         from outside of the class, some values come from config files,
+         also it highlights most of the static methods that are candidates
+         for utils package, but we have not decided yet. -->
+  <inspection_tool class="SameParameterValue" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- it is ok as some methods are in role of configuration 'isEditable{ return false;} -->
+  <inspection_tool class="SameReturnValue" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SassScssResolvedByNameOnly" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SassScssUnresolvedMixin" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SassScssUnresolvedPlaceholderSelector" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SassScssUnresolvedVariable" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ScheduledMethodInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ScopeFunctionConversion" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SeamAnnotationIncorrectSignatureInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SeamAnnotationsInconsistencyInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SeamBijectionIllegalScopeParameterInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SeamBijectionTypeMismatchInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SeamBijectionUndefinedContextVariableInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SeamDomModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SeamDuplicateComponentsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SeamIllegalComponentScopeInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SeamJamComponentInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SecondUnsafeCall" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SelfAssignment" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SelfIncludingJspFiles" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- this inspection is not for us -->
+  <inspection_tool class="SerializableClassInSecureContext" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreAnonymousInnerClasses" value="false"/>
+    <option name="superClassString" value=""/>
+  </inspection_tool>
+  <inspection_tool class="SerializableHasSerializationMethods" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreAnonymousInnerClasses" value="true"/>
+    <option name="superClassString"
+            value="com.puppycrawl.tools.checkstyle.gui.BaseCellEditor,
+                        ,com.puppycrawl.tools.checkstyle.gui.CodeSelector,
+                        ,com.puppycrawl.tools.checkstyle.gui.CodeSelectorPresentation,
+                        ,com.puppycrawl.tools.checkstyle.gui.ListToTreeSelectionModelWrapper,
+                        ,com.puppycrawl.tools.checkstyle.gui.Main,
+                        ,com.puppycrawl.tools.checkstyle.gui.MainFrame,
+                        ,com.puppycrawl.tools.checkstyle.gui.MainFrameModel,
+                        ,com.puppycrawl.tools.checkstyle.gui.ParseTreeTableModel,
+                        ,com.puppycrawl.tools.checkstyle.gui.ParseTreeTablePresentation,
+                        ,com.puppycrawl.tools.checkstyle.gui.TreeTableCellRenderer,
+                        ,com.puppycrawl.tools.checkstyle.gui.TreeTableModelAdapter,
+                        ,com.puppycrawl.tools.checkstyle.gui.TreeTable"/>
+    <option name="ignoreClassWithoutFields" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true"
+                   level="ERROR" enabled_by_default="true">
+    <option name="ignoreAnonymousInnerClasses" value="false"/>
+    <option name="superClassString" value=""/>
+  </inspection_tool>
+  <inspection_tool class="SerializableInnerClassWithNonSerializableOuterClass" enabled="true"
+                   level="ERROR" enabled_by_default="true">
+    <option name="ignoreAnonymousInnerClasses" value="false"/>
+    <option name="superClassString" value=""/>
+  </inspection_tool>
+  <inspection_tool class="SerializableStoresNonSerializable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SerializableWithUnconstructableAncestor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ServerEndpointInconsistencyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ServletWithoutMappingInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SessionScopedInjectsRequestScoped" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SetReplaceableByEnumSet" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SetupCallsSuperSetup" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SetupIsPublicVoidNoArg" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SharedThreadLocalRandom" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ShiftOutOfRange" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ShiftOutOfRangeJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SignalWithoutCorrespondingAwait" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SillyAssignment" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SillyAssignmentJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SimpleDateFormatWithoutLocale" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SimplifiableAnnotation" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SimplifiableCallChain" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SimplifiableConditionalExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SimplifiableEqualsExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SimplifiableIfStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- if asserts methods use messages such simplification damage ease of read
+         see details at https://github.com/checkstyle/checkstyle/pull/6823 -->
+  <inspection_tool class="SimplifiableJUnitAssertion" enabled="false" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SimplifyAssertNotNull" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SimplifyBooleanWithConstants" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SimplifyNegatedBinaryExpression" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SimplifyWhenWithBooleanConstantCondition" enabled="false"
+                   level="WEAK WARNING" enabled_by_default="false"/>
+  <!-- the only violation found is false-positive at AvoidEscapedUnicodeCharactersCheck -->
+  <inspection_tool class="SingleCharAlternation" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SingleCharacterStartsWith" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we like single import for single class -->
+  <inspection_tool class="SingleClassImport" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="Singleton" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="SingletonConstructor" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SingletonInjectsScoped" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SleepWhileHoldingLock" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SocketResource" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="insideTryAllowed" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="SortModifiers" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <!-- even we limit validation comments only, there are still a lot of violations on javadoc
+     parameters naming , it also violates names of inspections in noinspection tags etc. -->
+  <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO"
+                   enabled_by_default="false">
+    <option name="processCode" value="true"/>
+    <option name="processLiterals" value="true"/>
+    <option name="processComments" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="SpringAopErrorsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringAopWarningsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBatchModel" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBeanAttributesInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBeanAutowiringInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SpringBeanConstructorArgInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBeanDepedencyCheckInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBeanInstantiationInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBeanLookupMethodInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBeanNameConventionInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBootAdditionalConfig" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBootApplicationProperties" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBootApplicationYaml" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringBootBootstrapConfigurationInspection" enabled="false"
+                   level="WEAK WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringCacheAnnotationsOnInterfaceInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringCacheNamesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringCacheableAndCachePutInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringCacheableComponentsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringComponentScan" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringContextConfigurationInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringDataJpaMethodInconsistencyInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SpringDataMethodInconsistencyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringDataRepositoryMethodParametersInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringDataRepositoryMethodReturnTypeInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringElInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringElStaticFieldInjectionInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringEventListenerInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringFacetCodeInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringFacetInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="checkTestFiles" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="SpringFacetProgrammaticInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringFactoryMethodInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringHandlersSchemasHighlighting" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringInactiveProfileHighlightingInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SpringIncorrectResourceTypeInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringInjectionValueConsistencyInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringInjectionValueStyleInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringIntegrationDeprecations21" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringIntegrationModel" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringJavaAutowiredFieldsWarningInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringJavaAutowiredMembersInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringJavaAutowiringInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SpringJavaConfigExternalBeansErrorInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SpringJavaConfigInconsistencyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringJavaConstructorAutowiringInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringJavaInjectionPointsAutowiringInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SpringJavaStaticMembersAutowiringInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringKotlinAutowiredMembers" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringKotlinAutowiring" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringLookupInjectionInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringMVCInitBinder" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringMVCViewInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringMessageDispatcherWebXmlInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringModelInspection" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SpringOsgiElementsInconsistencyInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringOsgiListenerInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringOsgiServiceCommonInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringPlaceholdersInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringPublicFactoryMethodInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringRequiredAnnotationInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringRequiredPropertyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringScopesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringSecurityAnnotationBeanPointersResolveInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SpringSecurityDebugActivatedInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringSecurityFiltersConfiguredInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringSecurityModelInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringStaticMembersAutowiringInspection" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SpringTestingDirtiesContextInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringTestingTransactionalInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringTransactionalComponentInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringWebServiceAnnotationsInconsistencyInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SpringWebServicesConfigurationsInspection" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="SpringWebSocketConfigurationInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringXmlAutowireExplicitlyInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringXmlAutowiringInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SpringXmlModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlAddNotNullColumnInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlAmbiguousColumnInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlAutoIncrementDuplicateInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlCheckUsingColumnsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlConstantConditionInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlDeprecateTypeInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlDerivedTableAliasInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlDialectInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlDropIndexedColumnInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlIdentifierInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlInsertValuesInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlNoDataSourceInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlNullComparisonInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlPostgresqlSelectFromProcedureInspection" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="SqlResolveInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlShouldBeInGroupByInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlSideEffectsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlSignatureInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlStorageInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlTypeInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SqlUnusedVariableInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StandardVariableNames" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignoreParameterNameSameAsSuper" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="StatefulEp" enabled="false" level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="StatementsPerFunctionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="30"/>
+  </inspection_tool>
+  <inspection_tool class="StaticCallOnSubclass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- we use static collections to store data that is constant/final for all instances -->
+  <inspection_tool class="StaticCollection" enabled="false" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_ignoreWeakCollections" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="StaticFieldReferenceOnSubclass" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StaticGuardedByInstance" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StaticImport" enabled="true" level="WARNING" enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="StaticInheritance" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StaticMethodNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="4"/>
+    <option name="m_maxLength" value="64"/>
+  </inspection_tool>
+  <!-- we are a library, not used by us heavily does not mean that is not required -->
+  <inspection_tool class="StaticMethodOnlyUsedInOneClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StaticNonFinalField" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StaticSuite" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="StaticVariableInitialization" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <scope name="Tests" level="ERROR" enabled="false">
+      <option name="m_ignorePrimitives" value="false"/>
+    </scope>
+    <option name="m_ignorePrimitives" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="StaticVariableNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="checkMutableFinals" value="false"/>
+    <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="5"/>
+    <option name="m_maxLength" value="32"/>
+  </inspection_tool>
+  <!-- it lacks option to skip inner field of the same size
+         that we use give convenient ready to use instances -->
+  <inspection_tool class="StaticVariableOfConcreteClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StaticVariableUninitializedUse" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false">
+      <option name="m_ignorePrimitives" value="false"/>
+    </scope>
+    <option name="m_ignorePrimitives" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="StringBufferField" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringBufferMustHaveInitialCapacity" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringBufferReplaceableByString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringBufferReplaceableByStringBuilder" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringCompareTo" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we like it, it is not performance issue for us -->
+  <inspection_tool class="StringConcatenation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StringConcatenationArgumentToLogCall" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringConcatenationInsideStringBufferAppend" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <!-- we are not fragile by this, it is mostly for SQL focused apps -->
+  <inspection_tool class="StringConcatenationMissingWhitespace" enabled="false" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="StringConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreSubstringArguments" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="StringEquality" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="StringEquals" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringEqualsIgnoreCase" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringLiteralBreaksHTMLJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="onlyWarnOnLoop" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="StringToString" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="StringToUpperWithoutLocale" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!--  usage of string.split will use less efficient way of parsing,
+    usage of some other tokennizer might demand new dependency -->
+  <inspection_tool class="StringTokenizer" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StringTokenizerDelimiter" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="Struts2ModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StrutsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StrutsTilesInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StrutsValidatorFormInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="StrutsValidatorInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SubstringZero" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuperClassHasFrequentlyUsedInheritors" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuperTearDownInFinally" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuppressionAnnotation" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="myAllowedSuppressions">
+      <list>
+        <option value="deprecation"/>
+        <option value="unchecked"/>
+        <option value="rawtypes"/>
+        <!-- There is no other way to deliver filename that was under processing.
+                     See https://github.com/checkstyle/checkstyle/issues/2285 -->
+        <option value="ProhibitedExceptionThrown"/>
+        <option value="MismatchedQueryAndUpdateOfCollection"/>
+        <!-- No way to split apart huge if/else branches in test. -->
+        <option value="IfStatementWithTooManyBranches"/>
+        <!-- we have to catch Exception in Checker and rethrow it -->
+        <option value="ProhibitedExceptionThrown"/>
+        <!-- we have to use it when pass null argument in test purposes -->
+        <option value="NullArgumentToVariableArgMethod"/>
+        <option value="ChainOfInstanceofChecks"/>
+        <option value="MagicNumber"/>
+        <!-- it is used for test purposes -->
+        <option value="AssignmentToStaticFieldFromInstanceMethod"/>
+        <option value="SuperClassHasFrequentlyUsedInheritors"/>
+        <!-- we still have classes derived from deprecated ones -->
+        <option value="DeprecatedIsStillUsed"/>
+        <!-- these are base classes for checks
+                     and not all their methods may need to be overwritten -->
+        <option value="NoopMethodInAbstractClass"/>
+        <!-- Main class is a wrapper command line program for the Checker -->
+        <option value="UseOfSystemOutOrSystemErr"/>
+        <option value="SuspiciousArrayCast"/>
+        <option value="AbstractClassWithOnlyOneDirectInheritor"/>
+        <!-- in some cases it makes the logic even more complicated -->
+        <option value="SimplifiableIfStatement"/>
+        <option value="ClassOnlyUsedInOnePackage"/>
+        <!-- bug in inspection as it might consider only imports -->
+        <option value="ClassIndependentOfModule"/>
+        <!-- it is hard to change api classes constructors -->
+        <option value="ConstructorWithTooManyParameters"/>
+        <option value="ProtectedInnerClass"/>
+        <option value="CheckedExceptionClass"/>
+        <option value="StaticVariableMayNotBeInitialized"/>
+        <option value="StaticVariableUsedBeforeInitialization"/>
+        <!-- violations in DetailAST will be addressed further -->
+        <option value="FieldNotUsedInToString"/>
+        <!-- WeakerAccess reports 'can be protected' that we can not change -->
+        <option value="WeakerAccess"/>
+        <!-- we need to work with AntClassLoader, there is no way to avoid this -->
+        <option value="ClassLoaderInstantiation"/>
+        <!-- There are asserts in DetailAstImplTest#checkNode,
+                       but idea does not see them -->
+        <option value="JUnitTestMethodWithNoAssertions"/>
+        <!-- we use it in Main class -->
+        <option value="CallToSystemExit"/>
+        <!-- we use it for testing purposes -->
+        <option value="unused"/>
+        <!-- we use it for testing purposes -->
+        <option value="UseOfPropertiesAsHashtable"/>
+        <!-- till #4862, #4864 -->
+        <option value="ThisEscapedInObjectConstruction"/>
+        <!-- it will make code too complicated in some cases -->
+        <option value="MultipleReturnPointsPerMethod"/>
+        <!-- MT check markers are annotations -->
+        <option value="AnnotationClass"/>
+        <!-- Suppression is only for TokenTypes class -->
+        <option value="ClassWithTooManyDependents"/>
+        <!-- XDocs UT is very long and complex -->
+        <option value="OverlyComplexBooleanExpression"/>
+        <option value="ReuseOfLocalVariable"/>
+        <!-- Sometimes resources are created in one method and released in another.
+                       In this case, there will be a warning "AutoCloseableResource", which need
+                       to be suppressed. -->
+        <option value="resource"/>
+        <!-- false positives -->
+        <option value="JUnitTestCaseWithNoTests"/>
+        <!-- false positives -->
+        <option value="NewClassNamingConvention"/>
+        <!-- false positives -->
+        <option value="JUnitTestClassNamingConvention"/>
+        <!-- usage of picocli library in Main.java case we won't fix -->
+        <option value="CanBeFinal"/>
+      </list>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="SuspiciousArrayCast" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Production" level="WARNING" enabled="true"/>
+  </inspection_tool>
+  <inspection_tool class="SuspiciousEqualsCombination" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SuspiciousGetterSetter" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="onlyWarnWhenFieldPresent" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuspiciousInstanceOfGuard" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SuspiciousLiteralUnderscore" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuspiciousLocalesLanguages" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuspiciousMethodCalls" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="REPORT_CONVERTIBLE_METHOD_CALLS" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="SuspiciousNameCombination" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <group names="x,width,left,right"/>
+    <group names="y,height,top,bottom"/>
+    <ignored>
+      <option name="METHOD_MATCHER_CONFIG"
+              value="java.io.PrintStream,println, ,
+    ,java.io.PrintWriter,println, ,
+    ,java.lang.System,identityHashCode, ,
+    ,java.sql.PreparedStatement,set.*, ,
+    ,java.sql.ResultSet,update.*, ,
+    ,java.sql.SQLOutput,write.*, ,
+    ,java.lang.Integer,compare.*, ,
+    ,java.lang.Long,compare.*, ,
+    ,java.lang.Short,compare, ,
+    ,java.lang.Byte,compare, ,
+    ,java.lang.Character,compare, ,
+    ,java.lang.Boolean,compare, ,
+    ,java.lang.Math,.*, ,
+    ,java.lang.StrictMath,.*"/>
+    </ignored>
+  </inspection_tool>
+  <inspection_tool class="SuspiciousSystemArraycopy" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuspiciousToArrayCall" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SuspiciousTypeOfGuard" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- we like switch statements, we can not avoid usage of them -->
+  <inspection_tool class="SwitchStatement" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SwitchStatementDensity" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="20"/>
+  </inspection_tool>
+  <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SwitchStatementWithNoDefaultBranchJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="2"/>
+  </inspection_tool>
+  <inspection_tool class="SwitchStatementWithTooManyBranches" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="21"/>
+  </inspection_tool>
+  <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreFullyCoveredEnums" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="SynchronizationOnLocalVariableOrMethodParameter" enabled="true"
+                   level="ERROR" enabled_by_default="true">
+    <option name="reportLocalVariables" value="true"/>
+    <option name="reportMethodParameters" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="SynchronizationOnStaticField" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SynchronizeOnLock" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SynchronizeOnNonFinalField" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SynchronizeOnThis" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SynchronizedMethod" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_includeNativeMethods" value="true"/>
+    <option name="ignoreSynchronizedSuperMethods" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="SynchronizedOnLiteralObject" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SyntaxError" enabled="true" level="ERROR" enabled_by_default="false">
+    <scope name="Checkstyle Inspection Scope" level="ERROR" enabled="true" />
+  </inspection_tool>
+  <inspection_tool class="SystemExit" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="SystemGC" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="SystemGetenv" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="SystemOutErr" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <!-- we do not use system variables for any security relates reasons
+         (no passwords or authentication etc.) -->
+  <inspection_tool class="SystemProperties" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="SystemRunFinalizersOnExit" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="SystemSetSecurityManager" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TaglibDomModelInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TailRecursion" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="TailRecursionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TeardownCallsSuperTeardown" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TeardownIsPublicVoidNoArg" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TelReferencesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TestCaseInProductCode" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TestCaseWithConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TestCaseWithNoTestMethods" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreSupers" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="TestFunctionName" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TestMethodInProductCode" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TestMethodIsPublicVoidNoArg" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TestMethodWithoutAssertion" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="assertionMethods"
+            value="org.junit.jupiter.api.Assertions,assert.*|fail.*, ,
+    ,org.mockito.Mockito,verify.*, ,
+    ,org.mockito.InOrder,verify, ,
+    ,org.hamcrest.MatcherAssert,assertThat, ,
+    ,com.google.common.truth.Truth,assert.*, ,
+    ,com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport,verify.*, ,
+    ,com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport,verify.*, ,
+    ,com.puppycrawl.tools.checkstyle.AbstractXmlTestSupport,verifyXml.*, ,
+    ,com.google.checkstyle.test.base.AbstractModuleTestSupport,verify.*, ,
+    ,com.puppycrawl.tools.checkstyle.internal.TestUtil,assert.*, ,
+    ,nl.jqno.equalsverifier.EqualsVerifier,verify.*, ,
+    ,org.checkstyle.base.AbstractItModuleTestSupport,verify.*"/>
+    <option name="assertKeywordIsAssertion" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="TestNGDataProvider" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TestNGMethodNamingConvention" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TestOnlyProblems" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TextLabelInSwitchStatement" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TextLabelInSwitchStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThisEscapedInConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThisExpressionReferencesGlobalObjectJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadDeathRethrown" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadDumpStack" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadLocalNotStaticFinal" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadPriority" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadRun" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="ThreadStartInConstruction" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadStopSuspendResume" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadWithDefaultRunMethod" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThreadYield" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="ThreeNegationsPerFunctionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- this inspection is not configurable, 3 it is too demanding,
+         result code will not be better -->
+  <inspection_tool class="ThreeNegationsPerMethod" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="m_ignoreInEquals" value="true"/>
+    <option name="ignoreInAssert" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ThrowCaughtLocally" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreRethrownExceptions" value="false"/>
+  </inspection_tool>
+  <!-- disabled till we switch to jacoco that support try-with-resources -->
+  <inspection_tool class="ThrowFromFinallyBlock" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ThrowFromFinallyBlockJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThrowableInstanceNeverThrown" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThrowablePrintedToSystemOut" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThrowableResultOfMethodCallIgnored" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_limit" value="3"/>
+  </inspection_tool>
+  <inspection_tool class="ThrowsRuntimeException" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="ThymeleafDialectDomInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ThymeleafMessagesResolveInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ThymeleafVariablesResolveInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TimeToString" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="ToArrayCallWithZeroLengthArrayArgument" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we use our own Check, that have proper suppression -->
+  <inspection_tool class="TodoComment" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <!-- show too much false-positives in our code -->
+  <inspection_tool class="TooBroadCatch" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TooBroadScope" enabled="true" level="ERROR" enabled_by_default="false">
+    <scope name="Production" level="ERROR" enabled="true">
+      <option name="m_allowConstructorAsInitializer" value="false"/>
+      <option name="m_onlyLookAtBlocks" value="false"/>
+    </scope>
+    <option name="m_allowConstructorAsInitializer" value="false"/>
+    <option name="m_onlyLookAtBlocks" value="false"/>
+  </inspection_tool>
+  <!-- it is ok in test to throw all to be printed on console -->
+  <inspection_tool class="TooBroadThrows" enabled="false" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="false"/>
+  </inspection_tool>
+  <inspection_tool class="TrailingSpacesInProperty" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- conflicts with SpotBugs -->
+  <inspection_tool class="TransientFieldNotInitialized" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TrivialConditionalJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TrivialIf" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="TrivialIfJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- we can not use try-with-resources till we switch to jacoco for code coverage -->
+  <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TryWithIdenticalCatches" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TsLint" enabled="false" level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="TypeCustomizer" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we like implementation to be concrete, we do not like a lot of abstractions -->
+  <inspection_tool class="TypeMayBeWeakened" enabled="false" level="ERROR"
+                   enabled_by_default="false">
+    <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true"/>
+    <option name="useParameterizedTypeForCollectionMethods" value="true"/>
+    <option name="doNotWeakenToJavaLangObject" value="true"/>
+    <option name="onlyWeakentoInterface" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="TypeParameterExtendsFinalClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TypeParameterExtendsObject" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TypeParameterFindViewById" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeParameterHidesVisibleType" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TypeParameterNamingConvention" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
+    <option name="m_minLength" value="1"/>
+    <option name="m_maxLength" value="1"/>
+  </inspection_tool>
+  <inspection_tool class="TypeScriptAbstractClassConstructorCanBeMadeProtected" enabled="false"
+                   level="WEAK WARNING" enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptAccessibilityCheck" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptCheckFunctionSignatures" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="TypeScriptCheckImport" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptFieldCanBeMadeReadonly" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptMissingAugmentationImport" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptPreferShortImport" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptSuspiciousConstructorParameterAssignment" enabled="false"
+                   level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptUMDGlobal" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptUnresolvedFunction" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptUnresolvedVariable" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptValidateJSTypes" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypeScriptValidateTypes" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="TypescriptExplicitMemberType" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UElementAsPsi" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UNCHECKED_WARNING" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="UnaryPlus" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <!-- this is old style, modern world like unchecked exceptions more -->
+  <inspection_tool class="UncheckedExceptionClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- raise a lot of violations that make no sense to benefit from parentheses,
+    like "a==1 && b==2" force to use parentheses, that is not good -->
+  <inspection_tool class="UnclearBinaryExpression" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnconditionalWait" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnconstructableTestCase" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UndeclaredTests" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UndesirableClassUsage" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnhandledExceptionInJSP" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UninstantiableBinding" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UninstantiableImplementedByClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UninstantiableProvidedByClass" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnknownGuard" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="UnknownLanguage" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnnecessarilyQualifiedInnerClassAccess" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreReferencesNeedingImport" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessarilyQualifiedStaticUsage" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreStaticFieldAccesses" value="false"/>
+    <option name="m_ignoreStaticMethodCalls" value="false"/>
+    <option name="m_ignoreStaticAccessFromStaticContext" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessarilyQualifiedStaticallyImportedElement" enabled="true"
+                   level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryBlockStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreSwitchBranches" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryBoxing" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryBreak" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryCallToStringValueOf" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryConditionalExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryConstantArrayCreationExpression" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryContinue" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryContinueJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- conflicts with other tools -->
+  <inspection_tool class="UnnecessaryDefault" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnnecessaryEnumModifier" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryExplicitNumericCast" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- it conflicts with our FinalLocalVariable -->
+  <inspection_tool class="UnnecessaryFinalOnLocalVariableOrParameter" enabled="false"
+                   level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="UnnecessaryFullyQualifiedName" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreJavadoc" value="false"/>
+    <option name="ignoreInModuleStatements" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryInheritDoc" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryInterfaceModifier" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryJavaDocLink" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreInlineLinkToSuper" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryLabelJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryLabelOnBreakStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryLabelOnContinueStatement" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryLocalVariable" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreImmediatelyReturnedVariables" value="false"/>
+    <option name="m_ignoreAnnotatedVariables" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryLocalVariableJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreImmediatelyReturnedVariables" value="false"/>
+    <option name="m_ignoreAnnotatedVariables" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryParentheses" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreClarifyingParentheses" value="false"/>
+    <option name="ignoreParenthesesOnConditionals" value="false"/>
+    <option name="ignoreParenthesesOnLambdaParameter" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryQualifiedReference" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryReturn" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryReturnJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessarySemicolon" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryStaticInjection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnnecessarySuperConstructor" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessarySuperQualifier" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryTemporaryOnConversionFromString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryTemporaryOnConversionToString" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryThis" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryToStringCall" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryUnaryMinus" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryUnboxing" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryUnicodeEscape" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnnecessaryVariable" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnparsedCustomBeanInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnpredictableBigDecimalConstructorCall" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreReferences" value="true"/>
+    <option name="ignoreComplexLiterals" value="false"/>
+  </inspection_tool>
+  <!-- we have our own understanding what we think code should be,
+         it is checked by RequireThisCheck -->
+  <inspection_tool class="UnqualifiedFieldAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- it is ok to skip name of outter class for inner class
+         in filed/variable declaration to keep type short -->
+  <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we have our own understanding what we think code should be,
+         it is checked by RequireThisCheck -->
+  <inspection_tool class="UnqualifiedMethodAccess" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- inspection does not have option to skip cases of usage
+        static field/method that is declared
+        in the same class, as result there are a lot of want-fix cases. -->
+  <inspection_tool class="UnqualifiedStaticUsage" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnreachableCodeJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnregisteredActivator" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnresolvedMessageChannel" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnresolvedPropertyKey" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnresolvedReference" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnsafeCastFromDynamic" enabled="false" level="INFO"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnsafeReturnStatementVisitor" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnsafeVfsRecursion" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnstableApiUsage" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="unstableApiAnnotations">
+      <set>
+        <!-- removed guava's Beta. Unstable doesn't mean it isn't safe to use, just might
+               change between versions and isn't stable -->
+        <option value="io.reactivex.annotations.Beta" />
+        <option value="io.reactivex.annotations.Experimental" />
+        <option value="org.apache.http.annotation.Beta" />
+        <option value="org.gradle.api.Incubating" />
+        <option value="org.jetbrains.annotations.ApiStatus.Experimental" />
+        <option value="rx.annotations.Beta" />
+        <option value="rx.annotations.Experimental" />
+      </set>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="UnterminatedStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="ignoreSemicolonAtEndOfBlock" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="UnusedAssignment" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="REPORT_PREFIX_EXPRESSIONS" value="false"/>
+    <option name="REPORT_POSTFIX_EXPRESSIONS" value="true"/>
+    <option name="REPORT_REDUNDANT_INITIALIZER" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Tests" level="WARNING" enabled="true">
+      <!-- comments explain why catch swallow is ok , wide used in tests -->
+      <option name="m_ignoreCatchBlocksWithComments" value="true"/>
+      <option name="m_ignoreTestCases" value="false"/>
+    </scope>
+    <option name="m_ignoreCatchBlocksWithComments" value="false"/>
+    <option name="m_ignoreTestCases" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnusedCatchParameterJS" enabled="true" level="ERROR"
+                   enabled_by_default="true">
+    <option name="m_ignoreCatchBlocksWithComments" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="UnusedDefine" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="UnusedEquals" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnusedImport" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <inspection_tool class="UnusedLabel" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="UnusedLambdaExpressionBody" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnusedMessageFormatParameter" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UnusedParameters" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <scope name="Production" level="WARNING" enabled="true"/>
+  </inspection_tool>
+  <inspection_tool class="UnusedProperty" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="UnusedReceiverParameter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UnusedSymbol" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UseDPIAwareBorders" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UseDPIAwareInsets" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UseExpressionBody" enabled="false" level="INFORMATION"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UseJBColor" enabled="false" level="WARNING" enabled_by_default="false"/>
+  <inspection_tool class="UseOfAWTPeerClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- we like this style of accessing of content of inner classes,
+         maybe one day in future we change our mind -->
+  <inspection_tool class="UseOfAnotherObjectsPrivateField" enabled="false" level="WARNING"
+                   enabled_by_default="false">
+    <option name="ignoreSameClass" value="true"/>
+    <option name="ignoreEquals" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="UseOfClone" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="UseOfJDBCDriverClass" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UseOfObsoleteAssert" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UseOfObsoleteDateTimeApi" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UseOfProcessBuilder" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UseOfPropertiesAsHashtable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UseOfSunClasses" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UsePrimitiveTypes" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UsePropertyAccessSyntax" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UseVirtualFileEquals" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UseWithIndex" enabled="false" level="INFO" enabled_by_default="false"/>
+  <inspection_tool class="UselessCallOnCollection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UselessCallOnNotNull" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UtilSchemaInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- we are not pure object-oriented library, we like reasonable mix of styles,
+         especially state-less and context-less -->
+  <inspection_tool class="UtilityClass" enabled="false" level="ERROR" enabled_by_default="false">
+    <option name="ignorableAnnotations">
+      <value/>
+    </option>
+  </inspection_tool>
+  <!-- we do not like this style -->
+  <inspection_tool class="UtilityClassCanBeEnum" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="UtilityClassWithPublicConstructor" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="UtilityClassWithoutPrivateConstructor" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignorableAnnotations">
+      <value/>
+    </option>
+    <option name="ignoreClassesWithOnlyMain" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="ValidExternallyBoundObject" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ValidatorConfigModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="ValidatorModelInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- we like varargs methods, we use modern jdk -->
+  <inspection_tool class="VarargParameter" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- using the same variable is not always required,
+         especially in case where null is signal for action or break etc. -->
+  <inspection_tool class="VariableNotUsedInsideIf" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="VoidExpressionJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="VoidMethodAnnotatedWithGET" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="VolatileArrayField" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="VolatileLongOrDoubleField" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="VtlDirectiveArgsInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="VtlFileReferencesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="VtlInterpolationsInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- VtlReferencesInspection produce a lot false-positives on ${projectVersion} -->
+  <inspection_tool class="VtlReferencesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="VtlTypesInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="W3CssValidation" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="myCssVersion" value="css3"/>
+    <option name="myIgnoreVendorSpecificProperties" value="true"/>
+  </inspection_tool>
+  <inspection_tool class="WSReferenceInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="WadlDomInspection" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="WaitCalledOnCondition" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WaitNotInLoop" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WaitNotInSynchronizedContext" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WaitOrAwaitWithoutTimeout" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WaitWhileHoldingTwoLocks" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WaitWithoutCorrespondingNotify" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- till https://youtrack.jetbrains.com/issue/IDEA-187208 -->
+  <inspection_tool class="WeakerAccess" enabled="false" level="WARNING"
+                   enabled_by_default="false">
+    <scope name="Production" level="WARNING" enabled="true">
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="false"/>
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="false"/>
+      <option name="SUGGEST_PRIVATE_FOR_INNERS" value="false"/>
+      <disabledExtension id="junit"/>
+    </scope>
+    <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true"/>
+    <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="true"/>
+    <option name="SUGGEST_PRIVATE_FOR_INNERS" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="WebProperties" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WebWarnings" enabled="true" level="ERROR" enabled_by_default="true"/>
+  <inspection_tool class="WebflowConfigModelInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="WebflowModelInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="WebflowSetupInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="Weblogic" enabled="false" level="ERROR" enabled_by_default="false"/>
+  <inspection_tool class="WhenWithOnlyElse" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="WhileCanBeForeach" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WhileLoopSpinsOnField" enabled="true" level="WARNING"
+                   enabled_by_default="true">
+    <option name="ignoreNonEmtpyLoops" value="false"/>
+  </inspection_tool>
+  <inspection_tool class="WithStatementJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WrapUnaryOperator" enabled="false" level="WEAK WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="WrongImportPackage" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="WrongPackageStatement" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WrongPropertyKeyValueDelimiter" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="WsdlHighlightingInspection" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="XHTMLIncompatabilitiesJS" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="XmlDuplicatedId" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <!-- there is not xsd or DTD for ant files https://ant.apache.org/faq.html#dtd,
+    some other config files also do not have schemes too -->
+  <inspection_tool class="XmlHighlighting" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <inspection_tool class="XmlInvalidId" enabled="true" level="WARNING" enabled_by_default="true"/>
+  <!-- this inspection is too severely demand all paths to be from repo root,
+         no options to adjust -->
+  <inspection_tool class="XmlPathReference" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
+  <!-- there is not xsd or DTD for ant files https://ant.apache.org/faq.html#dtd,
+    some other config files also do not have schemes too -->
+  <inspection_tool class="XmlUnboundNsPrefix" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="XmlUnusedNamespaceDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="XmlWrongFileType" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <inspection_tool class="XmlWrongRootElement" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="XsltDeclarations" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="XsltTemplateInvocation" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="XsltUnusedDeclaration" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="XsltVariableShadowing" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <!-- conflicting with ToArrayCallWithZeroLengthArrayArgument -->
+  <inspection_tool class="ZeroLengthArrayInitialization" enabled="false" level="WARNING"
+                   enabled_by_default="true"/>
+  <inspection_tool class="dependsOnMethodTestNG" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
+  <inspection_tool class="groupsTestNG" enabled="true" level="ERROR" enabled_by_default="true">
+    <option name="groups">
+      <value>
+        <list size="0"/>
+      </value>
+    </option>
+  </inspection_tool>
+  <inspection_tool class="gwtRawAsyncCallback" enabled="false" level="WARNING"
+                   enabled_by_default="false"/>
+  <!-- disabled till https://youtrack.jetbrains.com/issue/IDEA-203421 -->
+  <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="true"
+                   field="protected" ignoreAccessors="true">
+    <option name="LOCAL_VARIABLE" value="true"/>
+    <option name="FIELD" value="true"/>
+    <option name="METHOD" value="false"/>
+    <option name="CLASS" value="true"/>
+    <option name="PARAMETER" value="true"/>
+    <option name="REPORT_PARAMETER_FOR_PUBLIC_METHODS" value="false"/>
+    <option name="ADD_MAINS_TO_ENTRIES" value="true"/>
+    <option name="ADD_APPLET_TO_ENTRIES" value="true"/>
+    <option name="ADD_SERVLET_TO_ENTRIES" value="true"/>
+    <option name="ADD_NONJAVA_TO_ENTRIES" value="true"/>
+  </inspection_tool>
+</profile>


### PR DESCRIPTION
based on feedback of https://teamcity-support.jetbrains.com/hc/requests/4025415

>The hanging build uses IntelliJ IDEA 2021.2.3 while the previous build was using 2020.1.1.
In TeamCity itself nothing has changed in the inspections build runner, so the issue is most likely on the IntelliJ IDEA side. I've created a ticket: https://youtrack.jetbrains.com/issue/TW-76168/IntelliJ-IDEA-2021-2-3-inspections-build-is-hanging
In the meantime try using the previous version of IntelliJ IDEA in this build.

I updated TC config to use 2020.1.1 .
it works but there are Grammar violations that we disabled in main repo - https://teamcity.jetbrains.com/buildConfiguration/Checkstyle_ContributionIdeaInspectionsMaster/3854533?buildTab=Inspection