### PR TITLE
Issue #614: Resolve Deprecated API IDEA violations

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
@@ -274,7 +274,7 @@ public final class NotesBuilder {
             actualObjectId = repo.resolve(ref);
         }
         else {
-            final Ref repoPeeled = repo.peel(referenceObj);
+            final Ref repoPeeled = repo.getRefDatabase().peel(referenceObj);
             actualObjectId = Optional.ofNullable(repoPeeled.getPeeledObjectId())
                 .orElse(referenceObj.getObjectId());
         }


### PR DESCRIPTION
#614
From `org.eclipse.jgit.lib.Repository.peel(..)` javadoc:
```java
/**                                                                          
 * Peel a possibly unpeeled reference to an annotated tag.                   
 * <p>                                                                       
 * If the ref cannot be peeled (as it does not refer to an annotated tag)    
 * the peeled id stays null, but {@link org.eclipse.jgit.lib.Ref#isPeeled()} 
 * will be true.                                                             
 *                                                                           
 * @param ref                                                                
 *            The ref to peel                                                
 * @return <code>ref</code> if <code>ref.isPeeled()</code> is true; else a   
 *         new Ref object representing the same data as Ref, but isPeeled()  
 *         will be true and getPeeledObjectId will contain the peeled object 
 *         (or null).                                                        
 * @deprecated use {@code getRefDatabase().peel(ref)} instead.               
 */                                                                          
```
