### PR TITLE
infra: upgrade releasenotes builder to java 11

### DIFF
--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -20,7 +20,7 @@
         <maven.plugin.apache.commons.lang.version>2.6</maven.plugin.apache.commons.lang.version>
         <maven.plugin.twitter4j.version>4.0.7</maven.plugin.twitter4j.version>
         <maven.plugin.javax.mail.version>1.5.0-b01</maven.plugin.javax.mail.version>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <tools.jar.version>${java.version}.0</tools.jar.version>
         <tools.jar.path>${java.home}/../lib/tools.jar</tools.jar.path>
         <checkstyle.version>10.3.3</checkstyle.version>

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/MailingListPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/MailingListPublisher.java
@@ -102,8 +102,7 @@ public class MailingListPublisher {
         mimeMessage.addRecipients(Message.RecipientType.TO,
                 InternetAddress.parse(RECIPIENT_ADDRESS));
 
-        final String post = new String(Files.readAllBytes(Paths.get(postFilename)),
-                StandardCharsets.UTF_8);
+        final String post = Files.readString(Paths.get(postFilename), StandardCharsets.UTF_8);
 
         final BodyPart messageBodyPart = new MimeBodyPart();
         messageBodyPart.setContent(post, "text/plain");

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/SourceforgeRssPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/SourceforgeRssPublisher.java
@@ -83,7 +83,7 @@ public class SourceforgeRssPublisher {
         conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
         try (OutputStream os = conn.getOutputStream()) {
-            final String postText = new String(Files.readAllBytes(Paths.get(postFilename)),
+            final String postText = Files.readString(Paths.get(postFilename),
                 StandardCharsets.UTF_8);
             os.write(String.format(POST_TEMPLATE, bearerToken, releaseNumber, postText)
                 .getBytes(StandardCharsets.UTF_8));

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/TwitterPublisher.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/publishers/TwitterPublisher.java
@@ -77,8 +77,7 @@ public class TwitterPublisher {
         twitter.setOAuthConsumer(consumerKey, consumerSecret);
         final AccessToken token = new AccessToken(accessToken, accessTokenSecret);
         twitter.setOAuthAccessToken(token);
-        final String post = new String(Files.readAllBytes(Paths.get(postFilename)),
-            StandardCharsets.UTF_8);
+        final String post = Files.readString(Paths.get(postFilename), StandardCharsets.UTF_8);
         twitter.updateStatus(post);
     }
 }


### PR DESCRIPTION
Java 11
['Files.readString()' or 'Files.writeString()' can be used (3)](https://teamcity.jetbrains.com/viewLog.html?buildId=3952165&tab=Inspection&buildTypeId=Checkstyle_ContributionIdeaInspectionsPullRequest#)