### PR TITLE
Issue #980: Replace AntBuilder.copy() with Files.walkFileTree()

### DIFF
--- a/checkstyle-tester/diff.groovy
+++ b/checkstyle-tester/diff.groovy
@@ -1,8 +1,12 @@
 import static java.lang.System.err
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.regex.Pattern
 
 static void main(String[] args) {
@@ -713,9 +717,29 @@ def postProcessCheckstyleReport(targetDir, repoName, repoPath) {
 }
 
 def copyDir(source, destination) {
-    new AntBuilder().copy(todir: destination) {
-        fileset(dir: source)
-    }
+    Path sourceDir = new File(source).toPath().toAbsolutePath().normalize()
+    Path destinationDir = new File(destination).toPath().toAbsolutePath().normalize()
+
+    Files.walkFileTree(sourceDir, new SimpleFileVisitor<Path>() {
+        @Override
+        FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+
+            if (dir.startsWith(destinationDir)) {
+                return FileVisitResult.SKIP_SUBTREE
+            }
+            Path targetDir = destinationDir.resolve(sourceDir.relativize(dir))
+            Files.createDirectories(targetDir)
+            return FileVisitResult.CONTINUE
+        }
+
+        @Override
+        FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+
+            Path targetFile = destinationDir.resolve(sourceDir.relativize(file))
+            Files.copy(file, targetFile, REPLACE_EXISTING)
+            return FileVisitResult.CONTINUE
+        }
+    })
 }
 
 def moveDir(source, destination) {


### PR DESCRIPTION
 Issue #980: 

**What is fixed:**
- Changed `targetDir.startsWith(sourceDir)` → `dir.startsWith(destinationDir)` since some of the valid directories were getting skipped which caused ci errors.

**Why earlier code failed:**
- Previous check skipped directories when dest was inside source
- Caused missing files and CI build failures

**Improvements:**
- NOT Added VCS directory excludes (`.git`, `.svn`, `.hg`, `CVS`, etc.)
- NOT Added VCS file excludes (`.gitignore`, `.gitattributes`, etc.)
- NOT Matches AntBuilder's `defaultexcludes` behavior