### PR TITLE
infra: pin patch version of openjdk base image

### DIFF
--- a/devops/docker/README.md
+++ b/devops/docker/README.md
@@ -1,0 +1,40 @@
+## Docker Image Release Workflow
+
+To login to dockerhub:
+```bash
+docker login
+```
+
+To build image:
+```bash
+docker build -t <org>/<image-name>:<version> .
+```
+
+Where `version` is <jdk-version>-<package-version>.
+
+Example:
+```bash
+docker build -t checkstyle/idea-docker:jdk11-idea2022.2.2 .
+```
+
+To push a new tag:
+```bash
+docker push <org>/<image-name>:<version>
+```
+
+Example:
+```bash
+docker push checkstyle/idea-docker:jdk11-idea2022.2.2
+```
+
+## Running Container on Local
+
+To run in interactive mode:
+```bash
+docker run -it <org>/<image-name>:<version> /bin/bash
+```
+
+To access and run commands in the running container:
+```bash
+docker exec –it <container_id> /bin/bash
+```

--- a/devops/docker/idea-image/Dockerfile
+++ b/devops/docker/idea-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/openjdk:11.0
+FROM cimg/openjdk:11.0.16
 
 RUN sudo apt update && sudo apt install -y wget
 


### PR DESCRIPTION
*Should* fix failure at https://app.circleci.com/pipelines/github/checkstyle/checkstyle/15829/workflows/6457dceb-0274-4045-9593-b6ae93660de6/jobs/191927, there have been issues reported with newest cimg/openjdk