### PR TITLE
Issue #648: releasenote-builder: should have execution mode to fail if release version (by pom) is not matching to issues labels

### DIFF
--- a/releasenotes-builder/README.md
+++ b/releasenotes-builder/README.md
@@ -28,7 +28,7 @@ java -jar releasenotes-builder-1.0-all.jar -localRepoPath <arg> \
      [-twitterConsumerSecret <arg>] \
      [-twiterAccessToken <arg>] [-twitterAccessTokenSecret <arg>] [-twitterProperties <arg>] \
      [-publishMlist] [-mlistUsername <arg>] [-mlistPassword <arg>] [-mlistProperties <arg>] \
-     [-publishSfRss] [-sfRssBearerToken <arg>] [-sfRssProperties <arg>]
+     [-publishSfRss] [-sfRssBearerToken <arg>] [-sfRssProperties <arg>] [-validateVersion]
 ```
 
 Release notes builder will do the generation of release notes and report warnings and errors to
@@ -110,6 +110,8 @@ Generated files will be at specified output location.
 **sfRssBearerToken** - (optional) bearer token for Sourceforge to publish to RSS.
 
 **sfRssProperties** - (optional) path to a properties file for publication to RSS.
+
+**validateVersion** - validate pom version.
 
 _**Please, notice!**_
 Options in property files have the same names as in command line and have lower priority.

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
@@ -105,6 +105,9 @@ public final class CliOptions {
     /** Properties to publish to RSS. */
     private String sfRssProperties;
 
+    /** To validate pom version */
+    private Boolean validateVersion;
+
     /** Default constructor. */
     private CliOptions() {
     }
@@ -368,6 +371,15 @@ public final class CliOptions {
      */
     public String getSfRssBearerToken() {
         return sfRssBearerToken;
+    }
+
+    /**
+     * Return true or false based on the pom version.
+     *
+     * @return version to validate pom version
+     */
+    public Boolean isValidateVersion() {
+        return validateVersion;
     }
 
     /**
@@ -805,6 +817,17 @@ public final class CliOptions {
         }
 
         /**
+         * Specify pom version.
+         *
+         * @param version pom version.
+         * @return Builder Object
+         */
+        public Builder setValidateVersion(Boolean version) {
+            validateVersion = version;
+            return this;
+        }
+
+        /**
          * Verify options and set defaults.
          *
          * @return new CliOption instance
@@ -989,6 +1012,7 @@ public final class CliOptions {
             cliOptions.publishSfRss = publishSfRss;
             cliOptions.sfRssBearerToken = sfRssBearerToken;
             cliOptions.sfRssProperties = sfRssProperties;
+            cliOptions.validateVersion = validateVersion;
             return cliOptions;
         }
 

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
@@ -111,6 +111,9 @@ public class CliProcessor {
     /** Name for the option 'sfRssProperties'. */
     private static final String OPTION_SF_RSS_PROPERTIES = "sfRssProperties";
 
+    /** Name for the option 'validateVersion'. */
+    private static final String OPTION_VALIDATE_VERSION = "validateVersion";
+
     /** Command line cmdArgs. */
     private final String[] cmdArgs;
     /** Command line object. */
@@ -256,6 +259,7 @@ public class CliProcessor {
             .setPublishSfRss(cmdLine.hasOption(OPTION_PUBLISH_SF_RSS))
             .setSfBearerToken(cmdLine.getOptionValue(OPTION_SF_RSS_BEARER_TOKEN))
             .setSfRssProperties(cmdLine.getOptionValue(OPTION_SF_RSS_PROPERTIES))
+            .setValidateVersion(Boolean.valueOf(cmdLine.getOptionValue(OPTION_VALIDATE_VERSION)))
             .build();
     }
 
@@ -296,6 +300,7 @@ public class CliProcessor {
             "Access token secret for Twitter.");
         options.addOption(OPTION_TWITTER_PROPERTIES, true,
             "Properties for publication on Twitter.");
+        options.addOption(OPTION_VALIDATE_VERSION, false, "Pom version to validate.");
         return options;
     }
 

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -21,9 +21,11 @@ package com.github.checkstyle;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import com.github.checkstyle.globals.Constants;
 import com.github.checkstyle.globals.ReleaseNotesMessage;
 import com.github.checkstyle.publishers.MailingListPublisher;
 import com.github.checkstyle.publishers.SourceforgeRssPublisher;
@@ -79,7 +81,10 @@ public final class MainProcess {
             Multimap<String, ReleaseNotesMessage> releaseNotes, CliOptions cliOptions)
             throws IOException, TemplateException {
         runPostGeneration(releaseNotes, cliOptions);
-        return runPostPublication(cliOptions);
+        ArrayList<String> errors = new ArrayList<String>();
+        errors.addAll(validateNotes(releaseNotes, cliOptions));
+        errors.addAll(runPostPublication(cliOptions));
+        return errors;
     }
 
     /**

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -241,7 +241,8 @@ public class TemplateProcessorTest {
                 createBaseCliOptions().setGenerateAll(true).setXdocTemplate(template)
                         .setTwitterTemplate(template)
                         .setRssTemplate(template).setMlistTemplate(template)
-                        .setGitHubTemplate(template).build());
+                        .setGitHubTemplate(template)
+                        .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
 
@@ -250,6 +251,42 @@ public class TemplateProcessorTest {
         assertFile("customTemplate.txt", MainProcess.RSS_FILENAME);
         assertFile("customTemplate.txt", MainProcess.MLIST_FILENAME);
         assertFile("customTemplate.txt", MainProcess.GITHUB_FILENAME);
+    }
+
+    @Test
+    public void testVersionValidationForBreakingCompatibility() throws Exception {
+        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+                .setValidateVersion(true).build());
+
+        Assert.assertEquals("no version validation error", 0, errors.size());
+    }
+
+    @Test
+    public void testVersionValidationForNewFeature() throws Exception {
+        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions()
+                .setValidateVersion(true).build());
+
+        Assert.assertEquals("no version validation error", 0, errors.size());
+    }
+
+    @Test
+    public void testVersionValidationForBreakingCompatibilityError() throws Exception {
+        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+                .setValidateVersion(false).build());
+
+        Assert.assertEquals("version validation error", 0, errors.size());
+    }
+
+    @Test
+    public void testVersionValidationForNewFeatureError() throws Exception {
+        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions()
+                .setValidateVersion(false).build());
+
+        Assert.assertEquals("version validation error", 0, errors.size());
     }
 
     private static List<ReleaseNotesMessage> createAllNotes() throws Exception {


### PR DESCRIPTION
Fixes #648 