### PR TITLE
Issue #738: swaps deprecated attributes in patch-diff-report

### DIFF
--- a/patch-diff-report-tool/src/main/resources/header.template
+++ b/patch-diff-report-tool/src/main/resources/header.template
@@ -68,7 +68,7 @@
 										<td th:unless="${child.hasPatchModule()}"> </td>
 									</tr>
 									<th:block th:each="grandchild : ${child.children}">
-										<th:block th:include="::module" th:with="child = ${grandchild}"/>
+										<th:block th:insert="~{::module}" th:with="child = ${grandchild}"/>
 									</th:block>
 								</th:block>
 							</th:block>	


### PR DESCRIPTION
Issue #738

Confirmed deprecations are gone from test run.

Old:
````
Running com.github.checkstyle.MainTest
[main] WARN org.thymeleaf.standard.processor.StandardIncludeTagProcessor - [THYMELEAF][main][header] Deprecated attribute {th:include,data-th-include} found in template header, line 71, col 21. Please use {th:insert,data-th-insert} instead, this deprecated attribute will be removed in future versions of Thymeleaf.
[main] WARN org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][main][header] Deprecated unwrapped fragment expression "::module" found in template header, line 71, col 21. Please use the complete syntax of fragment expressions instead ("~{::module}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
....
````