### PR TITLE
doc: Fix misformatted links

### DIFF
--- a/checkstyle-tester/README.md
+++ b/checkstyle-tester/README.md
@@ -276,42 +276,41 @@ such as Indentation and WhiteSpace Checks, and put them each into their own conf
 then separating the rest into files with roughly ten checks each.
 
 You may modify all the checks that depend on external files to use default settings.  **For each
-of the configuration files, you should use the [`my_check.xml`]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/my_check.xml)
+of the configuration files, you should use the
+[`my_check.xml`](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/my_check.xml)
 file as a base**, and add the checks from `checkstyle-checks.xml` to it. Then `diff.groovy`
 should be run on all projects in `projects-to-test-on.properties`, using the `diff.groovy`
 script once for each configuration file.
-[See instructions above]
-(https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#basic-difference-report)
-for "Basic Difference Report". You can also use our check regression script, found [here]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/multi_config_check_regression.groovy),
+[See instructions above](https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#basic-difference-report)
+for "Basic Difference Report". You can also use our check regression script, found
+[here](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/multi_config_check_regression.groovy),
 to automate this process for you.
 
 ### ANTLR Regression Report
 
-This report is generated using the [`launch_diff_antlr.sh`]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_antlr.sh)
+This report is generated using the
+[`launch_diff_antlr.sh`](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_antlr.sh)
 script. This script generates a report based on the differences in the ASTs generated
 from your PR branch and Checkstyle's 'main' branch using projects that are selected
-(uncommented) in the [`projects-to-test-on.properties`]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/projects-to-test-on.properties)
+(uncommented) in the
+[`projects-to-test-on.properties`](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/projects-to-test-on.properties)
 file. For the ANTLR regression report, we usually only want to see that changes
 to the Checkstyle project. To ensure that you test against any new inputs that
 you have created (unit test inputs, etc.), please make sure that you comment out
-all other projects, and add the following line to [`projects-to-test-on.properties`]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/projects-to-test-on.properties):
+all other projects, and add the following line to
+[`projects-to-test-on.properties`](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/projects-to-test-on.properties):
 
 ```bash
 my-checkstyle|git|https://github.com/<username>/checkstyle.git|<pr-branch>||
 ```
 
 Where `<username>` and `<pr-branch>` are your github username and the branch that
-your Checkstyle PR is based on, respectively. To use [`launch_diff_antlr.sh`]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_antlr.sh),
-you must modify the [`launch_diff_variables.sh`]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_variables.sh)
-file to reflect the location of the variables that [`launch_diff_antlr.sh`]
-(https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_antlr.sh)
+your Checkstyle PR is based on, respectively. To use
+[`launch_diff_antlr.sh`](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_antlr.sh),
+you must modify the
+[`launch_diff_variables.sh`](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_variables.sh)
+file to reflect the location of the variables that
+[`launch_diff_antlr.sh`](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/launch_diff_antlr.sh)
 uses to produce the report. Please note that `PULL_REMOTE` will need to be set to the name
 of the remote repository where your branch resides. If your branch is found at
 `origin/name-of-your-branch-here`, you will set `PULL_REMOTE=origin`. Then, run:


### PR DESCRIPTION
Some of the links in `checkstyle-tester/README.md` were misformatted. This PR fixes that. See difference below:

---
Before:
https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/README.md
<img width="923" height="775" alt="image" src="https://github.com/user-attachments/assets/f08c5e74-66cd-440f-b379-2b9316f8cd3c" />

After:
https://github.com/stoyanK7/contribution/tree/doc-antlr-md/checkstyle-tester
<img width="940" height="576" alt="image" src="https://github.com/user-attachments/assets/123f77f5-4779-4a67-85c8-a87f8593b1e8" />
