### PR TITLE
Issue #623: Add -generateGitHubPage and - githubpostTemplate arguments

### DIFF
--- a/releasenotes-builder/README.md
+++ b/releasenotes-builder/README.md
@@ -21,9 +21,11 @@ Jar file which includes all required dependencies will be located at
 java -jar releasenotes-builder-1.0-all.jar -localRepoPath <arg> \
      -remoteRepoPath <arg> -startRef <arg> [-endRef <arg>] \
      -releaseNumber <arg> [-outputLocation <args>] [-githubAuthToken <arg>] \
-     [-generateAll] [-generateXdoc] [-generateTwit] [-generateRss] [-generateMlist] \
-     [-xdocTemplate] [-twitterTemplate] [-rssTemplate] [-mlistTemplate] \
-     [-publishAllSocial] [-publishTwit] [-twitterConsumerKey <arg>] [-twitterConsumerSecret <arg>] \
+     [-generateAll] [-generateXdoc] [-generateTwit] [-generateRss] [-generateMlist]
+     [-generateGitHub] \
+     [-xdocTemplate] [-twitterTemplate] [-rssTemplate] [-mlistTemplate] [-gitHubTemplate] \
+     [-publishAllSocial] [-publishTwit] [-twitterConsumerKey <arg>]
+     [-twitterConsumerSecret <arg>] \
      [-twiterAccessToken <arg>] [-twitterAccessTokenSecret <arg>] [-twitterProperties <arg>] \
      [-publishMlist] [-mlistUsername <arg>] [-mlistPassword <arg>] [-mlistProperties <arg>] \
      [-publishSfRss] [-sfRssBearerToken <arg>] [-sfRssProperties <arg>]
@@ -65,6 +67,9 @@ Generated file will be ```rss.txt```.
 **generateMlist** - (optional) generate a release notes post to publish on Mailing list.
 Generated file will be ```mailing_list.txt```.
 
+**generateGitHub** - (optional) generate a release notes post to publish on GitHub Page.
+Generated file will be ```github_post.txt```.
+
 **generateAll** - (optional) generate all possible posts.
 Generated files will be at specified output location.
 
@@ -77,6 +82,8 @@ Generated files will be at specified output location.
 **mlistTemplate** - (optional) path to the external mailing list freemarker template file.
 
 **publishAllSocial** - (optional) publish all possible posts. Posts are read from generated files.
