### PR TITLE
Issue #727: shallow validation of release number

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import com.github.checkstyle.globals.Constants;
 import com.github.checkstyle.globals.ReleaseNotesMessage;
@@ -53,6 +54,12 @@ public final class MainProcess {
     /** GitHub Post template file name. */
     public static final String GITHUB_TEMPLATE_FILE =
         "com/github/checkstyle/templates/github_post.template";
+
+    /** Checkstyle supports only 3 digit versions for now. */
+    public static final String RELEASE_NUMBER_PATTERN = "^\\d+\\.\\d+\\.\\d+$";
+
+    /** Compiled pattern for release number. */
+    private static final Pattern RELEASE_PATTERN = Pattern.compile(RELEASE_NUMBER_PATTERN);
 
     /** Default constructor. */
     private MainProcess() {
@@ -103,6 +110,9 @@ public final class MainProcess {
         final String errorEnding = "Please correct release number by running https://github.com/"
             + "checkstyle/checkstyle/actions/workflows/bump-version-and-update-milestone.yml";
 
+        if (!RELEASE_PATTERN.matcher(releaseVersion).find()) {
+            errors.add("Release number should match pattern " + RELEASE_NUMBER_PATTERN);
+        }
         if (isPatch(releaseVersion) && containsNewOrBreakingCompatabilityLabel) {
             errors.add(
                 String.format("%s Release number is a patch(%s), but release notes contain 'new' "

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
@@ -19,6 +19,7 @@
 
 package com.github.checkstyle;
 
+import static com.github.checkstyle.MainProcess.RELEASE_NUMBER_PATTERN;
 import static org.kohsuke.github.GHIssueState.CLOSED;
 
 import org.junit.Assert;
@@ -44,13 +45,70 @@ public class MainTest extends AbstractReleaseNotesTestSupport {
         addCommit("Hello World", "CheckstyleUser");
 
         runMainContentGenerationAndAssertReturnCode(0,
-            "-releaseNumber", "10.0.1.",
+            "-releaseNumber", "10.0.1",
             "-generateAll",
             "-validateVersion"
         );
 
         Assert.assertEquals("expected error output", "", systemErr.getLog());
         Assert.assertEquals("expected output", MSG_EXECUTION_SUCCEEDED, systemOut.getLog());
+    }
+
+    @Test
+    public void testBadVersion3Dots() {
+        addCommit("Hello World", "CheckstyleUser");
+
+        runMainContentGenerationAndAssertReturnCode(-2,
+            "-releaseNumber", "10.0.1.",
+            "-generateAll",
+            "-validateVersion"
+        );
+
+        Assert.assertEquals("expected error output", "", systemErr.getLog());
+        Assert.assertEquals("expected output",
+            getExecutionFailedMessage(1)
+                + System.lineSeparator()
+                + "Release number should match pattern " + RELEASE_NUMBER_PATTERN
+                + System.lineSeparator(),
+            systemOut.getLog());
+    }
+
+    @Test
+    public void testBadVersionWithChars() {
+        addCommit("Hello World", "CheckstyleUser");
+
+        runMainContentGenerationAndAssertReturnCode(-2,
+            "-releaseNumber", "10.p.1",
+            "-generateAll",
+            "-validateVersion"
+        );
+
+        Assert.assertEquals("expected error output", "", systemErr.getLog());
+        Assert.assertEquals("expected output",
+            getExecutionFailedMessage(1)
+                + System.lineSeparator()
+                + "Release number should match pattern " + RELEASE_NUMBER_PATTERN
+                + System.lineSeparator(),
+            systemOut.getLog());
+    }
+
+    @Test
+    public void testBadVersion2Dots() {
+        addCommit("Hello World", "CheckstyleUser");
+
+        runMainContentGenerationAndAssertReturnCode(-2,
+            "-releaseNumber", "10.0.",
+            "-generateAll",
+            "-validateVersion"
+        );
+
+        Assert.assertEquals("expected error output", "", systemErr.getLog());
+        Assert.assertEquals("expected output",
+            getExecutionFailedMessage(1)
+                + System.lineSeparator()
+                + "Release number should match pattern " + RELEASE_NUMBER_PATTERN
+                + System.lineSeparator(),
+            systemOut.getLog());
     }
 
     @Test


### PR DESCRIPTION
Issue #727

it is not comprehended validation, but enough to avoid basic typos