### PR TITLE
Pull #770: Boost implementation of isIssueOrPull method

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/CommitMessage.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/CommitMessage.java
@@ -61,13 +61,13 @@ import java.util.regex.Pattern;
 
     /**
      * Checks whether commits message is associated with a pull request or an issue.
-     * Commit message which is associated with a pull request or an issue starts with 'Pull'
-     * or 'Issue' prefix.
+     * Commit message which is associated with a pull request or an issue follows one
+     * of the following formats: 'Pull #[number]: [title]' or 'Issue #[number]: [title]'.
      *
      * @return true if commits message is associated with a pull request or an issue.
      */
     public boolean isIssueOrPull() {
-        return message.startsWith("Issue") || message.startsWith("Pull");
+        return message.matches("^(Pull|Issue) #\\d+: .*$");
     }
 
     /**

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
@@ -393,4 +393,20 @@ public class MainTest extends AbstractReleaseNotesTestSupport {
         Assert.assertEquals("expected error output", "", systemErr.getLog());
         Assert.assertEquals("expected output", MSG_EXECUTION_SUCCEEDED, systemOut.getLog());
     }
+
+    @Test
+    public void testMistypedCommitMessage() {
+        addCommit("Issue 1: Hello World", "CheckstyleUser");
+        addCommit("Pull 2: Hello World", "CheckstyleUser");
+        addCommit("Issue #asd: asd", "CheckstyleUser");
+
+        runMainContentGenerationAndAssertReturnCode(0,
+            "-releaseNumber", "10.0.1",
+            "-generateAll",
+            "-validateVersion"
+        );
+
+        Assert.assertEquals("expected error output", "", systemErr.getLog());
+        Assert.assertEquals("expected output", MSG_EXECUTION_SUCCEEDED, systemOut.getLog());
+    }
 }

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -288,6 +288,7 @@ public class TemplateProcessorTest extends AbstractReleaseNotesTestSupport {
                 + "LongAndWeExpectItToGetWrappedDueToBeingTooLng", label);
             addIssue(9, CLOSED, "Mock issue title 9 escape @ and @@@@@", label);
             addIssue(10, CLOSED, "Mock issue title 10 escape < > & <&<>&<<", label);
+            addIssue(13, CLOSED, "Mock pull title 13", label);
         }
     }
 
@@ -306,5 +307,11 @@ public class TemplateProcessorTest extends AbstractReleaseNotesTestSupport {
             + "LongAndWeExpectItToGetWrappedDueToBeingTooLng", "Author 11");
         addCommit("Issue #9: Mock issue title 9 escape @ and @@@@@", "Author 12");
         addCommit("Issue #10: Mock issue title 10 escape < > & <&<>&<<", "Author 13");
+        addCommit("Issue 11: Mock issue title 11 missing #", "Author 14");
+        addCommit("Pull 12: Mock pull title 12 missing #", "Author 15");
+        addCommit("miscasmdifs324y23123sda!@.asd12", "Author 16");
+        addCommit("Issue #asd: asd", "Author 17");
+        addCommit("Pull #13: Mock pull title 13", "Author 18");
+        addCommit(".Issue #14: Mock issue title 14", "Author 19");
     }
 }

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
@@ -12,6 +12,16 @@ Breaking backward compatibility:
   #8 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
   #9 - Mock issue title 9 escape `@` and `@``@``@``@``@`
   #10 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
+  #13 - Mock pull title 13
 
 
 
+<details>
+<summary>Other Changes:</summary>
+<br/>
+  Issue 11: Mock issue title 11 missing # <br/>
+  Pull 12: Mock pull title 12 missing # <br/>
+  miscasmdifs324y23123sda!`@`.asd12 <br/>
+  Issue #asd: asd <br/>
+  .Issue #14: Mock issue title 14 <br/>
+</details>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
@@ -14,4 +14,14 @@ Bug fixes:
   #8 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
   #9 - Mock issue title 9 escape `@` and `@``@``@``@``@`
   #10 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
+  #13 - Mock pull title 13
 
+<details>
+<summary>Other Changes:</summary>
+<br/>
+  Issue 11: Mock issue title 11 missing # <br/>
+  Pull 12: Mock pull title 12 missing # <br/>
+  miscasmdifs324y23123sda!`@`.asd12 <br/>
+  Issue #asd: asd <br/>
+  .Issue #14: Mock issue title 14 <br/>
+</details>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
@@ -13,5 +13,15 @@ New:
   #8 - Mock issue title 8 thisIssueTitleIsExactly100CharactersLongAndWeExpectItToGetWrappedDueToBeingTooLng
   #9 - Mock issue title 9 escape `@` and `@``@``@``@``@`
   #10 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
+  #13 - Mock pull title 13
 
 
+<details>
+<summary>Other Changes:</summary>
+<br/>
+  Issue 11: Mock issue title 11 missing # <br/>
+  Pull 12: Mock pull title 12 missing # <br/>
+  miscasmdifs324y23123sda!`@`.asd12 <br/>
+  Issue #asd: asd <br/>
+  .Issue #14: Mock issue title 14 <br/>
+</details>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
@@ -1,2 +1,2 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
-Breaking backward compatibility: 10
+Breaking backward compatibility: 11

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.1 - https://checkstyle.org/releasenotes.html#Release_1.0.1
 
-Bug fixes: 10
+Bug fixes: 11

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
 
-New functionality: 10
+New functionality: 11

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
@@ -55,5 +55,33 @@
             Author: Author 13
             <a href="https://github.com/checkstyle/checkstyle/issues/10">#10</a>
           </li>
+          <li>
+            Mock pull title 13.
+            Author: Author 18
+            <a href="https://github.com/checkstyle/checkstyle/issues/13">#13</a>
+          </li>
+        </ul>
+      <p>Notes:</p>
+        <ul>
+          <li>
+            Issue 11: Mock issue title 11 missing #.
+            Author: Author 14
+          </li>
+          <li>
+            Pull 12: Mock pull title 12 missing #.
+            Author: Author 15
+          </li>
+          <li>
+            miscasmdifs324y23123sda!@.asd12.
+            Author: Author 16
+          </li>
+          <li>
+            Issue #asd: asd.
+            Author: Author 17
+          </li>
+          <li>
+            .Issue #14: Mock issue title 14.
+            Author: Author 19
+          </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -55,5 +55,33 @@
             Author: Author 13
             <a href="https://github.com/checkstyle/checkstyle/issues/10">#10</a>
           </li>
+          <li>
+            Mock pull title 13.
+            Author: Author 18
+            <a href="https://github.com/checkstyle/checkstyle/issues/13">#13</a>
+          </li>
+        </ul>
+      <p>Notes:</p>
+        <ul>
+          <li>
+            Issue 11: Mock issue title 11 missing #.
+            Author: Author 14
+          </li>
+          <li>
+            Pull 12: Mock pull title 12 missing #.
+            Author: Author 15
+          </li>
+          <li>
+            miscasmdifs324y23123sda!@.asd12.
+            Author: Author 16
+          </li>
+          <li>
+            Issue #asd: asd.
+            Author: Author 17
+          </li>
+          <li>
+            .Issue #14: Mock issue title 14.
+            Author: Author 19
+          </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -55,5 +55,30 @@
             Author: Author 13
             <a href="https://github.com/checkstyle/checkstyle/issues/10">#10</a>
           </li>
+          <li>
+            Issue 11: Mock issue title 11 missing #.
+            Author: Author 14
+          </li>
+          <li>
+            Pull 12: Mock pull title 12 missing #.
+            Author: Author 15
+          </li>
+          <li>
+            miscasmdifs324y23123sda!@.asd12.
+            Author: Author 16
+          </li>
+          <li>
+            Issue #asd: asd.
+            Author: Author 17
+          </li>
+          <li>
+            Mock pull title 13.
+            Author: Author 18
+            <a href="https://github.com/checkstyle/checkstyle/issues/13">#13</a>
+          </li>
+          <li>
+            .Issue #14: Mock issue title 14.
+            Author: Author 19
+          </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
@@ -55,5 +55,33 @@
             Author: Author 13
             <a href="https://github.com/checkstyle/checkstyle/issues/10">#10</a>
           </li>
+          <li>
+            Mock pull title 13.
+            Author: Author 18
+            <a href="https://github.com/checkstyle/checkstyle/issues/13">#13</a>
+          </li>
+        </ul>
+      <p>Notes:</p>
+        <ul>
+          <li>
+            Issue 11: Mock issue title 11 missing #.
+            Author: Author 14
+          </li>
+          <li>
+            Pull 12: Mock pull title 12 missing #.
+            Author: Author 15
+          </li>
+          <li>
+            miscasmdifs324y23123sda!@.asd12.
+            Author: Author 16
+          </li>
+          <li>
+            Issue #asd: asd.
+            Author: Author 17
+          </li>
+          <li>
+            .Issue #14: Mock issue title 14.
+            Author: Author 19
+          </li>
         </ul>
     </section>


### PR DESCRIPTION
Part of https://github.com/checkstyle/checkstyle/issues/12717
> Additionally, we should fallback release notes categories to "misc" if something is wrong with parsing a format, we need to update release notes generator.

---
It seems we are already handling this case. The problem was that we were not checking for the hash `#` char in the commit message. We expect to see it as shown here
https://github.com/checkstyle/checkstyle/blob/a144e7fb576f6a875bf5a630190754ca025b7381/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java#L74-L75