### PR TITLE
Issue #701: releasenotes builder: release version validation should work on digits

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -102,7 +102,6 @@ public final class MainProcess {
     public static List<String> validateNotes(Multimap<String, ReleaseNotesMessage> releaseNotes,
                                               CliOptions cliOptions) {
         final String releaseVersion = cliOptions.getReleaseNumber();
-        final long amountOfCommas = getAmountOfCommasInReleaseVersion(releaseVersion);
         final boolean containsNewOrBreakingCompatabilityLabel =
             releaseNotes.containsKey(Constants.NEW_FEATURE_LABEL)
                 || releaseNotes.containsKey(Constants.NEW_MODULE_LABEL)
@@ -113,14 +112,14 @@ public final class MainProcess {
         final String errorEnding = "Please correct release number by running https://github.com/"
             + "checkstyle/checkstyle/actions/workflows/bump-version-and-update-milestone.yml";
 
-        if (isPatch(amountOfCommas) && containsNewOrBreakingCompatabilityLabel) {
+        if (isPatch(releaseVersion) && containsNewOrBreakingCompatabilityLabel) {
             errors.add(
                 String.format("%s Release number is a patch(%s), but release notes contain 'new' "
                         + "or 'breaking compatability' labels. %s",
                     errorBeginning, releaseVersion, errorEnding)
             );
         }
-        else if (isMinor(amountOfCommas) && !containsNewOrBreakingCompatabilityLabel) {
+        else if (isMinor(releaseVersion) && !containsNewOrBreakingCompatabilityLabel) {
             errors.add(
                 String.format("%s Release number is minor(%s), but release notes do not contain "
                     + "'new' or 'breaking compatability' labels. %s",
@@ -132,36 +131,35 @@ public final class MainProcess {
     }
 
     /**
-     * Retrieves the amount of commas in the release version. For instance,
-     * 10.3.3 would return {@code 2}.
+     * Check if a release version is minor. A release version is minor when
+     * it ends with a zero(0), for example 10.4.0.
      *
-     * @param releaseVersion release number in the command line interface.
-     * @return amount of commas in release version.
+     * @param releaseVersion checkstyle release version.
+     * @return {@code true} if release version is minor.
      */
-    private static long getAmountOfCommasInReleaseVersion(String releaseVersion) {
-        return releaseVersion.chars().filter(character -> character == '.').count();
+    private static boolean isMinor(String releaseVersion) {
+        return endsWithZero(releaseVersion);
     }
 
     /**
-     * Returns {@code true} if amount of commas is 2. This means
-     * the release is a patch.
+     * Check if a release version is minor. A release version is minor when
+     * it ends with any other digit but a zero(0), for example 10.4.1.
      *
-     * @param amountOfCommas amount of commas in release number.
-     * @return {@code true} if amount of commas is 2.
+     * @param releaseVersion checkstyle release version.
+     * @return {@code true} if release version is patch.
      */
-    private static boolean isPatch(long amountOfCommas) {
-        return amountOfCommas == 2;
+    private static boolean isPatch(String releaseVersion) {
+        return !endsWithZero(releaseVersion);
     }
 
     /**
-     * Returns {@code true} if amount of commas is 1. This means
-     * the release is minor.
+     * Check if provided string ends with a zero(0).
      *
-     * @param amountOfCommas amount of commas in release number.
-     * @return {@code true} if amount of commas is 1.
+     * @param str string to check.
+     * @return {@code true} if string to check ends with a zero(0).
      */
-    private static boolean isMinor(long amountOfCommas) {
-        return amountOfCommas == 1;
+    private static boolean endsWithZero(String str) {
+        return !str.isEmpty() && str.charAt(str.length() - 1) == '0';
     }
 
     /**

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -52,12 +52,12 @@ import com.google.common.collect.Multimap;
 public class TemplateProcessorTest {
 
     private static final String MSG_RELEASE_IS_MINOR =
-        "[ERROR] Validation of release number failed. Release number is minor(1.0), but "
+        "[ERROR] Validation of release number failed. Release number is minor(1.0.0), but "
             + "release notes do not contain 'new' or 'breaking compatability' labels. Please "
             + "correct release number by running https://github.com/checkstyle/checkstyle/"
             + "actions/workflows/bump-version-and-update-milestone.yml";
     private static final String MSG_RELEASE_IS_PATCH =
-        "[ERROR] Validation of release number failed. Release number is a patch(1.0.0), but "
+        "[ERROR] Validation of release number failed. Release number is a patch(1.0.1), but "
             + "release notes contain 'new' or 'breaking compatability' labels. Please correct "
             + "release number by running https://github.com/checkstyle/checkstyle/actions/"
             + "workflows/bump-version-and-update-milestone.yml";
@@ -74,7 +74,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyBreakingCompatibility() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateAll(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -89,7 +89,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyNewFeature() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions()
+            createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateAll(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -104,7 +104,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyBug() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions()
+            createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions("1.0.1")
                 .setGenerateAll(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -119,7 +119,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyMisc() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions()
+            createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions("1.0.1")
                 .setGenerateAll(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -133,7 +133,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyNewModule() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions()
+            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions("1.0.0")
                 .setGenerateAll(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -154,7 +154,7 @@ public class TemplateProcessorTest {
                 Collections.singletonList(createReleaseNotesMessage("Title 3", "Author 3")),
                 Collections.singletonList(createReleaseNotesMessage(4, "Title 4", "Author 4")),
                 Collections.singletonList(createReleaseNotesMessage("Title 5", "Author 5"))
-            ), createBaseCliOptions().setGenerateAll(true).build(), true);
+            ), createBaseCliOptions("1.0.0").setGenerateAll(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
 
@@ -168,7 +168,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyXdoc() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateXdoc(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -183,7 +183,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyTwitter() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateTw(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -198,7 +198,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyRss() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateRss(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -213,7 +213,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyMlist() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateMlist(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -228,7 +228,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGenerateOnlyGitHub() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateGitHub(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -243,7 +243,7 @@ public class TemplateProcessorTest {
     @Test
     public void testGitHub() throws Exception {
         final List<String> errors = MainProcess.runPostGenerationAndPublication(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions()
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setGenerateGitHub(true).build(), true);
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -276,7 +276,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesMinorNoNotes() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, null, null, null), createBaseCliOptions("1.0")
+            createNotes(null, null, null, null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -286,7 +286,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesMinorBreaking() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0")
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -295,7 +295,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesMinorNewFeature() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions("1.0")
+            createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -304,7 +304,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesMinorBug() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions("1.0")
+            createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -314,7 +314,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesMinorMiscellaneous() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions("1.0")
+            createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -324,7 +324,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesMinorNewModule() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions("1.0")
+            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -334,7 +334,7 @@ public class TemplateProcessorTest {
     public void testValidateNotesMinorBugAndMiscellaneous() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null,
-                createAllNotes(), createAllNotes(), null), createBaseCliOptions("1.0")
+                createAllNotes(), createAllNotes(), null), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -345,7 +345,7 @@ public class TemplateProcessorTest {
     public void testValidateNotesMinorNewModuleNewFeatureAndBreaking() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
             createNotes(createAllNotes(), createAllNotes(),
-                null, null, createAllNotes()), createBaseCliOptions("1.0")
+                null, null, createAllNotes()), createBaseCliOptions("1.0.0")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -354,7 +354,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesPatchNoNotes() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, null, null, null), createBaseCliOptions("1.0.0")
+            createNotes(null, null, null, null, null), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -363,7 +363,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesPatchBreaking() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.0")
+            createNotes(createAllNotes(), null, null, null, null), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -373,7 +373,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesPatchNewFeature() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions("1.0.0")
+            createNotes(null, createAllNotes(), null, null, null), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -383,7 +383,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesPatchBug() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions("1.0.0")
+            createNotes(null, null, createAllNotes(), null, null), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -392,7 +392,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesPatchMiscellaneous() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions("1.0.0")
+            createNotes(null, null, null, createAllNotes(), null), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -401,7 +401,7 @@ public class TemplateProcessorTest {
     @Test
     public void testValidateNotesPatchNewModule() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
-            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions("1.0.0")
+            createNotes(null, null, null, null, createAllNotes()), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -412,7 +412,7 @@ public class TemplateProcessorTest {
     public void testValidateNotesPatchNewFeatureNewModuleAndBreaking() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
             createNotes(createAllNotes(), createAllNotes(),
-                null, null, createAllNotes()), createBaseCliOptions("1.0.0")
+                null, null, createAllNotes()), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("one error", 1, errors.size());
@@ -423,7 +423,7 @@ public class TemplateProcessorTest {
     public void testValidateNotesPatchBugAndMiscellaneous() throws Exception {
         final List<String> errors = MainProcess.validateNotes(
             createNotes(null, null,
-                createAllNotes(), createAllNotes(), null), createBaseCliOptions("1.0.0")
+                createAllNotes(), createAllNotes(), null), createBaseCliOptions("1.0.1")
                 .setValidateVersion(true).build());
 
         Assert.assertEquals("no errors", 0, errors.size());
@@ -448,7 +448,7 @@ public class TemplateProcessorTest {
     }
 
     private Builder createBaseCliOptions() {
-        return createBaseCliOptions("1.0.0");
+        return createBaseCliOptions("1.0.1");
     }
 
     private Builder createBaseCliOptions(String releaseNumber) {

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
@@ -1,4 +1,4 @@
-Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+Checkstyle 1.0.1 - https://checkstyle.org/releasenotes.html#Release_1.0.1
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistBug.txt
@@ -1,4 +1,4 @@
-Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+Checkstyle 1.0.1 - https://checkstyle.org/releasenotes.html#Release_1.0.1
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/rssMlistMisc.txt
@@ -1,4 +1,4 @@
-Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+Checkstyle 1.0.1 - https://checkstyle.org/releasenotes.html#Release_1.0.1
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
@@ -1,3 +1,3 @@
-Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+Checkstyle 1.0.1 - https://checkstyle.org/releasenotes.html#Release_1.0.1
 
 Bug fixes: 10

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterMisc.txt
@@ -1,2 +1,2 @@
-Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
+Checkstyle 1.0.1 - https://checkstyle.org/releasenotes.html#Release_1.0.1
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -1,5 +1,5 @@
   
-    <section name="Release 1.0.0">
+    <section name="Release 1.0.1">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Bug fixes:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -1,5 +1,5 @@
   
-    <section name="Release 1.0.0">
+    <section name="Release 1.0.1">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Notes:</p>
         <ul>


### PR DESCRIPTION
Resolves #701

---
For the manual test I modified the script to be pointing to this branch and changed `CS_RELEASE_VERSION` to `10.5.0`. Runs with no errors: https://github.com/stoyanK7/checkstyle/commit/dee3811dd6eb71765ccf3bc085763cfdf876042b


If I change `CS_RELEASE_VERSION` to `10.5.1`, it is failing as expected.
```
[WARN] Issue #11163 "Enforce file size on Java inputs" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/11163
[WARN] Issue #11446 "Update Tests to use new 'verifyXxxxxx' method or 'execute' that use inlined config in Input files" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/11446
[WARN] Issue #11214 "Specify violation messages in input files." is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/11214
[WARN] Issue #12330 "Resolve Pitest for Block Profile-2" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/12330

Generation ends with 1 errors.

[ERROR] Validation of release number failed. Release number is a patch(10.5.1), but release notes contain 'new' or 'breaking compatability' labels. Please correct release number by running https://github.com/checkstyle/checkstyle/actions/workflows/bump-version-and-update-milestone.yml

```
