### PR TITLE
Issue #652: releasenotes-builder: Release notes for GitHub shows escape at-symbol

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/globals/ReleaseNotesMessage.java
@@ -49,6 +49,8 @@ public final class ReleaseNotesMessage {
     private final String title;
     /** Short Width Title. */
     private final String shortWidthTitle;
+    /** Title with escaped GitHub characters. */
+    private final String githubEscapedTitle;
     /** Author. */
     private final String author;
 
@@ -62,6 +64,7 @@ public final class ReleaseNotesMessage {
         issueNo = issue.getNumber();
         title = getActualTitle(issue);
         shortWidthTitle = split(title);
+        githubEscapedTitle = escapeGithubCharacters(title);
         this.author = author;
     }
 
@@ -75,6 +78,7 @@ public final class ReleaseNotesMessage {
         issueNo = -1;
         this.title = title;
         shortWidthTitle = split(title);
+        githubEscapedTitle = escapeGithubCharacters(title);
         this.author = author;
     }
 
@@ -94,6 +98,15 @@ public final class ReleaseNotesMessage {
      */
     public String getTitle() {
         return title;
+    }
+
+    /**
+     * Returns the GitHub escaped title.
+     *
+     * @return the GitHub escaped title.
+     */
+    public String getGithubEscapedTitle() {
+        return githubEscapedTitle;
     }
 
     /**
@@ -199,5 +212,15 @@ public final class ReleaseNotesMessage {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Escapes GitHub characters by placing them inside code block.
+     *
+     * @param str string to escape.
+     * @return escaped string.
+     */
+    private static String escapeGithubCharacters(String str) {
+        return str.replaceAll("(@|<|>|&)", "`$1`");
     }
 }

--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/github_post.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/github_post.template
@@ -4,7 +4,7 @@ Checkstyle ${releaseNo} - https://checkstyle.org/releasenotes.html#Release_${rel
 Breaking backward compatibility:
 
 <#list breakingMessages as message>
-  #${message.issueNo} - ${message.title}
+  #${message.issueNo} - ${message.githubEscapedTitle}
 </#list>
 </#if>
 
@@ -12,7 +12,7 @@ Breaking backward compatibility:
 New:
 
 <#list newMessages as message>
-  #${message.issueNo} - ${message.title}
+  #${message.issueNo} - ${message.githubEscapedTitle}
 </#list>
 </#if>
 
@@ -20,7 +20,7 @@ New:
 Bug fixes:
 
 <#list bugMessages as message>
-  #${message.issueNo} - ${message.title}
+  #${message.issueNo} - ${message.githubEscapedTitle}
 </#list>
 </#if>
 
@@ -29,7 +29,7 @@ Bug fixes:
 <summary>Other Changes:</summary>
 <br/>
 <#list notesMessages as message>
-  ${message.title} <br/>
+  ${message.githubEscapedTitle} <br/>
 </#list>
 </details>
 </#if>

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -442,8 +442,9 @@ public class TemplateProcessorTest {
             createReleaseNotesMessage("Mock issue title 7 thisIssueTitleIsExactly87Characters"
                 + "LongAndThenYouThe13ChrIndentation", "Author 10"),
             createReleaseNotesMessage("Mock issue title 8 thisIssueTitleIsExactly100Characters"
-                + "LongAndWeExpectItToGetWrappedDueToBeingTooLng", "Author 11"));
-
+                + "LongAndWeExpectItToGetWrappedDueToBeingTooLng", "Author 11"),
+            createReleaseNotesMessage("Mock issue title 9 escape @ and @@@@@", "Author 12"),
+            createReleaseNotesMessage("Mock issue title 10 escape < > & <&<>&<<", "Author 13"));
     }
 
     private Builder createBaseCliOptions() {

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
@@ -6,10 +6,12 @@ Breaking backward compatibility:
   #-1 - Mock issue title 2
   #123 - Mock issue title 3
   #123 - Mock issue title 4
-  #123 - Mock issue title 5 ==> test
+  #123 - Mock issue title 5 ==`>` test
   #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
   #-1 - Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
   #-1 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
+  #-1 - Mock issue title 9 escape `@` and `@``@``@``@``@`
+  #-1 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
@@ -8,8 +8,10 @@ Bug fixes:
   #-1 - Mock issue title 2
   #123 - Mock issue title 3
   #123 - Mock issue title 4
-  #123 - Mock issue title 5 ==> test
+  #123 - Mock issue title 5 ==`>` test
   #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
   #-1 - Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
   #-1 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
+  #-1 - Mock issue title 9 escape `@` and `@``@``@``@``@`
+  #-1 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
@@ -7,9 +7,11 @@ New:
   #-1 - Mock issue title 2
   #123 - Mock issue title 3
   #123 - Mock issue title 4
-  #123 - Mock issue title 5 ==> test
+  #123 - Mock issue title 5 ==`>` test
   #-1 - Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
   #-1 - Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
   #-1 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
+  #-1 - Mock issue title 9 escape `@` and `@``@``@``@``@`
+  #-1 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBreakingCompatibility.txt
@@ -10,6 +10,8 @@ Breaking backward compatibility:
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
   Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
   Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
+  Mock issue title 9 escape @ and @@@@@
+  Mock issue title 10 escape < > & <&<>&<<
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBug.txt
@@ -12,4 +12,6 @@ Bug fixes:
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
   Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
   Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
+  Mock issue title 9 escape @ and @@@@@
+  Mock issue title 10 escape < > & <&<>&<<
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistMisc.txt
@@ -13,3 +13,5 @@ Notes:
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
   Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
   Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
+  Mock issue title 9 escape @ and @@@@@
+  Mock issue title 10 escape < > & <&<>&<<

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistNew.txt
@@ -11,5 +11,7 @@ New:
   Mock issue title 6 L1234567890123456789012345678901234567890123456789012345678901234567890ooooooooooooooooooooooooooooooooooooooooooooooooong'"
   Mock issue title 7 thisIssueTitleIsExactly87CharactersLongAndThenYouThe13ChrIndentation
   Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
+  Mock issue title 9 escape @ and @@@@@
+  Mock issue title 10 escape < > & <&<>&<<
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
@@ -1,2 +1,2 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
-Breaking backward compatibility: 8
+Breaking backward compatibility: 10

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
 
-Bug fixes: 8
+Bug fixes: 10

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
 
-New functionality: 8
+New functionality: 10

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
@@ -41,5 +41,13 @@
             thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
             Author: Author 11
           </li>
+          <li>
+            Mock issue title 9 escape @ and @@@@@.
+            Author: Author 12
+          </li>
+          <li>
+            Mock issue title 10 escape &lt; &gt; &amp; &lt;&amp;&lt;&gt;&amp;&lt;&lt;.
+            Author: Author 13
+          </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -41,5 +41,13 @@
             thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
             Author: Author 11
           </li>
+          <li>
+            Mock issue title 9 escape @ and @@@@@.
+            Author: Author 12
+          </li>
+          <li>
+            Mock issue title 10 escape &lt; &gt; &amp; &lt;&amp;&lt;&gt;&amp;&lt;&lt;.
+            Author: Author 13
+          </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -41,5 +41,13 @@
             thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
             Author: Author 11
           </li>
+          <li>
+            Mock issue title 9 escape @ and @@@@@.
+            Author: Author 12
+          </li>
+          <li>
+            Mock issue title 10 escape &lt; &gt; &amp; &lt;&amp;&lt;&gt;&amp;&lt;&lt;.
+            Author: Author 13
+          </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
@@ -41,5 +41,13 @@
             thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng.
             Author: Author 11
           </li>
+          <li>
+            Mock issue title 9 escape @ and @@@@@.
+            Author: Author 12
+          </li>
+          <li>
+            Mock issue title 10 escape &lt; &gt; &amp; &lt;&amp;&lt;&gt;&amp;&lt;&lt;.
+            Author: Author 13
+          </li>
         </ul>
     </section>


### PR DESCRIPTION
Resolves #652
