### PR TITLE
Pull #788: Add suppression for missingMessageKeyAnnotation

### DIFF
--- a/patch-diff-report-tool/config/suppressions.xml
+++ b/patch-diff-report-tool/config/suppressions.xml
@@ -17,4 +17,7 @@
     <!-- Until https://github.com/checkstyle/checkstyle/issues/3496 and when we have time to fix this in sevntu-->
     <suppress checks="ReturnCount" files=".*CheckstyleRecord\.java|DiffReport\.java|MergedConfigurationModule\.java"/>
 
+    <!-- MessageKey annotation is used for documentation and applies only to checks -->
+    <suppress id="missingMessageKeyAnnotation" files=".*" />
+
 </suppressions>


### PR DESCRIPTION
Suppresses check for `@MessageKey` annotation introduced at https://github.com/checkstyle/checkstyle/pull/13129

Addresses failure from semaphore https://checkstyle.semaphoreci.com/jobs/1f208a16-8ea8-48b9-b58a-ae97e2185597
I do not have access to the logs so I had to run it locally
```
[INFO] [checkstyle] Running Checkstyle 10.12.1-SNAPSHOT on 44 files
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/contribution/patch-diff-report-tool/src/main/java/com/github/checkstyle/CliArgsValidator.java:38:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/contribution/patch-diff-report-tool/src/main/java/com/github/checkstyle/Main.java:54:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[INFO]      [echo] Checkstyle finished (../../../config/checkstyle-checks.xml) : 04/06/2023 01:09:09 PM

```
