### PR TITLE
Issue #980: Replace AntBuilder.copy() with Files.walkFileTree()

### DIFF
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -1,8 +1,12 @@
 import static java.lang.System.err
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.regex.Pattern
 
 static void main(String[] args) {
@@ -713,9 +717,35 @@ def postProcessCheckstyleReport(targetDir, repoName, repoPath) {
 }
 
 def copyDir(source, destination) {
-    new AntBuilder().copy(todir: destination) {
-        fileset(dir: source)
-    }
+    Path sourceDir = new File(source).toPath().toAbsolutePath().normalize()
+    Path destinationDir = new File(destination).toPath().toAbsolutePath().normalize()
+
+    Files.walkFileTree(sourceDir, new SimpleFileVisitor<Path>() {
+        @Override
+        FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (dir.startsWith(destinationDir)) {
+                return FileVisitResult.SKIP_SUBTREE
+            }
+            Path targetDir = destinationDir.resolve(sourceDir.relativize(dir))
+            if (targetDir.startsWith(sourceDir)) {
+                return FileVisitResult.SKIP_SUBTREE
+            }
+            if (!Files.exists(targetDir)) {
+                Files.createDirectories(targetDir)
+            }
+            return FileVisitResult.CONTINUE
+        }
+
+        @Override
+        FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            Path targetFile = destinationDir.resolve(sourceDir.relativize(file))
+            if (targetFile.startsWith(sourceDir)) {
+                return FileVisitResult.CONTINUE
+            }
+            Files.copy(file, targetFile, REPLACE_EXISTING)
+            return FileVisitResult.CONTINUE
+        }
+    })
 }
 
 def moveDir(source, destination) {


### PR DESCRIPTION
Issue #980: 

## Description

Replaces the `AntBuilder.copy()` implementation in `copyDir` with Java NIO's `Files.walkFileTree()` and `SimpleFileVisitor`. This addresses the issues that caused PR #982 to be reverted.

## Changes

- Replaced `AntBuilder.copy(todir: destination) { fileset(dir: source) }` with `Files.walkFileTree()` and `SimpleFileVisitor`
- Added proper infinite recursion prevention by:
  1. Skipping directories that are inside the destination
  2. Skipping directories/files whose target would end up inside the source (prevents nested copies when destination is inside source)

## Note on Symlinks

The implementation does not follow directory symlinks by default. This is intentional:
- All symlinks in tested repos point to directories already within the same repository
- Not following them avoids copying the same files twice
---

Closes #980