### PR TITLE
Release notes mock test

### DIFF
--- a/releasenotes-builder/config/import-control.xml
+++ b/releasenotes-builder/config/import-control.xml
@@ -22,10 +22,16 @@
     <allow class="com.google.common.base.Verify"/>
   </file>
 
-  <subpackage name="github">
+  <subpackage name="git">
     <allow class="com.google.common.base.Verify"/>
     <allow class="com.google.common.collect.Sets"/>
     <allow pkg="org.eclipse.jgit"/>
+  </subpackage>
+
+  <subpackage name="github">
+    <allow class="com.github.checkstyle.git.CsGit"/>
+    <allow pkg="org.eclipse.jgit.api.errors"/>
+    <allow pkg="org.eclipse.jgit.revwalk"/>
     <allow pkg="org.kohsuke.github"/>
   </subpackage>
 

--- a/releasenotes-builder/config/suppressions.xml
+++ b/releasenotes-builder/config/suppressions.xml
@@ -17,6 +17,8 @@
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
+    <suppress checks="AnonInnerLength" files=".*[\\/]src[\\/]test[\\/]"/>
+    <suppress checks="IllegalCatch" files=".*[\\/]src[\\/]test[\\/]"/>
 
     <suppress id="ImportControlMain" message=".* - java\.time\..*"/>
 

--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -26,6 +26,7 @@
         <checkstyle.version>10.5.0</checkstyle.version>
         <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
         <junit.version>4.13.2</junit.version>
