### PR TITLE
Issue #14448: Migrate IDEA to highest true-scopes release v2022.3.3

### DIFF
--- a/devops/docker/idea-image/Dockerfile
+++ b/devops/docker/idea-image/Dockerfile
@@ -3,7 +3,7 @@ FROM cimg/openjdk:11.0.16
 RUN sudo apt update && sudo apt install -y wget
 
 # ENV is transferred to container
-ENV IDEA_VERSION="ideaIC-2023.3.4"
+ENV IDEA_VERSION="ideaIC-2022.3.3"
 ENV IDEA_PATH="/home/circleci/idea"
 ENV PATH="${PATH}:${IDEA_PATH}/bin"
 


### PR DESCRIPTION
Aims to close https://github.com/checkstyle/checkstyle/issues/14448

Follow-up of https://github.com/checkstyle/checkstyle/pull/14604 and #837 

Based on observations from https://github.com/checkstyle/checkstyle/pull/14604#discussion_r1530584190 and further discussions.

last time we upgraded `2022.2.2` -> `2023.3.4`  at
https://github.com/checkstyle/contribution/commit/80a61391a97ac64f48d1ebef333c2910cd85b795 , but latest is problematic with scopes.

The latest IDEA release that we have used for update (2023.3.4) had issues with scopes.
A bit of research on different versions landed me on `v2022.3.3` being stable and good with scopes.

Link to PR in Checkstyle main repo with updated docker image : https://github.com/checkstyle/checkstyle/pull/14696

Link to docker image (personal) for testing update : 
https://hub.docker.com/layers/manishkk07/manish-k-07-checkstyle/jdk11-idea2022.3.3/images/sha256-3a659714655f8e033e648d894ac20eb110a0aa557f0f19821366cb54e4089305?context=repo

To pull image : `docker pull manishkk07/manish-k-07-checkstyle:jdk11-idea2022.3.3`