### PR TITLE
Issue #818: do shallow clone while retaining checkout abilitiy to specific SHA

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -41,7 +41,7 @@ checkstyle-tester-diff-groovy-patch)
   sed -i'' 's/^guava/#guava/' ../.ci-temp/projects-to-test-on.properties
   sed -i'' 's/#checkstyle/checkstyle/' ../.ci-temp/projects-to-test-on.properties
   groovy diff.groovy -l ../.ci-temp/projects-to-test-on.properties \
-    -c my_check.xml -b master -p patch-branch -r ../.ci-temp/checkstyle
+    -c my_check.xml -b master -p patch-branch -r ../.ci-temp/checkstyle -h
   ;;
 
 checkstyle-tester-diff-groovy-base-patch)
@@ -50,7 +50,7 @@ checkstyle-tester-diff-groovy-base-patch)
   git checkout -b patch-branch
   cd ../../checkstyle-tester
   groovy diff.groovy -l projects-to-test-on.properties \
-    -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r ../.ci-temp/checkstyle
+    -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r ../.ci-temp/checkstyle -h
   ;;
 
 checkstyle-tester-diff-groovy-patch-only)
@@ -59,7 +59,7 @@ checkstyle-tester-diff-groovy-patch-only)
   git checkout -b patch-branch
   cd ../../checkstyle-tester
   groovy diff.groovy -l projects-to-test-on.properties \
-    -pc my_check.xml -p patch-branch -r ../.ci-temp/checkstyle -m single
+    -pc my_check.xml -p patch-branch -r ../.ci-temp/checkstyle -m single --useShallowClone
   ;;
 
 checkstyle-tester-diff-groovy-regression-single)
@@ -76,7 +76,7 @@ checkstyle-tester-diff-groovy-regression-single)
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
     -pc ../../../checkstyle-tester/diff-groovy-regression-config.xml \
     -r ../../checkstyle -xm "-Dcheckstyle.failsOnError=false" \
-    -m single -p master
+    -m single -p master -h
 
   # Run report with current branch
   cd ../../../checkstyle-tester/
@@ -85,7 +85,7 @@ checkstyle-tester-diff-groovy-regression-single)
   rm -rf reports repositories
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
     -pc diff-groovy-regression-config.xml -r ../.ci-temp/checkstyle/ \
-    -m single -p master -xm "-Dcheckstyle.failsOnError=false"
+    -m single -p master -xm "-Dcheckstyle.failsOnError=false" -h
 
   cd ..
   # We need to ignore file paths below, since they will be different between reports

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ environment:
       CMD3: " && cd checkstyle && git checkout -b patch-branch"
       CMD4: " "
       CMD5: " && cd ..\\checkstyle-tester "
-      CMD6: " && groovy diff.groovy -l projects-to-test-on.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -s"
+      CMD6: " && groovy diff.groovy -l projects-to-test-on.properties -bc my_check.xml -pc my_check.xml -b master -p patch-branch -r C:\\projects\\contribution\\checkstyle -s -h"
 
 build_script:
   - ps: >

--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -72,6 +72,16 @@ would add `--extraMvnRegressionOptions "-Dmaven.site.skip=true"` to `diff.groovy
  (optional, default is false). This option is
  used for files that are not compilable or that Checkstyle cannot parse.
 
+**useShallowClone** (h) - this option tells `diff.groovy` to use shallow clone for repositories
+defined in the file
+specified for the `--listOfProjects (-l)` argument. This option is a toggle (does not require an argument)
+and convenient for cases when internet is not stable and it is better to clone minimal required sources.
+Shallow cloning cannot be used for projects that reference SHA commit and, by default,
+fallback to using normal cloning. ATTENTION: if you change tag/branch in config for project
+that previously cloned shallowly there will be error to checkout to new tag/branch
+(Example: `fatal: Could not parse object 'c2ac5b90a467aedb04b52ae50a99e83207d847b3'.`), to resovle
+problem you need to remove impacted project folder(s) from repositories directory.
+
 ## Outputs
 
 When the script finishes its work the following directory structure will be created


### PR DESCRIPTION
Resolves #818 

This PR reuses the earlier PR on shallow clone PR, while  reverted retaining checkout abilitiy to specific SHA. 

I tested this PR on main repo https://github.com/checkstyle/checkstyle/pull/14662, by following the footprints of what already has been done. I am attaching the test results below:

**Successful build while retaining checkout to specific SHA:**
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/25238/workflows/51a420a4-ff1f-4137-89c0-802b6ecfcd81/jobs/577549
```
Testing Checkstyle started
   [delete] Deleting directory /home/circleci/project/.ci-temp/contribution/checkstyle-tester/src/main/java
Cloning git repository 'pmd' to repositories/pmd folder ...
Cloning into 'repositories/pmd'...
Cloning git repository 'pmd' - completed

Running command: git fetch --tags
Resetting git sources to commit 'pmd_releases/6.21.0'
Running command: git reset --hard refs/tags/pmd_releases/6.21.0
HEAD is now at a28e9e22e5 [maven-release-plugin] prepare release pmd_releases/6.21.0
pmd is synchronized
```

**Sucessful build testing Shallow Clone:**
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/25238/workflows/51a420a4-ff1f-4137-89c0-802b6ecfcd81/jobs/577567
```
Testing Checkstyle started
   [delete] Deleting directory /home/circleci/project/.ci-temp/contribution/checkstyle-tester/src/main/java
Shallow clone git repository 'apache-struts' to repositories/apache-struts folder ...
Cloning into 'repositories/apache-struts'...
Cloning git repository 'apache-struts' - completed
```