### PR TITLE
infra: change cron in bump_license_year.yml

### DIFF
--- a/.github/workflows/bump_license_year.yml
+++ b/.github/workflows/bump_license_year.yml
@@ -7,7 +7,7 @@
 name: "Bump license year"
 on:
     schedule:
-        - cron: "0 0 1 1 *"
+        - cron: "0 2 1 1 *"
     workflow_dispatch:
 permissions:
     contents: write


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/issues/12572#issuecomment-1368578305

> Cron is slightly different to let naun repo be updated first, dependable repositores update after. Distance might be in 1-2 hour as in main repo queue is longer.