### PR TITLE
add new check: JavadocLeadingAsteriskAlign

### DIFF
--- a/checkstyle-tester/checks-only-javadoc-error.xml
+++ b/checkstyle-tester/checks-only-javadoc-error.xml
@@ -5,7 +5,7 @@
 
 <module name="Checker">
   <property name="charset" value="UTF-8"/>
-  
+
   <!-- do not change severity to 'error', as that will hide errors caused by exceptions -->
   <property name="severity" value="warning"/>
 
@@ -22,6 +22,7 @@
     <module name="JavadocContentLocation"/>
     <module name="JavadocMissingLeadingAsterisk"/>
     <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+    <module name="JavadocLeadingAsteriskAlign"/>
     <module name="JavadocParagraph"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="MissingDeprecated"/>


### PR DESCRIPTION
added `JavadocLeadingAsteriskAlign` check to `checkstyle-tester/checks-only-javadoc-error.xml`