### PR TITLE
Issue #816: use git status --exit-code to work same on any host

### DIFF
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -190,11 +190,12 @@ def copyConfigFilesAndUpdatePaths(configFilesList) {
 
 def hasUnstagedChanges(gitRepo) {
     def hasUnstagedChanges = true
-    def gitStatusCmd = "git status".execute(null, gitRepo)
+    def gitStatusCmd = "git diff --exit-code".execute(null, gitRepo)
     gitStatusCmd.waitFor()
-    def gitStatusOutput = gitStatusCmd.text
-    if (gitStatusOutput.contains("nothing to commit")) {
+    if (gitStatusCmd.exitValue() == 0) {
         hasUnstagedChanges = false
+    } else {
+        println gitStatusCmd.text
     }
     return hasUnstagedChanges
 }


### PR DESCRIPTION
Issue #816

```
✔ ~/java/github/checkstyle/contribution/checkstyle-tester [master|✚ 1…2⚑ 1] 
$ groovy diff.groovy --localGitRepo ~/java/github/romani/checkstyle   --baseBranch master --patchBranch plan3d/Issue_3132 --config my-config.xml   --listOfProjects projects-to-test-on.properties
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass$3$1 (file:/opt/groovy/groovy-2.4.7/lib/groovy-2.4.7.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass$3$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
diff --git a/pom.xml b/pom.xml
index 55bc341..6e96628 100644
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
+<!-- -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

Caught: java.lang.IllegalStateException: Error: git repository /home/rivanov/java/github/romani/checkstyle has unstaged changes!
java.lang.IllegalStateException: Error: git repository /home/rivanov/java/github/romani/checkstyle has unstaged changes!
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at diff.run(diff.groovy:18)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

green path was also tested for https://github.com/checkstyle/checkstyle/pull/9758