### PR TITLE
Pull #721: Fix generated extra empty line with spaces in xdoc

### DIFF
--- a/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
+++ b/releasenotes-builder/src/main/resources/com/github/checkstyle/templates/xdoc_freemarker.template
@@ -1,4 +1,4 @@
-  <#escape x as x?html>
+  <#t><#escape x as x?html>
     <section name="Release ${releaseNo}">
       <div class="releaseDate">${todaysDate}</div>
       <#if breakingMessages?has_content>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Breaking backward compatibility:</p>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Breaking backward compatibility:</p>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.1">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Bug fixes:</p>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.1">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>Notes:</p>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
@@ -1,4 +1,3 @@
-  
     <section name="Release 1.0.0">
       <div class="releaseDate">XX.XX.XXXX</div>
       <p>New:</p>


### PR DESCRIPTION
Resolves https://github.com/checkstyle/checkstyle/issues/12498

Github actions changes; https://github.com/stoyanK7/checkstyle/commit/4dba500002f3ee1c56b9d5552db18723b0802518
Actions job: https://github.com/stoyanK7/checkstyle/actions/runs/3614141814/jobs/6090376899

`<#t>` docs: https://freemarker.apache.org/docs/ref_directive_t.html#ref.directive.t 