### PR TITLE
Issue #14448: Updated IDEA version to v2023.3.4

### DIFF
--- a/devops/docker/idea-image/Dockerfile
+++ b/devops/docker/idea-image/Dockerfile
@@ -3,7 +3,7 @@ FROM cimg/openjdk:11.0.16
 RUN sudo apt update && sudo apt install -y wget
 
 # ENV is transferred to container
-ENV IDEA_VERSION="ideaIC-2022.2.2"
+ENV IDEA_VERSION="ideaIC-2023.3.4"
 ENV IDEA_PATH="/home/circleci/idea"
 ENV PATH="${PATH}:${IDEA_PATH}/bin"
 


### PR DESCRIPTION
Aims to close https://github.com/checkstyle/checkstyle/issues/14448

Link to PR in Checkstyle main repo with updated docker image : https://github.com/checkstyle/checkstyle/pull/14604

IDEA version used : v`2023.3.4`  (latest release)
```
Version: 2023.3.4
Build: 233.14475.28
13 February 2024
```
https://www.jetbrains.com/idea/download/?section=linux

Link to docker image used for testing update : 
https://hub.docker.com/repository/docker/manishkk07/manish-k-07-checkstyle/tags?page=1&ordering=last_updated

To pull image : `docker pull manishkk07/manish-k-07-checkstyle:jdk11-idea2023.3.4`
