### PR TITLE
Issue #364: releasenotes-builder: avoid extra line wrapping

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
@@ -19,6 +19,8 @@
 
 package com.github.checkstyle.globals;
 
+import java.util.Collections;
+
 import org.kohsuke.github.GHIssue;
 
 /**
@@ -29,10 +31,17 @@ import org.kohsuke.github.GHIssue;
 public final class ReleaseNotesMessage {
 
     /** Max size of line. */
-    private static final int MAX_TITLE_LINE_SIZE = 70;
+    private static final int MAX_TITLE_LINE_SIZE = 100;
 
     /** Converted size of html character. */
     private static final int HTML_CHAR_SIZE = 5;
+
+    /** Amount of whitespace characters preceding the title. */
+    private static final int TITLE_INDENTATION = 12;
+
+    /** Twelve spaces. */
+    private static final String TWELVE_SPACES = String.join(
+        "", Collections.nCopies(TITLE_INDENTATION, " "));
 
     /** Issue number. */
     private final int issueNo;
@@ -131,7 +140,8 @@ public final class ReleaseNotesMessage {
      */
     // -@cs[CyclomaticComplexity|ExecutableStatementCount] Can't be split apart easily.
     private static String split(String str) {
-        final int length = str.length();
+        final String indentedStr = TWELVE_SPACES + str;
+        final int length = indentedStr.length();
         final StringBuilder sb = new StringBuilder(length);
         int index = 0;
         int splitStart = index;
@@ -140,7 +150,7 @@ public final class ReleaseNotesMessage {
         int lastSpaceOutPosition = -1;
 
         while (index < length) {
-            final char ch = str.charAt(index);
+            final char ch = indentedStr.charAt(index);
             final int charSize;
 
             if (ch == '>' || ch == '<' || ch == '&' || ch == '\'' || ch == '"') {
@@ -154,19 +164,20 @@ public final class ReleaseNotesMessage {
 
             if (outPosition > MAX_TITLE_LINE_SIZE) {
                 if (lastSpacePosition == -1) {
-                    sb.append(str, splitStart, index - 1);
+                    sb.append(indentedStr, splitStart, index - 1);
                     sb.append("-");
 
                     splitStart = index - 1;
                     outPosition = 0;
                 }
                 else {
-                    sb.append(str, splitStart, lastSpacePosition);
+                    sb.append(indentedStr, splitStart, lastSpacePosition);
                     splitStart = lastSpacePosition + 1;
-                    outPosition -= lastSpaceOutPosition;
+                    outPosition -= lastSpaceOutPosition - TITLE_INDENTATION;
                 }
 
                 sb.append(System.lineSeparator());
+                sb.append(TWELVE_SPACES);
                 lastSpacePosition = -1;
                 lastSpaceOutPosition = -1;
             }
@@ -184,7 +195,7 @@ public final class ReleaseNotesMessage {
         }
 
         if (splitStart != index) {
-            sb.append(str.substring(splitStart));
+            sb.append(indentedStr.substring(splitStart));
         }
 
         return sb.toString();

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -438,7 +438,12 @@ public class TemplateProcessorTest {
             createReleaseNotesMessage(123, "Mock issue title 5 ==> test", "Author 6, Author 7"),
             createReleaseNotesMessage("Mock issue title 6 L12345678901234567890123456789012345678"
                 + "90123456789012345678901234567890oooooooooooooooooooooooooooooooooooooooooooooo"
-                + "ooong'\"", "Author 1"));
+                + "ooong'\"", "Author 1"),
+            createReleaseNotesMessage("Mock issue title 7 thisIssueTitleIsExactly87Characters"
+                + "LongAndThenYouThe13ChrIndentation", "Author 10"),
+            createReleaseNotesMessage("Mock issue title 8 thisIssueTitleIsExactly100Characters"
+                + "LongAndWeExpectItToGetWrappedDueToBeingTooLng", "Author 11"));
+
     }
 
     private Builder createBaseCliOptions() {

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
@@ -8,6 +8,8 @@ Breaking backward compatibility:
   #123 - Mock issue title 4
   #123 - Mock issue title 5 ==> test
   #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+  #-1 - Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
+  #-1 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
@@ -10,4 +10,6 @@ Bug fixes:
   #123 - Mock issue title 4
   #123 - Mock issue title 5 ==> test
   #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+  #-1 - Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
+  #-1 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
@@ -9,5 +9,7 @@ New:
   #123 - Mock issue title 4
   #123 - Mock issue title 5 ==> test
   #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+  #-1 - Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
+  #-1 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBreakingCompatibility.txt
@@ -8,6 +8,8 @@ Breaking backward compatibility:
   Mock issue title 4
   Mock issue title 5 ==> test
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+  Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
+  Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBug.txt
@@ -10,4 +10,6 @@ Bug fixes:
   Mock issue title 4
   Mock issue title 5 ==> test
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+  Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
+  Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistMisc.txt
@@ -11,3 +11,5 @@ Notes:
   Mock issue title 4
   Mock issue title 5 ==> test
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+  Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
+  Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistNew.txt
@@ -9,5 +9,7 @@ New:
   Mock issue title 4
   Mock issue title 5 ==> test
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
+  Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
+  Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
@@ -1,2 +1,2 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
-Breaking backward compatibility: 6
+Breaking backward compatibility: 8

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
 
-Bug fixes: 6
+Bug fixes: 8

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
 
-New functionality: 6
+New functionality: 8

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
@@ -28,9 +28,18 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+            L1234567890123456789012345678901234567890123456789012345678901234567890oooooooooooooooo-
+            ooooooooooooooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
+          </li>
+          <li>
+            Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation.
+            Author: Author 10
+          </li>
+          <li>
+            Mock issue title 8
+            thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
+            Author: Author 11
           </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -28,9 +28,18 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+            L1234567890123456789012345678901234567890123456789012345678901234567890oooooooooooooooo-
+            ooooooooooooooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
+          </li>
+          <li>
+            Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation.
+            Author: Author 10
+          </li>
+          <li>
+            Mock issue title 8
+            thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
+            Author: Author 11
           </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -28,9 +28,18 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+            L1234567890123456789012345678901234567890123456789012345678901234567890oooooooooooooooo-
+            ooooooooooooooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
+          </li>
+          <li>
+            Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation.
+            Author: Author 10
+          </li>
+          <li>
+            Mock issue title 8
+            thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
+            Author: Author 11
           </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
@@ -28,9 +28,18 @@
           </li>
           <li>
             Mock issue title 6
-L12345678901234567890123456789012345678901234567890123456789012345678-
-90ooooooooooooooooooooooooooooooooooooooooooooooooong&#39;&quot;.
+            L1234567890123456789012345678901234567890123456789012345678901234567890oooooooooooooooo-
+            ooooooooooooooooooooooooooooooooong&#39;&quot;.
             Author: Author 1
+          </li>
+          <li>
+            Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation.
+            Author: Author 10
+          </li>
+          <li>
+            Mock issue title 8
+            thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
+            Author: Author 11
           </li>
         </ul>
     </section>


### PR DESCRIPTION
Resolves #364