### PR TITLE
minor: fix typo in exclusion

### DIFF
--- a/checkstyle-tester/projects-to-test-on.properties
+++ b/checkstyle-tester/projects-to-test-on.properties
@@ -5,7 +5,7 @@
 # Few projects that delivers set of unusual Java constructions that shall be correctly handled by AST visitor
 # 'InputAllEscapedUnicodeCharacters' must be skipped because it is too big and slows down JXR
 #checkstyle|git|https://github.com/checkstyle/checkstyle.git|master|**/.ci-temp/**/*,**/resources-noncompilable/**/asttreestringprinter/**/*,**/resources-noncompilable/**/filefilters/**/*,**/resources-noncompilable/**/main/**/*,**/resources-noncompilable/**/suppressionsstringprinter/**/*,**/resources-noncompilable/**/gui/**/*,**/resources-noncompilable/**/javadocpropertiesgenerator/**/*,src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParser.java,**/InputAllEscapedUnicodeCharacters.java,**/resources-noncompilable/**/javaparser/InputJavaParser.java,**/resources-noncompilable/**/checks/imports/unusedimports/InputUnusedImportsSingleWordPackage.java,**/resources-noncompilable/**/grammar/java19/*,**/resources-noncompilable/**/treewalker/**/*,**/resources-noncompilable/**/defaultlogger/**/*
-#sevntu-checkstyle|git|https://github.com/sevntu-checkstyle/sevntu.checkstyle|master|**/test/resources-noncompilable/InputLogicConditionNeedOptimizationCheck2.java
+#sevntu-checkstyle|git|https://github.com/sevntu-checkstyle/sevntu.checkstyle|master|**/test/resources-noncompilable/**/InputLogicConditionNeedOptimizationCheck2.java
 #checkstyle-sonar|git|https://github.com/checkstyle/sonar-checkstyle|master||
 
 # openjdk 25 requires lots of excludes, list here should be consistent with file filters at https://github.com/checkstyle/checkstyle/blob/master/config/projects-to-test/openjdk25-excluded.files


### PR DESCRIPTION
Fixes typo I made in https://github.com/checkstyle/contribution/pull/995

Forgot to add `**`