### PR TITLE
Issue #364: releasenotes-builder: avoid extra line wrapping

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
@@ -29,7 +29,7 @@ import org.kohsuke.github.GHIssue;
 public final class ReleaseNotesMessage {
 
     /** Max size of line. */
-    private static final int MAX_TITLE_LINE_SIZE = 70;
+    private static final int MAX_TITLE_LINE_SIZE = 99;
 
     /** Converted size of html character. */
     private static final int HTML_CHAR_SIZE = 5;

--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
@@ -1,4 +1,4 @@
-  <#escape x as x?html>
+<#escape x as x?html>
     <section name="Release ${releaseNo}">
       <div class="releaseDate">${todaysDate}</div>
       <#if breakingMessages?has_content>
@@ -50,4 +50,4 @@
         </ul>
       </#if>
     </section>
-  </#escape>
+</#escape>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Breaking backward compatibility:</p>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Breaking backward compatibility:</p>
@@ -28,8 +27,8 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooo-
+oooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
           </li>
         </ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Bug fixes:</p>
@@ -28,8 +27,8 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooo-
+oooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
           </li>
         </ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Notes:</p>
@@ -28,8 +27,8 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooo-
+oooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
           </li>
         </ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>New:</p>
@@ -28,8 +27,8 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooo-
+oooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
           </li>
         </ul>


### PR DESCRIPTION
Fixes #364 