### PR TITLE
Issue #980: Refactor AntBuilder DeleteDir to Use Groovy's built-in file operations

### DIFF
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -723,7 +723,10 @@ def moveDir(source, destination) {
 }
 
 def deleteDir(dir) {
-    new AntBuilder().delete(dir: dir, failonerror: false)
+    def dirFile = new File(dir)
+    if (dirFile.exists()) {
+        dirFile.deleteDir()
+    }
 }
 
 def executeCmd(cmd, dir = new File("").absoluteFile) {


### PR DESCRIPTION
part of : #980