+
+**gitHubTemplate** - (optional) path to the external GitHub Page freemarker template file.
 
 **publishTwit** - (optional) publish on Twitter from ```twitter.txt```.
 

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
@@ -59,6 +59,8 @@ public final class CliOptions {
     private boolean generateRss;
     /** Whether to generate a post for Mailing List. */
     private boolean generateMlist;
+    /** Whether to generate a post for GitHub Page. */
+    private boolean generateGitHub;
 
     /** File location for xdoc template. */
     private String xdocTemplate;
@@ -68,6 +70,8 @@ public final class CliOptions {
     private String rssTemplate;
     /** File location for mailing list template. */
     private String mlistTemplate;
+    /** File location for GitHub page template. */
+    private String gitHubTemplate;
 
     /** Whether to publish all social posts. */
     private boolean publishAllSocial;
@@ -214,6 +218,15 @@ public final class CliOptions {
     }
 
     /**
+     * Returns whether to generate a post for GitHub page.
+     *
+     * @return whether to generate a post for GitHub page.
+     */
+    public boolean isGenerateGitHub() {
+        return generateGitHub;
+    }
+
+    /**
      * Returns the file location for xdoc template.
      *
      * @return the file location for xdoc template
@@ -247,6 +260,15 @@ public final class CliOptions {
      */
     public String getMlistTemplate() {
         return mlistTemplate;
+    }
+
+    /**
+     * Returns the file location for GitHub Post template.
+     *
+     * @return the file location for GitHub Post template
+     */
+    public String getGitHubTemplate() {
+        return gitHubTemplate;
     }
 
     /**
@@ -511,6 +533,18 @@ public final class CliOptions {
         }
 
         /**
+         * Specify GitHub post template.
+         *
+         * @param genGitHub gitHub post
+         * @return Builder Object
+         * @noinspection ReturnOfInnerClass
+         */
+        public Builder setGenerateGitHub(boolean genGitHub) {
+            generateGitHub = genGitHub;
+            return this;
+        }
+
+        /**
          * Specify xdoc template.
          *
          * @param xdocTemp xdoc template
@@ -555,6 +589,18 @@ public final class CliOptions {
          */
         public Builder setMlistTemplate(String mlistTemp) {
             mlistTemplate = mlistTemp;
+            return this;
+        }
+
+        /**
+         * Specify GitHub Post template.
+         *
+         * @param gitHubPageTemp GitHub post template
+         * @return Builder Object
+         * @noinspection ReturnOfInnerClass
+         */
+        public Builder setGitHubTemplate(String gitHubPageTemp) {
+            gitHubTemplate = gitHubPageTemp;
             return this;
         }
 
@@ -891,10 +937,12 @@ public final class CliOptions {
             cliOptions.generateTw = generateTw;
             cliOptions.generateRss = generateRss;
             cliOptions.generateMlist = generateMlist;
+            cliOptions.generateGitHub = generateGitHub;
             cliOptions.xdocTemplate = xdocTemplate;
             cliOptions.twitterTemplate = twitterTemplate;
             cliOptions.rssTemplate = rssTemplate;
             cliOptions.mlistTemplate = mlistTemplate;
+            cliOptions.gitHubTemplate = gitHubTemplate;
             cliOptions.publishAllSocial = publishAllSocial;
             cliOptions.publishTwit = publishTwit;
             cliOptions.twitterConsumerKey = twitterConsumerKey;

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
@@ -81,6 +81,8 @@ public class CliProcessor {
     private static final String OPTION_GENERATE_RSS = "generateRss";
     /** Name for the option 'generateMlist'. */
     private static final String OPTION_GENERATE_MLIST = "generateMlist";
+    /** Name for the option 'generateGitHub'. */
+    private static final String OPTION_GENERATE_GITHUB = "generateGitHub";
 
     /** Name for the option 'xdocTemplate'. */
     private static final String OPTION_XDOC_TEMPLATE = "xdocTemplate";
@@ -90,6 +92,8 @@ public class CliProcessor {
     private static final String OPTION_RSS_TEMPLATE = "rssTemplate";
     /** Name for the option 'xdocTemplate'. */
     private static final String OPTION_MLIST_TEMPLATE = "mlistTemplate";
+    /** Name for the option 'gitHubTemplate'. */
+    private static final String OPTION_GITHUB_TEMPLATE = "gitHubTemplate";
 
     /** Name for the option 'publishAllSocial'. */
     private static final String OPTION_PUBLISH_ALL_SOCIAL = "publishAllSocial";
@@ -204,7 +208,12 @@ public class CliProcessor {
                 result.add(String.format("Could not find mailing list template '%s'!", path));
             }
         }
-
+        if (cmdLine.hasOption(OPTION_GITHUB_TEMPLATE)) {
+            final String path = cmdLine.getOptionValue(OPTION_GITHUB_TEMPLATE);
+            if (!Files.isRegularFile(Paths.get(path))) {
+                result.add(String.format("Could not find github post template '%s'!", path));
+            }
+        }
         return result;
     }
 
@@ -226,11 +235,12 @@ public class CliProcessor {
             .setGenerateXdoc(cmdLine.hasOption(OPTION_GENERATE_XDOC))
             .setGenerateTw(cmdLine.hasOption(OPTION_GENERATE_TW))
             .setGenerateRss(cmdLine.hasOption(OPTION_GENERATE_RSS))
-            .setGenerateMlist(cmdLine.hasOption(OPTION_GENERATE_MLIST))
+            .setGenerateGitHub(cmdLine.hasOption(OPTION_GENERATE_GITHUB))
             .setXdocTemplate(cmdLine.getOptionValue(OPTION_XDOC_TEMPLATE))
             .setTwitterTemplate(cmdLine.getOptionValue(OPTION_TWITTER_TEMPLATE))
             .setRssTemplate(cmdLine.getOptionValue(OPTION_RSS_TEMPLATE))
             .setMlistTemplate(cmdLine.getOptionValue(OPTION_MLIST_TEMPLATE))
+            .setGitHubTemplate(cmdLine.getOptionValue(OPTION_GITHUB_TEMPLATE))
             .setPublishAllSocial(cmdLine.hasOption(OPTION_PUBLISH_ALL_SOCIAL))
             .setPublishTwit(cmdLine.hasOption(OPTION_PUBLISH_TWIT))
             .setTwitterConsumerKey(cmdLine.getOptionValue(OPTION_TWITTER_CONSUMER_KEY))
@@ -272,10 +282,13 @@ public class CliProcessor {
             "Whether a mailing list post should be generated.");
         options.addOption(OPTION_XDOC_TEMPLATE, true, "Path to xdoc template");
         options.addOption(OPTION_TWITTER_TEMPLATE, true, "Path to twitter template");
+        options.addOption(OPTION_GENERATE_GITHUB,
+                          "Whether a github post should be generated.");
         options.addOption(OPTION_RSS_TEMPLATE, true, "Path to rss template");
         options.addOption(OPTION_MLIST_TEMPLATE, true, "Path to mailing list template");
         options.addOption(OPTION_PUBLISH_ALL_SOCIAL, "Whether to publish all social posts");
         options.addOption(OPTION_PUBLISH_TWIT, "Whether to publish a Twitter post.");
+        options.addOption(OPTION_GITHUB_TEMPLATE, true, "Path to github page template");
         options.addOption(OPTION_TWITTER_CONSUMER_KEY, true, "Consumer key for Twitter.");
         options.addOption(OPTION_TWITTER_CONSUMER_SECRET, true, "Consumer secret for Twitter.");
         options.addOption(OPTION_TWITTER_ACCESS_TOKEN, true, "Access token for Twitter.");

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -43,6 +43,8 @@ public final class MainProcess {
     public static final String RSS_FILENAME = "rss.txt";
     /** Filename for a generated Mailing List post. */
     public static final String MLIST_FILENAME = "mailing_list.txt";
+    /** Filename for a generated GitHub Post. */
+    public static final String GITHUB_FILENAME = "github_post.txt";
 
     /** FreeMarker xdoc template file name. */
     public static final String FREEMARKER_XDOC_TEMPLATE_FILE =
@@ -56,6 +58,9 @@ public final class MainProcess {
     /** Mailing List template file name. */
     public static final String MLIST_TEMPLATE_FILE =
         "com/github/checkstyle/templates/mailing_list.template";
+    /** GitHub Post template file name. */
+    public static final String GITHUB_TEMPLATE_FILE =
+        "com/github/checkstyle/templates/github_post.template";
 
     /** Default constructor. */
     private MainProcess() {
@@ -114,6 +119,11 @@ public final class MainProcess {
             TemplateProcessor.generateWithFreemarker(templateVariables,
                     outputLocation + MLIST_FILENAME, cliOptions.getMlistTemplate(),
                     MLIST_TEMPLATE_FILE);
+        }
+        if (cliOptions.isGenerateAll() || cliOptions.isGenerateGitHub()) {
+            TemplateProcessor.generateWithFreemarker(templateVariables,
+                    outputLocation + GITHUB_FILENAME, cliOptions.getGitHubTemplate(),
+                    GITHUB_TEMPLATE_FILE);
         }
     }
 

--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/github_post.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/github_post.template
@@ -1,0 +1,36 @@
+Checkstyle ${releaseNo} - https://checkstyle.org/releasenotes.html#Release_${releaseNo}
+
+<#if breakingMessages?has_content>
+Breaking backward compatibility:
+
+<#list breakingMessages as message>
+  #${message.issueNo} - ${message.title}
+</#list>
+</#if>
+
+<#if newMessages?has_content>
+New:
+
+<#list newMessages as message>
+  #${message.issueNo} - ${message.title}
+</#list>
+</#if>
+
+<#if bugMessages?has_content>
+Bug fixes:
+
+<#list bugMessages as message>
+  #${message.issueNo} - ${message.title}
+</#list>
+</#if>
+
+<#if notesMessages?has_content>
+<details>
+<summary>Other Changes:</summary>
+<br>
+<#list notesMessages as message>
+  ${message.title}
+<br />
+</#list>
+</details>
+</#if>

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -72,6 +72,7 @@ public class TemplateProcessorTest {
         assertFile("twitterBreakingCompatibility.txt", MainProcess.TWITTER_FILENAME);
         assertFile("rssMlistBreakingCompatibility.txt", MainProcess.RSS_FILENAME);
         assertFile("rssMlistBreakingCompatibility.txt", MainProcess.MLIST_FILENAME);
+        assertFile("githubPageBreakingCompatibility.txt", MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -86,6 +87,7 @@ public class TemplateProcessorTest {
         assertFile("twitterNew.txt", MainProcess.TWITTER_FILENAME);
         assertFile("rssMlistNew.txt", MainProcess.RSS_FILENAME);
         assertFile("rssMlistNew.txt", MainProcess.MLIST_FILENAME);
+        assertFile("githubPageNew.txt", MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -100,6 +102,7 @@ public class TemplateProcessorTest {
         assertFile("twitterBug.txt", MainProcess.TWITTER_FILENAME);
         assertFile("rssMlistBug.txt", MainProcess.RSS_FILENAME);
         assertFile("rssMlistBug.txt", MainProcess.MLIST_FILENAME);
+        assertFile("githubPageBug.txt", MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -128,6 +131,7 @@ public class TemplateProcessorTest {
         assertFile("twitterNew.txt", MainProcess.TWITTER_FILENAME);
         assertFile("rssMlistNew.txt", MainProcess.RSS_FILENAME);
         assertFile("rssMlistNew.txt", MainProcess.MLIST_FILENAME);
+        assertFile("githubPageNew.txt", MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -147,6 +151,7 @@ public class TemplateProcessorTest {
         assertFile("twitterAll.txt", MainProcess.TWITTER_FILENAME);
         assertFile("rssMlistAll.txt", MainProcess.RSS_FILENAME);
         assertFile("rssMlistAll.txt", MainProcess.MLIST_FILENAME);
+        assertFile("githubPageAll.txt", MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -161,6 +166,7 @@ public class TemplateProcessorTest {
         assertFile(MainProcess.TWITTER_FILENAME);
         assertFile(MainProcess.RSS_FILENAME);
         assertFile(MainProcess.MLIST_FILENAME);
+        assertFile(MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -175,6 +181,7 @@ public class TemplateProcessorTest {
         assertFile("twitterBreakingCompatibility.txt", MainProcess.TWITTER_FILENAME);
         assertFile(MainProcess.RSS_FILENAME);
         assertFile(MainProcess.MLIST_FILENAME);
+        assertFile(MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -189,6 +196,7 @@ public class TemplateProcessorTest {
         assertFile(MainProcess.TWITTER_FILENAME);
         assertFile("rssMlistBreakingCompatibility.txt", MainProcess.RSS_FILENAME);
         assertFile(MainProcess.MLIST_FILENAME);
+        assertFile(MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -202,7 +210,23 @@ public class TemplateProcessorTest {
         assertFile(MainProcess.XDOC_FILENAME);
         assertFile(MainProcess.TWITTER_FILENAME);
         assertFile(MainProcess.RSS_FILENAME);
+        assertFile(MainProcess.GITHUB_FILENAME);
         assertFile("rssMlistBreakingCompatibility.txt", MainProcess.MLIST_FILENAME);
+    }
+
+    @Test
+    public void testGenerateOnlyGitHub() throws Exception {
+        final List<String> errors = MainProcess.run(
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+                .setGenerateGitHub(true).build());
+
+        Assert.assertEquals("no errors", 0, errors.size());
+
+        assertFile(MainProcess.XDOC_FILENAME);
+        assertFile(MainProcess.TWITTER_FILENAME);
+        assertFile(MainProcess.RSS_FILENAME);
+        assertFile(MainProcess.MLIST_FILENAME);
+        assertFile("githubPageBreakingCompatibility.txt", MainProcess.GITHUB_FILENAME);
     }
 
     @Test
@@ -216,7 +240,8 @@ public class TemplateProcessorTest {
                         createAllNotes()),
                 createBaseCliOptions().setGenerateAll(true).setXdocTemplate(template)
                         .setTwitterTemplate(template)
-                        .setRssTemplate(template).setMlistTemplate(template).build());
+                        .setRssTemplate(template).setMlistTemplate(template)
+                        .setGitHubTemplate(template).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
 
@@ -224,6 +249,7 @@ public class TemplateProcessorTest {
         assertFile("customTemplate.txt", MainProcess.TWITTER_FILENAME);
         assertFile("customTemplate.txt", MainProcess.RSS_FILENAME);
         assertFile("customTemplate.txt", MainProcess.MLIST_FILENAME);
+        assertFile("customTemplate.txt", MainProcess.GITHUB_FILENAME);
     }
 
     private static List<ReleaseNotesMessage> createAllNotes() throws Exception {

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageAll.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageAll.txt
@@ -1,0 +1,21 @@
+Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+
+Breaking backward compatibility:
+
+  #-1 - Title 1
+
+New:
+
+  #2 - Title 2
+  #-1 - Title 5
+
+Bug fixes:
+
+  #-1 - Title 3
+
+<details>
+<summary>Other Changes:</summary>
+<br>
+  Title 4
+<br />
+</details>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
@@ -1,0 +1,13 @@
+Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+
+Breaking backward compatibility:
+
+  #-1 - Mock issue title 1
+  #-1 - Mock issue title 2
+  #123 - Mock issue title 3
+  #123 - Mock issue title 4
+  #123 - Mock issue title 5 ==> test
+  #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+
+
+

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
@@ -1,0 +1,13 @@
+Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+
+
+
+Bug fixes:
+
+  #-1 - Mock issue title 1
+  #-1 - Mock issue title 2
+  #123 - Mock issue title 3
+  #123 - Mock issue title 4
+  #123 - Mock issue title 5 ==> test
+  #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
@@ -1,0 +1,13 @@
+Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+
+
+New:
+
+  #-1 - Mock issue title 1
+  #-1 - Mock issue title 2
+  #123 - Mock issue title 3
+  #123 - Mock issue title 4
+  #123 - Mock issue title 5 ==> test
+  #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+
+


### PR DESCRIPTION
Fixes #623 

Checkstyle 10.4-SNAPSHOT - https://checkstyle.org/releasenotes.html#Release_10.4-SNAPSHOT



Bug fixes:

  #11736 - MissingJavadocType: Support qualified annotation names
  #11655 - Update google_checks.xml to have the SuppressionCommentFilter and SuppressWarningsHolder modules in the config by default (and by extension, SuppressWarningsFilter)

<details>
<summary>Other Changes:</summary>
<br>
  Update releasenotes to use GitHub Pages execution
<br />
  Allow SuppressWarningHolder to suppress the violation with NameCheck
<br />
  Pitest: Kill all surviving mutations
<br />
  Pitest: Activate "ALL" mutator group
<br />
  Use Shellcheck to resolve violations code in Shell Script
<br />
  pitest: increase mutation coverage for pitest-imports profile to 100% 
<br />
  Update GitHub Action for bump-license-year.sh
<br />
  Solve fb-contrib errors
<br />
  Remove pitest mutation checking HTML model
<br />
  automate execution by Github action bump-license-year.sh on first day of month
<br />
  update code base to have javadoc tag to explain noinspection tag content
<br />
  doc: put example of enableExternalDtdLoad to xdoc
<br />
  update doc for SuppressWarningsHolder
<br />
  releasenotes script generated empty commit
<br />
  Include CDG Accelerator Plugin to boost pitest performance
<br />
  Enforce file size on Java inputs
<br />
  Expand XPath IT Regression Testing
<br />
  There are semantic problems in the Chinese error message of keyword `design.forExtension` .
<br />
  prepare-settings.sh fails to create settings.xml
<br />
  Use groovy version provided by `apt` in pitest.yml
<br />
  tweet-releasenotes.sh does not check env variables
<br />
  download of m2 cache from sourceforge.io is slow 
<br />
  infra: turns off create dependency reduced pom for shade plugin
<br />
  Update Tests to use new 'verifyXxxxxx' method or 'execute' that use inlined config in Input files
<br />
  Specify violation messages in input files.
<br />
  pitest: increase mutation coverage for javadoc profile to 100%
<br />
</details>

