### PR TITLE
Pull #771: Trim newlines in isIssueOrPull method

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/CommitMessage.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/CommitMessage.java
@@ -63,11 +63,15 @@ import java.util.regex.Pattern;
      * Checks whether commits message is associated with a pull request or an issue.
      * Commit message which is associated with a pull request or an issue follows one
      * of the following formats: 'Pull #[number]: [title]' or 'Issue #[number]: [title]'.
+     * This method trims '\r' and '\n'.
      *
      * @return true if commits message is associated with a pull request or an issue.
      */
     public boolean isIssueOrPull() {
-        return message.matches("^(Pull|Issue) #\\d+: .*$");
+        return message
+            .replace("\r", "")
+            .replace("\n", "")
+            .matches("^(Pull|Issue) #\\d+: .*$");
     }
 
     /**

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -289,6 +289,9 @@ public class TemplateProcessorTest extends AbstractReleaseNotesTestSupport {
             addIssue(9, CLOSED, "Mock issue title 9 escape @ and @@@@@", label);
             addIssue(10, CLOSED, "Mock issue title 10 escape < > & <&<>&<<", label);
             addIssue(13, CLOSED, "Mock pull title 13", label);
+            addIssue(14, CLOSED, "Mock issue title 14", label);
+            addIssue(15, CLOSED, "Mock issue title 15", label);
+            addIssue(16, CLOSED, "Mock issue title 16", label);
         }
     }
 
@@ -313,5 +316,8 @@ public class TemplateProcessorTest extends AbstractReleaseNotesTestSupport {
         addCommit("Issue #asd: asd", "Author 17");
         addCommit("Pull #13: Mock pull title 13", "Author 18");
         addCommit(".Issue #14: Mock issue title 14", "Author 19");
+        addCommit("Issue #14: Mock issue title 14\r\n", "Author 20");
+        addCommit("Issue #15: Mock issue title 15\r", "Author 21");
+        addCommit("Issue #16: Mock issue title 16\n", "Author 22");
     }
 }

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBreakingCompatibility.txt
@@ -13,6 +13,9 @@ Breaking backward compatibility:
   #9 - Mock issue title 9 escape `@` and `@``@``@``@``@`
   #10 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
   #13 - Mock pull title 13
+  #14 - Mock issue title 14
+  #15 - Mock issue title 15
+  #16 - Mock issue title 16
 
 
 

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageBug.txt
@@ -15,6 +15,9 @@ Bug fixes:
   #9 - Mock issue title 9 escape `@` and `@``@``@``@``@`
   #10 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
   #13 - Mock pull title 13
+  #14 - Mock issue title 14
+  #15 - Mock issue title 15
+  #16 - Mock issue title 16
 
 <details>
 <summary>Other Changes:</summary>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/githubPageNew.txt
@@ -14,6 +14,9 @@ New:
   #9 - Mock issue title 9 escape `@` and `@``@``@``@``@`
   #10 - Mock issue title 10 escape `<` `>` `&` `<``&``<``>``&``<``<`
   #13 - Mock pull title 13
+  #14 - Mock issue title 14
+  #15 - Mock issue title 15
+  #16 - Mock issue title 16
 
 
 <details>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBreakingCompatibility.txt
@@ -1,2 +1,2 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
-Breaking backward compatibility: 11
+Breaking backward compatibility: 14

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterBug.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.1 - https://checkstyle.org/releasenotes.html#Release_1.0.1
 
-Bug fixes: 11
+Bug fixes: 14

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/twitterNew.txt
@@ -1,3 +1,3 @@
 Checkstyle 1.0.0 - https://checkstyle.org/releasenotes.html#Release_1.0.0
 
-New functionality: 11
+New functionality: 14

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBreakingCompatibility.txt
@@ -60,6 +60,21 @@
             Author: Author 18
             <a href="https://github.com/checkstyle/checkstyle/issues/13">#13</a>
           </li>
+          <li>
+            Mock issue title 14.
+            Author: Author 20
+            <a href="https://github.com/checkstyle/checkstyle/issues/14">#14</a>
+          </li>
+          <li>
+            Mock issue title 15.
+            Author: Author 21
+            <a href="https://github.com/checkstyle/checkstyle/issues/15">#15</a>
+          </li>
+          <li>
+            Mock issue title 16.
+            Author: Author 22
+            <a href="https://github.com/checkstyle/checkstyle/issues/16">#16</a>
+          </li>
         </ul>
       <p>Notes:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocBug.txt
@@ -60,6 +60,21 @@
             Author: Author 18
             <a href="https://github.com/checkstyle/checkstyle/issues/13">#13</a>
           </li>
+          <li>
+            Mock issue title 14.
+            Author: Author 20
+            <a href="https://github.com/checkstyle/checkstyle/issues/14">#14</a>
+          </li>
+          <li>
+            Mock issue title 15.
+            Author: Author 21
+            <a href="https://github.com/checkstyle/checkstyle/issues/15">#15</a>
+          </li>
+          <li>
+            Mock issue title 16.
+            Author: Author 22
+            <a href="https://github.com/checkstyle/checkstyle/issues/16">#16</a>
+          </li>
         </ul>
       <p>Notes:</p>
         <ul>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocMisc.txt
@@ -80,5 +80,20 @@
             .Issue #14: Mock issue title 14.
             Author: Author 19
           </li>
+          <li>
+            Mock issue title 14.
+            Author: Author 20
+            <a href="https://github.com/checkstyle/checkstyle/issues/14">#14</a>
+          </li>
+          <li>
+            Mock issue title 15.
+            Author: Author 21
+            <a href="https://github.com/checkstyle/checkstyle/issues/15">#15</a>
+          </li>
+          <li>
+            Mock issue title 16.
+            Author: Author 22
+            <a href="https://github.com/checkstyle/checkstyle/issues/16">#16</a>
+          </li>
         </ul>
     </section>

--- a/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
+++ b/releasenotes-builder/src/test/resources/com/github/checkstyle/xdocNew.txt
@@ -60,6 +60,21 @@
             Author: Author 18
             <a href="https://github.com/checkstyle/checkstyle/issues/13">#13</a>
           </li>
+          <li>
+            Mock issue title 14.
+            Author: Author 20
+            <a href="https://github.com/checkstyle/checkstyle/issues/14">#14</a>
+          </li>
+          <li>
+            Mock issue title 15.
+            Author: Author 21
+            <a href="https://github.com/checkstyle/checkstyle/issues/15">#15</a>
+          </li>
+          <li>
+            Mock issue title 16.
+            Author: Author 22
+            <a href="https://github.com/checkstyle/checkstyle/issues/16">#16</a>
+          </li>
         </ul>
       <p>Notes:</p>
         <ul>


### PR DESCRIPTION
Resolves https://github.com/checkstyle/checkstyle/issues/12717#issuecomment-1426842225
> Hmm , and now we have a problem that release notes builder is not failing if labels are not defined.

>Should be red https://github.com/checkstyle/checkstyle/actions/runs/4149773299, as label on this issue is not defined for release notes.

>If issue is not closed, there use to be warning. But absence of label is error. I keep this issue open and without label to wait for fix.

`CommitMessageTest` trims them as well: 
https://github.com/checkstyle/checkstyle/blob/a144e7fb576f6a875bf5a630190754ca025b7381/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java#L190-L194

---
```sh
 stoyan @  zenbook:  ~/open-source/checkstyle                                                                                                                               :44d032b71 [!]
$ ./.ci/releasenotes-gen.sh   
```
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.571 s
[INFO] Finished at: 2023-02-11T20:45:29+01:00
[INFO] ------------------------------------------------------------------------
Cloning into 'checkstyle'...
remote: Enumerating objects: 214518, done.
remote: Counting objects: 100% (21/21), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 214518 (delta 5), reused 3 (delta 1), pack-reused 214497
Receiving objects: 100% (214518/214518), 84.95 MiB | 14.13 MiB/s, done.
Resolving deltas: 100% (123581/123581), done.
LATEST_RELEASE_TAG=checkstyle-10.7.0
CS_RELEASE_VERSION=10.7.1
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

[WARN] Issue #11637 "Use Shellcheck to resolve violations code in Shell Script" is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/11637
[WARN] Issue #12717 "Remove admins from white list on commit validation " is not closed! Please review issue https://github.com/checkstyle/checkstyle/issues/12717

Generation ends with 1 errors.

[ERROR] Issue #12717 does not have breaking compatibility, bug, miscellaneous, new feature, new module label! Please set label at https://github.com/checkstyle/checkstyle/issues/12717

```

---
Thanks @rnveach for pointing the issue out!