### PR TITLE
CatchParameterName: rename ex variable to exc

### DIFF
--- a/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/CliOptions.java
@@ -688,9 +688,9 @@ public final class CliOptions {
                         props.getProperty(CliProcessor.OPTION_TWITTER_ACCESS_TOKEN_SECRET);
                 }
             }
-            catch (IOException ex) {
+            catch (IOException exc) {
                 throw new IllegalStateException("Twitter properties file has access problems"
-                    + " (twitterProperties=" + twitterProperties + ')', ex);
+                    + " (twitterProperties=" + twitterProperties + ')', exc);
             }
         }
 

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/Main.java
@@ -79,8 +79,8 @@ public final class Main {
                 }
             }
         }
-        catch (ParseException | GitAPIException | IOException | TemplateException ex) {
-            ex.printStackTrace();
+        catch (ParseException | GitAPIException | IOException | TemplateException exc) {
+            exc.printStackTrace();
             errors.add("[ERROR] An exception was thrown. See above for more details.");
             CliProcessor.printUsage();
         }

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/MainProcess.java
@@ -261,8 +261,8 @@ public final class MainProcess {
                     cliOptions.getTwitterAccessTokenSecret(), post);
         }
         // -@cs[IllegalCatch] We should execute all publishers, so cannot fail-fast
-        catch (Exception ex) {
-            errors.add(ex.toString());
+        catch (Exception exc) {
+            errors.add(exc.toString());
         }
     }
 

--- a/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
+++ b/releasenotes-builder/src/main/java/com/github/checkstyle/github/NotesBuilder.java
@@ -167,7 +167,7 @@ public final class NotesBuilder {
                         result.addError(error);
                     }
                 }
-                catch (GHFileNotFoundException ex) {
+                catch (GHFileNotFoundException exc) {
                     result.addWarning(String.format(MESSAGE_ISSUE_NOT_FOUND, issueNo));
 
                     issueNumber = issueNo;


### PR DESCRIPTION
Rename `CatchParameterName` ex variable to exc in remaining files.