### PR TITLE
Issue #665: adds validation of a configuration being required

### DIFF
--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -55,7 +55,6 @@ to patch branch (required if baseConfig is specified);
 
 **config** (c) - path to the checkstyle config file. It will be applied to base
 and patch branches (required if baseConfig and patchConfig are not specified).
-The default config should be changed in order to be appropriate for your use purposes;
 
 **listOfProjects** (l) - path to the file which contains the projects which sources
 will be analyzed by Checkstyle during report generation.

--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -121,7 +121,12 @@ def areValidCliOptions(cliOptions) {
 
 def isValidCheckstyleConfigsCombination(config, baseConfig, patchConfig, toolMode) {
     def valid = true
-    if (config && (patchConfig || baseConfig)) {
+    if (!config && !patchConfig && !baseConfig) {
+        err.println "Error: you should specify either \'config\'," \
+            + " or \'baseConfig\', or \'patchConfig\'!"
+        valid = false
+    }
+    else if (config && (patchConfig || baseConfig)) {
         err.println "Error: you should specify either \'config\'," \
             + " or \'baseConfig\' and \'patchConfig\', or \'patchConfig\' only!"
         valid = false


### PR DESCRIPTION
Issue #665


````
> groovy .\diff.groovy -r M:\checkstyle -p localtest -l M:\projects-to-test-on.properties

Error: you should specify either 'config', or 'baseConfig', or 'patchConfig'!
Caught: java.lang.IllegalArgumentException: Error: invalid command line arguments!
java.lang.IllegalArgumentException: Error: invalid command line arguments!
````

Program goes to completion with `-c my_check.xml`.