### PR TITLE
Rework test layout

### DIFF
--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -82,6 +82,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
@@ -19,6 +19,7 @@
 
 package com.github.checkstyle;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -590,6 +591,9 @@ public final class CliOptions {
             }
             if (outputLocation == null) {
                 outputLocation = "";
+            }
+            else if (!outputLocation.endsWith(File.separator)) {
+                outputLocation += File.separator;
             }
             Verify.verifyNotNull(localRepoPath,
                 "Path to a local git repository should not be null!");

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/internal/AbstractPathTestSupport.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/internal/AbstractPathTestSupport.java
@@ -1,0 +1,124 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.internal;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import com.github.checkstyle.globals.Constants;
+
+public abstract class AbstractPathTestSupport {
+
+    protected static final String BUG = Constants.BUG_LABEL;
+    protected static final String NEW_FEATURE = Constants.NEW_FEATURE_LABEL;
+    protected static final String NEW_MODULE = Constants.NEW_MODULE_LABEL;
+    protected static final String MISC = Constants.MISCELLANEOUS_LABEL;
+    protected static final String BREAKING = Constants.BREAKING_COMPATIBILITY_LABEL;
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        temporaryFolder.delete();
+        temporaryFolder.create();
+    }
+
+    /**
+     * Retrieves the temporary folder.
+     *
+     * @return The temporary folder.
+     */
+    protected File getTempFolder() {
+        return temporaryFolder.getRoot();
+    }
+
+    /**
+     * Returns canonical path for the file with the given file name.
+     * The path is formed base on the root location.
+     * This implementation uses 'src/test/resources/'
+     * as a root location.
+     *
+     * @param fileName file name.
+     * @return canonical path for the file name.
+     * @throws IOException if I/O exception occurs while forming the path.
+     */
+    protected static String getPath(String fileName) throws IOException {
+        return new File("src/test/resources/com/github/checkstyle/" + fileName).getCanonicalPath();
+    }
+
+    /**
+     * Asserts file equals the expected result.
+     *
+     * @param expectedName Expected file path to read.
+     * @param actualName Actual file path to read.
+     * @throws IOException if there is an error reading the file.
+     */
+    protected void assertFile(String expectedName, String actualName) throws IOException {
+        final String expected =
+                getFileContents(new File(getPath(expectedName)));
+        final String actual = getFileContents(new File(getTempFolder(), actualName))
+                .replace(LocalDate.now()
+                                .format(DateTimeFormatter.ofPattern("dd.MM.yyyy", Locale.US)),
+                        "XX.XX.XXXX");
+
+        Assert.assertEquals("expected " + actualName, expected, actual);
+    }
+
+    /**
+     * Asserts file does not exist.
+     *
+     * @param actualName Actual file path to check.
+     */
+    protected void assertFile(String actualName) {
+        Assert.assertFalse("file does not exist",
+            new File(temporaryFolder.getRoot(), actualName).exists());
+    }
+
+    protected static String getFileContents(File file) throws IOException {
+        final StringBuilder result = new StringBuilder(256);
+
+        try (BufferedReader br = Files.newBufferedReader(file.toPath())) {
+            do {
+                final String line = br.readLine();
+
+                if (line == null) {
+                    break;
+                }
+
+                result.append(line);
+                result.append('\n');
+            } while (true);
+        }
+
+        return result.toString();
+    }
+
+}

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/internal/AbstractReleaseNotesTestSupport.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/internal/AbstractReleaseNotesTestSupport.java
@@ -1,0 +1,188 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.internal;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.kohsuke.github.GHFileNotFoundException;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHRepository;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.github.checkstyle.Main;
+import com.github.checkstyle.git.CsGit;
+import com.github.checkstyle.github.CsGitHub;
+import com.github.checkstyle.publishers.TwitterPublisher;
+
+public abstract class AbstractReleaseNotesTestSupport extends AbstractPathTestSupport {
+
+    private static final Set<RevCommit> TEST_COMMITS = new LinkedHashSet<>();
+
+    private static final Set<GHIssue> TEST_ISSUES = new LinkedHashSet<>();
+
+    private static final Answer<GHIssue> ISSUE_ANSWER = new Answer<>() {
+        @Override
+        public GHIssue answer(InvocationOnMock invocation) throws Throwable {
+            final int findIssue = invocation.getArgument(0);
+
+            for (GHIssue item : TEST_ISSUES) {
+                if (item.getNumber() == findIssue) {
+                    return item;
+                }
+            }
+
+            throw new GHFileNotFoundException("Cannot find Issue: " + findIssue);
+        }
+    };
+
+    private static boolean mocked;
+
+    @Rule
+    public final SystemErrRule systemErr = new SystemErrRule().enableLog().mute();
+    @Rule
+    public final SystemOutRule systemOut = new SystemOutRule().enableLog().mute();
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        if (!mocked) {
+            mocked = true;
+
+            // GHRepository
+            final GHRepository mockGhRepository = mock(GHRepository.class);
+            when(mockGhRepository.getIssue(anyInt())).then(ISSUE_ANSWER);
+            // CsGitHub static
+            final MockedStatic<CsGitHub> mockCsGitHubStatic = mockStatic(CsGitHub.class);
+            mockCsGitHubStatic.when(() -> CsGitHub.createRemoteRepo(anyString(), anyString()))
+                    .thenReturn(mockGhRepository);
+            // CsGit static
+            final MockedStatic<CsGit> mockCsGitStatic = mockStatic(CsGit.class);
+            mockCsGitStatic.when(
+                    () -> CsGit.getCommitsBetweenReferences(anyString(), anyString(), anyString()))
+                    .thenReturn(TEST_COMMITS);
+
+            // TwitterPublisher static
+            mockStatic(TwitterPublisher.class);
+        }
+    }
+
+    @Before
+    public void reset() {
+        TEST_COMMITS.clear();
+        TEST_ISSUES.clear();
+    }
+
+    /**
+     * Adds a new commit for the current test.
+     *
+     * @param commitMessage The commit message to add.
+     * @param author The commit author to add.
+     * @return {@code true} if the commit added is new.
+     */
+    protected boolean addCommit(String commitMessage, String author) {
+        return TEST_COMMITS.add(RevCommitUtil.create(commitMessage, author));
+    }
+
+    /**
+     * Adds a new issue for the current test.
+     *
+     * @param ghNumber The number of the issue.
+     * @param ghState The state of the issue.
+     * @param ghTitle The title of the issue.
+     * @param labels The labels of the issue.
+     * @return {@code true} if the issue added is new.
+     */
+    protected boolean addIssue(int ghNumber, GHIssueState ghState, String ghTitle,
+            String... labels) {
+        return TEST_ISSUES.add(GhIssueUtil.create(ghNumber, ghState, ghTitle, labels));
+    }
+
+    /**
+     * Retrieve a copy of all current commits.
+     *
+     * @return Copy of all current commits.
+     */
+    protected Set<RevCommit> getCommits() {
+        return new LinkedHashSet<>(TEST_COMMITS);
+    }
+
+    /**
+     * Retrieve a copy of all current issues.
+     *
+     * @return Copy of all current issues.
+     */
+    protected Set<GHIssue> getIssues() {
+        return new LinkedHashSet<>(TEST_ISSUES);
+    }
+
+    /**
+     * Helper method to run {@link Main#main(String...)} and verify the exit code.
+     * Uses {@link Mockito#mockStatic(Class)} to mock method {@link Runtime#exit(int)}
+     * to avoid VM termination.
+     *
+     * @param expectedExitCode the expected exit code to verify
+     * @param arguments the command line arguments
+     * @noinspection CallToSystemExit, ResultOfMethodCallIgnored
+     * @noinspectionreason CallToSystemExit - test helper method requires workaround to
+     *      verify exit code
+     * @noinspectionreason ResultOfMethodCallIgnored - temporary suppression until #11589
+     */
+    protected void runMainAndAssertReturnCode(int expectedExitCode, String... arguments) {
+        systemOut.clearLog();
+        systemErr.clearLog();
+
+        final Runtime mock = mock(Runtime.class);
+        try (MockedStatic<Runtime> runtime = mockStatic(Runtime.class)) {
+            runtime.when(Runtime::getRuntime)
+                    .thenReturn(mock);
+            Main.main(arguments);
+        }
+        catch (Exception exception) {
+            fail(String.format("Unexpected exception: %s", exception));
+        }
+        if (expectedExitCode == 0) {
+            verify(mock, never()).exit(expectedExitCode);
+        }
+        else {
+            verify(mock).exit(expectedExitCode);
+        }
+    }
+
+}

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/internal/RevCommitUtil.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/internal/RevCommitUtil.java
@@ -30,11 +30,7 @@ public final class RevCommitUtil {
     private RevCommitUtil() {
     }
 
-    public static RevCommit create(String commitMessage) {
-        return create("CheckstyleUser", commitMessage);
-    }
-
-    public static RevCommit create(String author, String commitMessage) {
+    public static RevCommit create(String commitMessage, String author) {
         final String commitData = String.format("tree %040x\n"
             + "parent %040x\n"
             + "author " + author + " <test@email.com> %d +0100\n"

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageAll.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageAll.txt
@@ -2,16 +2,16 @@ Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
 
 Breaking backward compatibility:
 
-  #-1 - Title 1
+  #1 - Title 1
 
 New:
 
   #2 - Title 2
-  #-1 - Title 5
+  #5 - Title 5
 
 Bug fixes:
 
-  #-1 - Title 3
+  #3 - Title 3
 
 <details>
 <summary>Other Changes:</summary>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocAll.txt
@@ -5,6 +5,7 @@
           <li>
             Title 1.
             Author: Author 1
+            <a href="https://github.com/checkstyle/checkstyle/issues/1">#1</a>
           </li>
         </ul>
       <p>New:</p>
@@ -17,6 +18,7 @@
           <li>
             Title 5.
             Author: Author 5
+            <a href="https://github.com/checkstyle/checkstyle/issues/5">#5</a>
           </li>
         </ul>
       <p>Bug fixes:</p>
@@ -24,6 +26,7 @@
           <li>
             Title 3.
             Author: Author 3
+            <a href="https://github.com/checkstyle/checkstyle/issues/3">#3</a>
           </li>
         </ul>
       <p>Notes:</p>
@@ -31,7 +34,6 @@
           <li>
             Title 4.
             Author: Author 4
-            <a href="https://github.com/checkstyle/checkstyle/issues/4">#4</a>
           </li>
         </ul>
     </section>


### PR DESCRIPTION
Discussed at https://github.com/checkstyle/contribution/pull/712#issuecomment-1336195814

Reworked and moved code around to build a new testing tier for release notes.

Commit `converts one test in TemplateProcess to the new layout` shows an example of converting an existing test to the new format.

Commit `ensure output location is treated as a directory` makes things easier if output location is always treated as a folder, otherwise we need to manually add `/` when passing it to Main as it doesn't save to the correct location.