+        <mockito.version>4.9.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -78,6 +79,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -20,6 +20,9 @@
 package com.github.checkstyle;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -207,12 +210,14 @@ public final class MainProcess {
      * @param errors list of publication errors.
      */
     private static void runTwitterPublication(CliOptions cliOptions, List<String> errors) {
-        final TwitterPublisher twitterPublisher = new TwitterPublisher(
-            cliOptions.getOutputLocation() + TWITTER_FILENAME,
-            cliOptions.getTwitterConsumerKey(), cliOptions.getTwitterConsumerSecret(),
-            cliOptions.getTwitterAccessToken(), cliOptions.getTwitterAccessTokenSecret());
         try {
-            twitterPublisher.publish();
+            final String post = Files.readString(
+                    Paths.get(cliOptions.getOutputLocation() + TWITTER_FILENAME),
+                    StandardCharsets.UTF_8);
+
+            TwitterPublisher.publish(cliOptions.getTwitterConsumerKey(),
+                    cliOptions.getTwitterConsumerSecret(), cliOptions.getTwitterAccessToken(),
+                    cliOptions.getTwitterAccessTokenSecret(), post);
         }
         // -@cs[IllegalCatch] We should execute all publishers, so cannot fail-fast
         catch (Exception ex) {

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/git/CsGit.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/git/CsGit.java
@@ -1,0 +1,97 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.git;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+import com.google.common.base.Verify;
+import com.google.common.collect.Sets;
+
+/**
+ * Class for Checkstyle's Git connection.
+ */
+public final class CsGit {
+    /** Private constructor. */
+    private CsGit() {
+    }
+
+    /**
+     * Returns a list of commits between two references.
+     *
+     * @param repoPath path to local git repository.
+     * @param startRef start reference.
+     * @param endRef end reference.
+     * @return a list of commits.
+     * @throws IOException if I/O error occurs.
+     * @throws GitAPIException if an error occurs when accessing Git API.
+     */
+    public static Set<RevCommit> getCommitsBetweenReferences(String repoPath, String startRef,
+            String endRef) throws IOException, GitAPIException {
+
+        final FileRepositoryBuilder builder = new FileRepositoryBuilder();
+        final Path path = Paths.get(repoPath);
+        final Repository repo = builder.findGitDir(path.toFile()).readEnvironment().build();
+
+        final ObjectId startCommit = getActualRefObjectId(repo, startRef);
+        Verify.verifyNotNull(startCommit, "Start reference \"" + startRef + "\" is invalid!");
+
+        final ObjectId endCommit = getActualRefObjectId(repo, endRef);
+        try (Git git = new Git(repo)) {
+            final Iterable<RevCommit> commits =
+                git.log().addRange(startCommit, endCommit).call();
+
+            return Sets.newLinkedHashSet(commits);
+        }
+    }
+
+    /**
+     * Returns actual SHA-1 object by commit reference.
+     *
+     * @param repo git repository.
+     * @param ref string representation of commit reference.
+     * @return actual SHA-1 object.
+     * @throws IOException if an I/O error occurs.
+     */
+    private static ObjectId getActualRefObjectId(Repository repo, String ref) throws IOException {
+        final ObjectId actualObjectId;
+        final Ref referenceObj = repo.findRef(ref);
+        if (referenceObj == null) {
+            actualObjectId = repo.resolve(ref);
+        }
+        else {
+            final Ref repoPeeled = repo.getRefDatabase().peel(referenceObj);
+            actualObjectId = Optional.ofNullable(repoPeeled.getPeeledObjectId())
+                .orElse(referenceObj.getObjectId());
+        }
+        return actualObjectId;
+    }
+}

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/git/package-info.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/git/package-info.java
@@ -17,36 +17,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-package com.github.checkstyle.publishers;
-
-import twitter4j.Twitter;
-import twitter4j.TwitterException;
-
 /**
- * Class for Twitter post publication.
- *
- * @author Vladislav Lisetskii
+ * Contains classes for accessing Git repo.
  */
-public final class TwitterPublisher {
-
-    /** Private constructor. */
-    private TwitterPublisher() {
-    }
-
-    /**
-     * Publish post.
-     *
-     * @param consumerKey consumer key.
-     * @param consumerSecret consumer secret.
-     * @param accessToken access token.
-     * @param accessTokenSecret access token secret.
-     * @param post the exact post to publish.
-     * @throws TwitterException if an error occurs while publishing.
-     */
-    public static void publish(String consumerKey, String consumerSecret,
-            String accessToken, String accessTokenSecret, String post) throws TwitterException {
-        final Twitter twitter = Twitter.newBuilder().oAuthConsumer(consumerKey, consumerSecret)
-            .oAuthAccessToken(accessToken, accessTokenSecret).build();
-        twitter.v1().tweets().updateStatus(post);
-    }
-}
+package com.github.checkstyle.git;

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/CsGitHub.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/CsGitHub.java
@@ -1,0 +1,55 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.github;
+
+import java.io.IOException;
+
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+/**
+ * Class for Checkstyle's GitHub connection.
+ */
+public final class CsGitHub {
+    /** Private constructor. */
+    private CsGitHub() {
+    }
+
+    /**
+     * Creates the connection to the remote repository.
+     *
+     * @param authToken the authorization token.
+     * @param remoteRepoPath path to remote git repository.
+     * @return the remote repository object.
+     * @throws IOException if an I/O error occurs.
+     */
+    public static GHRepository createRemoteRepo(String authToken, String remoteRepoPath)
+            throws IOException {
+        final GitHub connection;
+        if (authToken == null) {
+            connection = GitHub.connectAnonymously();
+        }
+        else {
+            connection = GitHub.connectUsingOAuth(authToken);
+        }
+
+        return connection.getRepository(remoteRepoPath);
+    }
+}

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
@@ -1,0 +1,226 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle;
+
+import static org.junit.Assert.fail;
+import static org.kohsuke.github.GHIssueState.OPEN;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.kohsuke.github.GHFileNotFoundException;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHRepository;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.github.checkstyle.git.CsGit;
+import com.github.checkstyle.github.CsGitHub;
+import com.github.checkstyle.globals.Constants;
+import com.github.checkstyle.internal.GhIssueUtil;
+import com.github.checkstyle.internal.RevCommitUtil;
+import com.github.checkstyle.publishers.TwitterPublisher;
+
+public class MainTest {
+    private static final String MISC = Constants.MISCELLANEOUS_LABEL;
+
+    private static final Set<RevCommit> TEST_COMMITS = new HashSet<>();
+
+    private static final Set<GHIssue> TEST_ISSUES = new HashSet<>();
+
+    private static final Answer<GHIssue> ISSUE_ANSWER = new Answer<GHIssue>() {
+        @Override
+        public GHIssue answer(InvocationOnMock invocation) throws Throwable {
+            final int findIssue = invocation.getArgument(0);
+
+            for (GHIssue item : TEST_ISSUES) {
+                if (item.getNumber() == findIssue) {
+                    return item;
+                }
+            }
+
+            throw new GHFileNotFoundException("Cannot find Issue: " + findIssue);
+        }
+    };
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        // GHRepository
+        final GHRepository mockGhRepository = mock(GHRepository.class);
+        when(mockGhRepository.getIssue(anyInt())).then(ISSUE_ANSWER);
+        // CsGitHub static
+        final MockedStatic<CsGitHub> mockCsGitHubStatic = mockStatic(CsGitHub.class);
+        mockCsGitHubStatic.when(() -> CsGitHub.createRemoteRepo(anyString(), anyString()))
+                .thenReturn(mockGhRepository);
+        // CsGit static
+        final MockedStatic<CsGit> mockCsGitStatic = mockStatic(CsGit.class);
+        mockCsGitStatic.when(
+                () -> CsGit.getCommitsBetweenReferences(anyString(), anyString(), anyString()))
+                .thenReturn(TEST_COMMITS);
+
+        // TwitterPublisher static
+        mockStatic(TwitterPublisher.class);
+    }
+
+    @Before
+    public void reset() {
+        TEST_COMMITS.clear();
+    }
+
+    @Test
+    public void testValidateVersion() {
+        runMainAndAssertReturnCode(0,
+                "-releaseNumber", "10.0.1",
+                "-validateVersion"
+        );
+    }
+
+    @Test
+    public void testNoCommits() throws Exception {
+        runMainAndAssertReturnCode(0,
+                "-localRepoPath", temporaryFolder.newFolder().getAbsolutePath(),
+                "-remoteRepoPath", "checkstyle/checkstyle",
+                "-startRef", "12345678",
+                "-releaseNumber", "10.0.1",
+                "-outputLocation", temporaryFolder.newFolder().getAbsolutePath(),
+                "-githubAuthToken", "TOKEN",
+                "-generateAll",
+                "-publishTwit",
+                "-twitterConsumerKey", "KEY",
+                "-twitterConsumerSecret", "SECRET",
+                "-twitterAccessToken", "TOKEN",
+                "-twitterAccessTokenSecret", "SECRET",
+                "-validateVersion"
+        );
+    }
+
+    @Test
+    public void testUnknownCommit() throws Exception {
+        TEST_COMMITS.add(RevCommitUtil.create("Hello World"));
+
+        runMainAndAssertReturnCode(0,
+                "-localRepoPath", temporaryFolder.newFolder().getAbsolutePath(),
+                "-remoteRepoPath", "checkstyle/checkstyle",
+                "-startRef", "12345678",
+                "-releaseNumber", "10.0.1",
+                "-outputLocation", temporaryFolder.newFolder().getAbsolutePath(),
+                "-githubAuthToken", "TOKEN",
+                "-generateAll",
+                "-publishTwit",
+                "-twitterConsumerKey", "KEY",
+                "-twitterConsumerSecret", "SECRET",
+                "-twitterAccessToken", "TOKEN",
+                "-twitterAccessTokenSecret", "SECRET",
+                "-validateVersion"
+        );
+    }
+
+    @Test
+    public void testIssueCommitWithIssueNotFound() throws IOException {
+        TEST_COMMITS.add(RevCommitUtil.create("Issue #1: Hello World"));
+
+        runMainAndAssertReturnCode(-2,
+                "-localRepoPath", temporaryFolder.newFolder().getAbsolutePath(),
+                "-remoteRepoPath", "checkstyle/checkstyle",
+                "-startRef", "12345678",
+                "-releaseNumber", "10.0.1",
+                "-outputLocation", temporaryFolder.newFolder().getAbsolutePath(),
+                "-githubAuthToken", "TOKEN",
+                "-generateAll",
+                "-publishTwit",
+                "-twitterConsumerKey", "KEY",
+                "-twitterConsumerSecret", "SECRET",
+                "-twitterAccessToken", "TOKEN",
+                "-twitterAccessTokenSecret", "SECRET",
+                "-validateVersion"
+        );
+    }
+
+    @Test
+    public void testIssueCommit() throws Exception {
+        TEST_COMMITS.add(RevCommitUtil.create("Issue #1: Hello World"));
+        TEST_ISSUES.add(GhIssueUtil.create(1, OPEN, "Hello World", MISC));
+
+        runMainAndAssertReturnCode(0,
+                "-localRepoPath", temporaryFolder.newFolder().getAbsolutePath(),
+                "-remoteRepoPath", "checkstyle/checkstyle",
+                "-startRef", "12345678",
+                "-releaseNumber", "10.0.1",
+                "-outputLocation", temporaryFolder.newFolder().getAbsolutePath(),
+                "-githubAuthToken", "TOKEN",
+                "-generateAll",
+                "-publishTwit",
+                "-twitterConsumerKey", "KEY",
+                "-twitterConsumerSecret", "SECRET",
+                "-twitterAccessToken", "TOKEN",
+                "-twitterAccessTokenSecret", "SECRET",
+                "-validateVersion"
+        );
+    }
+
+    /**
+     * Helper method to run {@link Main#main(String...)} and verify the exit code.
+     * Uses {@link Mockito#mockStatic(Class)} to mock method {@link Runtime#exit(int)}
+     * to avoid VM termination.
+     *
+     * @param expectedExitCode the expected exit code to verify
+     * @param arguments the command line arguments
+     * @noinspection CallToSystemExit, ResultOfMethodCallIgnored
+     * @noinspectionreason CallToSystemExit - test helper method requires workaround to
+     *      verify exit code
+     * @noinspectionreason ResultOfMethodCallIgnored - temporary suppression until #11589
+     */
+    private static void runMainAndAssertReturnCode(int expectedExitCode, String... arguments) {
+        final Runtime mock = mock(Runtime.class);
+        try (MockedStatic<Runtime> runtime = mockStatic(Runtime.class)) {
+            runtime.when(Runtime::getRuntime)
+                    .thenReturn(mock);
+            Main.main(arguments);
+        }
+        catch (Exception exception) {
+            fail(String.format("Unexpected exception: %s", exception));
+        }
+        if (expectedExitCode == 0) {
+            verify(mock, never()).exit(expectedExitCode);
+        }
+        else {
+            verify(mock).exit(expectedExitCode);
+        }
+    }
+}

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/internal/GhIssueUtil.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/internal/GhIssueUtil.java
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.internal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHLabel;
+
+public final class GhIssueUtil {
+    private GhIssueUtil() {
+    }
+
+    public static GHIssue create(int ghNumber, GHIssueState ghState, String ghTitle,
+            String... labels) {
+        final List<GHLabel> ghLabels = new ArrayList<>();
+
+        for (String label : labels) {
+            final GHLabel mockGhLabel = mock(GHLabel.class);
+            when(mockGhLabel.getName()).thenReturn(label);
+
+            ghLabels.add(mockGhLabel);
+        }
+
+        return new GHIssue() {
+            @Override
+            public int getNumber() {
+                return ghNumber;
+            }
+
+            @Override
+            public GHIssueState getState() {
+                return ghState;
+            }
+
+            @Override
+            public String getTitle() {
+                return ghTitle;
+            }
+
+            @Override
+            public Collection<GHLabel> getLabels() {
+                return ghLabels;
+            }
+        };
+    }
+}

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/internal/RevCommitUtil.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/internal/RevCommitUtil.java
@@ -1,0 +1,49 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.internal;
+
+import java.util.Date;
+import java.util.Random;
+
+import org.eclipse.jgit.revwalk.RevCommit;
+
+public final class RevCommitUtil {
+    private static final Random RANDOM = new Random();
+
+    private RevCommitUtil() {
+    }
+
+    public static RevCommit create(String commitMessage) {
+        return create("CheckstyleUser", commitMessage);
+    }
+
+    public static RevCommit create(String author, String commitMessage) {
+        final String commitData = String.format("tree %040x\n"
+            + "parent %040x\n"
+            + "author " + author + " <test@email.com> %d +0100\n"
+            + "committer " + author + " <test@email.com> %d +0100\n\n"
+            + commitMessage,
+                RANDOM.nextLong(),
+                RANDOM.nextLong(),
+                new Date().getTime(),
+                new Date().getTime());
+        return RevCommit.parse(commitData.getBytes());
+    }
+}


### PR DESCRIPTION
This is what brought the PR https://github.com/checkstyle/contribution/pull/703 . Alternate idea for https://github.com/checkstyle/contribution/issues/327#issuecomment-1326900135 .

This PR is not expected to pass CI yet, but it is a working example. This draft PR is looking for approval as being the future method for testing in this project.

Including @stoyanK7 .

This is rough example executing Main in a test with successful completion. No commits are returned, no errors produced. We can take this and make common test methods where we return specific commits, and can expand on other things like publishing failures (by throwing exceptions), and eventually test all aspects of our code.

Any API calls like Git, GitHub, Twitter, etc... are separated from the main logic and mocked to not really execute, but return results for our logic processing. They basically will not execute and we skip over them completely since they are isolated into their own world.

~Besides more clean up is needed, I believe more of GitHub needs to be mocked like issue labels and~ we should be capturing output.