### PR TITLE
Issue #630: releasenotes-builder: update Github template to be more compact.

### DIFF
--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/github_post.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/github_post.template
@@ -27,10 +27,9 @@ Bug fixes:
 <#if notesMessages?has_content>
 <details>
 <summary>Other Changes:</summary>
-<br>
 <#list notesMessages as message>
-  ${message.title}
-<br />
+<br/>
+  ${message.title} <br/>
 </#list>
 </details>
 </#if>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageAll.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageAll.txt
@@ -15,7 +15,6 @@ Bug fixes:
 
 <details>
 <summary>Other Changes:</summary>
-<br>
-  Title 4
-<br />
+<br/>
+  Title 4 <br/>
 </details>


### PR DESCRIPTION
Fixes #630 