### PR TITLE
Issue #1012: Activate test in jdk21

### DIFF
--- a/releasenotes-builder/pom.xml
+++ b/releasenotes-builder/pom.xml
@@ -24,7 +24,7 @@
         <checkstyle.version>13.0.0</checkstyle.version>
         <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-checks.xml</checkstyle.configLocation>
         <junit.version>4.13.2</junit.version>
-        <mockito.version>5.2.0</mockito.version>
+        <mockito.version>5.21.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -87,7 +87,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/MainTest.java
@@ -23,12 +23,10 @@ import static com.github.checkstyle.MainProcess.RELEASE_NUMBER_PATTERN;
 import static org.kohsuke.github.GHIssueState.CLOSED;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.checkstyle.internal.AbstractReleaseNotesTestSupport;
 
-@Ignore
 public class MainTest extends AbstractReleaseNotesTestSupport {
     @Test
     public void test() {

--- a/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
+++ b/releasenotes-builder/src/test/java/com/github/checkstyle/templates/TemplateProcessorTest.java
@@ -26,13 +26,11 @@ import java.io.File;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.checkstyle.MainProcess;
 import com.github.checkstyle.internal.AbstractReleaseNotesTestSupport;
 
-@Ignore
 public class TemplateProcessorTest extends AbstractReleaseNotesTestSupport {
     @Test
     public void testIssueCommitWithIssueNotFound() throws Exception {


### PR DESCRIPTION
Issue #1012 

While Mockito Core historically provided basic mocking functionality, the capabilities of Mockito Inline are now the default in Mockito 5.0.0 and later, eliminating the need for separate configuration or dependencies for advanced mocking scenarios.
For most modern Java applications, using mockito-core alone is sufficient, as it includes the inline mock maker functionality by default.

```
atharv@atharv-IdeaPad-3-15IIL05:~/Desktop/oss/contribution/releasenotes-builder$ mvn -Dtest=MainTest test
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< com.github.checkstyle:releasenotes-builder >-------------
[INFO] Building releasenotes-builder 1.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ releasenotes-builder ---
[INFO] Copying 5 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (default-compile) @ releasenotes-builder ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ releasenotes-builder ---
[INFO] Copying 18 resources from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.1:testCompile (default-testCompile) @ releasenotes-builder ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ releasenotes-builder ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.github.checkstyle.MainTest
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (/home/atharv/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.960 s -- in com.github.checkstyle.MainTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.118 s
[INFO] Finished at: 2026-01-05T12:33:30+05:30
[INFO] ------------------------------------------------------------------------

```
```
atharv@atharv-IdeaPad-3-15IIL05:~/Desktop/oss/contribution/releasenotes-builder$ mvn -Dtest=TemplateProcessorTest test
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< com.github.checkstyle:releasenotes-builder >-------------
[INFO] Building releasenotes-builder 1.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ releasenotes-builder ---
[INFO] Copying 5 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (default-compile) @ releasenotes-builder ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ releasenotes-builder ---
[INFO] Copying 18 resources from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.1:testCompile (default-testCompile) @ releasenotes-builder ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ releasenotes-builder ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.github.checkstyle.templates.TemplateProcessorTest
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (/home/atharv/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.124 s -- in com.github.checkstyle.templates.TemplateProcessorTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.428 s
[INFO] Finished at: 2026-01-05T12:34:29+05:30
[INFO] ------------------------------------------------------------------------
atharv@atharv-IdeaPad-3-15IIL05:~/Desktop/oss/contribution/releasenotes-builder$ 


```