### PR TITLE
Revert "Issue #818: do shallow clone to speedup download"

### DIFF
--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -72,16 +72,6 @@ would add `--extraMvnRegressionOptions "-Dmaven.site.skip=true"` to `diff.groovy
  (optional, default is false). This option is
  used for files that are not compilable or that Checkstyle cannot parse.
 
-**useShallowClone** (h) - this option tells `diff.groovy` to use shallow clone for repositories
- defined in the file
- specified for the `--listOfProjects (-l)` argument (optional, default is false). This option is
- convenient for cases when internet is not stable and it is better to clone minimal required sources.
- Shallow cloning cannot be used for projects that reference SHA commit and, by default,
- fallback to using normal cloning. ATTENTION: if you change tag/branch in config for project
- that previously cloned shallowly there will be error to checkout to new tag/branch
- (Example: `fatal: Could not parse object 'c2ac5b90a467aedb04b52ae50a99e83207d847b3'.`), to resovle
- problem you need to remove impacted project folder(s) from repositories directory.
-
 ## Outputs
 
 When the script finishes its work the following directory structure will be created


### PR DESCRIPTION
This reverts commit f10f82a9c036fc4565b4868d7cc8b0a3fe6eea2d.

We damaged ability to check out a specific SHA/ branch somehow. 

From failing [build](https://app.circleci.com/pipelines/github/checkstyle/checkstyle/23498/workflows/f5bbd3dc-3865-40f5-a44a-6bb41a9541df/jobs/501286/parallel-runs/0/steps/0-103?invite=true#step-103-33601_26): 
```
Testing Checkstyle started
   [delete] Deleting directory /home/circleci/project/.ci-temp/contribution/checkstyle-tester/src/main/java
Cloning git repository 'pmd' to repositories/pmd folder ...
Cloning command: git clone https://github.com/pmd/pmd repositories/pmd
Cloning into 'repositories/pmd'...
Cloning git repository 'pmd' - completed

pmd is synchronized
     [copy] Copying 4891 files to /home/circleci/project/.ci-temp/contribution/checkstyle-tester/src/main/java/pmd
Running 'mvn clean' on src/main/java ...
Running command: mvn -e --no-transfer-progress --batch-mode clean
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...

```

From successful [build](https://app.circleci.com/pipelines/github/checkstyle/checkstyle/23519/workflows/a2a6d40e-29cc-4cd9-b7c4-56ab2847869f/jobs/502198/parallel-runs/0/steps/0-103?invite=true#step-103-34362_34): 
```
Testing Checkstyle started
   [delete] Deleting directory /home/circleci/project/.ci-temp/contribution/checkstyle-tester/src/main/java
Cloning git repository 'pmd' to repositories/pmd folder ...
Cloning into 'repositories/pmd'...
Cloning git repository 'pmd' - completed

Resetting git sources to commit 'pmd_releases/6.21.0'
Running command: git reset --hard pmd_releases/6.21.0
HEAD is now at a28e9e22e5 [maven-release-plugin] prepare release pmd_releases/6.21.0
pmd is synchronized
     [copy] Copying 4019 files to /home/circleci/project/.ci-temp/contribution/checkstyle-tester/src/main/java/pmd
Running 'mvn clean' on src/main/java ...
Running command: mvn -e --no-transfer-progress --batch-mode clean
[INFO] Error stacktraces are turned on.

```



