### PR TITLE
Issue #944: Using compatible ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,4 +78,5 @@ workflows:
     jobs:
       - validate-with-script:
           name: "markdown lint"
+          image-name: "cimg/ruby:3.2"
           command: "./.ci/validation.sh markdownlint"


### PR DESCRIPTION
Issue: #944

PR updates the markdown lint job to use the official cimg/ruby:3.2 Docker image, which includes Ruby 3.2+. This satisfies the version requirement of mdl and allows the job to complete successfully.