### PR TITLE
Pull #675: Fix releasenote-builder: should have execution mode to fail if release version (by pom) is not matching to issues labels

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
@@ -378,7 +378,7 @@ public final class CliOptions {
      *
      * @return whether to validate release version.
      */
-    public Boolean isValidateVersion() {
+    public boolean isValidateVersion() {
         return validateVersion;
     }
 
@@ -822,7 +822,7 @@ public final class CliOptions {
          * @param validate flag to validate release version.
          * @return Builder Object
          */
-        public Builder setValidateVersion(Boolean validate) {
+        public Builder setValidateVersion(boolean validate) {
             validateVersion = validate;
             return this;
         }

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliProcessor.java
@@ -259,7 +259,7 @@ public class CliProcessor {
             .setPublishSfRss(cmdLine.hasOption(OPTION_PUBLISH_SF_RSS))
             .setSfBearerToken(cmdLine.getOptionValue(OPTION_SF_RSS_BEARER_TOKEN))
             .setSfRssProperties(cmdLine.getOptionValue(OPTION_SF_RSS_PROPERTIES))
-            .setValidateVersion(Boolean.valueOf(cmdLine.getOptionValue(OPTION_VALIDATE_VERSION)))
+            .setValidateVersion(cmdLine.hasOption(OPTION_VALIDATE_VERSION))
             .build();
     }
 
@@ -300,7 +300,7 @@ public class CliProcessor {
             "Access token secret for Twitter.");
         options.addOption(OPTION_TWITTER_PROPERTIES, true,
             "Properties for publication on Twitter.");
-        options.addOption(OPTION_VALIDATE_VERSION,
+        options.addOption(OPTION_VALIDATE_VERSION, false,
             "Whether release number should be validated to match release notes labels.");
         return options;
     }

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
@@ -65,6 +65,11 @@ public final class Main {
             else {
                 final CliOptions cliOptions = cliProcessor.getCliOptions();
                 final Result notesBuilderResult = runGithubNotesBuilder(cliOptions);
+                if (cliOptions.isValidateVersion()) {
+                    final List<String> validationErrors = MainProcess
+                        .validateNotes(notesBuilderResult.getReleaseNotes(), cliOptions);
+                    notesBuilderResult.addErrors(validationErrors);
+                }
                 errorCounter = notesBuilderResult.getErrorMessages().size();
                 if (errorCounter == 0) {
                     publicationErrors = MainProcess.runPostGenerationAndPublication(

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -80,12 +80,7 @@ public final class MainProcess {
             Multimap<String, ReleaseNotesMessage> releaseNotes, CliOptions cliOptions)
             throws IOException, TemplateException {
         runPostGeneration(releaseNotes, cliOptions);
-        final List<String> errors = new ArrayList<>();
-        if (cliOptions.isValidateVersion()) {
-            errors.addAll(validateNotes(releaseNotes, cliOptions));
-        }
-        errors.addAll(runPostPublication(cliOptions));
-        return errors;
+        return runPostPublication(cliOptions);
     }
 
     /**
@@ -95,7 +90,7 @@ public final class MainProcess {
      * @param cliOptions command line options.
      * @return list of notes validation errors.
      */
-    private static List<String> validateNotes(Multimap<String, ReleaseNotesMessage> releaseNotes,
+    public static List<String> validateNotes(Multimap<String, ReleaseNotesMessage> releaseNotes,
                                               CliOptions cliOptions) {
         final String releaseVersion = cliOptions.getReleaseNumber();
         final long amountOfCommas = getAmountOfCommasInReleaseVersion(releaseVersion);

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/globals/Result.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/globals/Result.java
@@ -100,6 +100,15 @@ public final class Result {
     }
 
     /**
+     * Adds multiple error messages into result.
+     *
+     * @param messages list of error messages.
+     */
+    public void addErrors(List<String> messages) {
+        errorMessages.addAll(messages);
+    }
+
+    /**
      * Adds warning message into result.
      *
      * @param message warning message.

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -275,7 +275,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorNoNotes() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, null, null, null), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
 
@@ -285,7 +285,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorBreaking() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
 
@@ -294,7 +294,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorNewFeature() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
 
@@ -303,7 +303,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorBug() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
 
@@ -313,7 +313,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorMiscellaneous() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
 
@@ -323,7 +323,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorNewModule() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
 
@@ -332,7 +332,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorBugAndMiscellaneous() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null,
                 createAllNotes(), createAllNotes(), null), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
@@ -343,7 +343,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesMinorNewModuleNewFeatureAndBreaking() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(createAllNotes(), createAllNotes(),
                 null, null, createAllNotes()), createBaseCliOptions("1.0")
                 .setValidateVersion(true).build());
@@ -353,7 +353,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchNoNotes() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, null, null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
@@ -362,7 +362,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchBreaking() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
@@ -372,7 +372,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchNewFeature() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
@@ -382,7 +382,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchBug() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
@@ -391,7 +391,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchMiscellaneous() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
@@ -400,7 +400,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchNewModule() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
@@ -410,7 +410,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchNewFeatureNewModuleAndBreaking() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(createAllNotes(), createAllNotes(),
                 null, null, createAllNotes()), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
@@ -421,7 +421,7 @@ public class TemplateProcessorTest {
 
     @Test
     public void testValidateNotesPatchBugAndMiscellaneous() throws Exception {
-        final List<String> errors = MainProcess.runPostGenerationAndPublication(
+        final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null,
                 createAllNotes(), createAllNotes(), null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());


### PR DESCRIPTION
Resolves bugs in  #670. Was not sure how to name this commit, so let me know what to rename it to.
Here is the output:
``` 
$ export READ_ONLY_TOKEN=xxx && export DRONE_PULL_REQUEST="master" && ./.ci/releasenotes-gen.sh
```
```
...
HEAD is now at 721550316 Issue #12319: validate PR number when commit is for PR
From https://github.com/checkstyle/checkstyle
 * branch                master     -> FETCH_HEAD
Already up to date.
LATEST_RELEASE_TAG=checkstyle-10.3.4
CS_RELEASE_VERSION=10.3.5
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

[WARN] Issue #12243 "Pitest/Checker: Drop New/Unnecessary Displays And Switch to Git Diff" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/12243
[WARN] Issue #11214 "Specify violation messages in input files." is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/11214

Validation of release number failed. Release number is a patch(10.3.5), but release notes contain 'new' or 'breaking compatability' labels. Please correct release number by running https://github.com/checkstyle/checkstyle/actions/workflows/bump-version-and-update-milestone.yml

Generation ends with 1 errors.

```