### PR TITLE
Remove JavadocStyle from configs

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -432,9 +432,6 @@
     <!-- JavadocAST Checks - disabled due to performance problem
     <module name="JavadocParagraph"/>
     -->
-    <module name="JavadocStyle">
-      <property name="scope" value="public"/>
-    </module>
     <!-- JavadocAST Checks - disabled due to performance problem
     <module name="JavadocTagContinuationIndentation"/>
     -->

--- a/checkstyle-tester/diff-groovy-regression-config.xml
+++ b/checkstyle-tester/diff-groovy-regression-config.xml
@@ -395,9 +395,6 @@
         <!-- JavadocAST Checks - disabled due to performance problem
         <module name="JavadocParagraph"/>
         -->
-        <module name="JavadocStyle">
-            <property name="scope" value="public"/>
-        </module>
         <!-- JavadocAST Checks - disabled due to performance problem
         <module name="JavadocTagContinuationIndentation"/>
         -->

--- a/examples/conf/template_config.xml
+++ b/examples/conf/template_config.xml
@@ -48,16 +48,9 @@
         <module name="JavadocVariable">
         </module>
         
-        <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocStyle -->
-        <!-- Validates Javadoc comments to help ensure they are well formed. -->
-            <!-- <property name="scope" value="private"/> -->
-            <!-- <property name="excludeScope" value=""/> -->
-            <!-- <property name="checkFirstSentence" value="true"/> -->
-            <!-- <property name="checkEmptyJavadoc" value="false"/> -->
-            <!-- <property name="checkHtml" value="true"/> -->
-            <!-- <property name="tokens" value="INTERFACE_DEF, CLASS_DEF,
-                    METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/> -->
-        <module name="JavadocStyle">
+        <!-- See http://checkstyle.sf.net/config_javadoc.html#SummaryJavadoc -->
+        <!-- Checks that a Javadoc summary sentence follows the configured format. -->
+        <module name="SummaryJavadoc">
         </module>
 
 


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/pull/20582

Removes `JavadocStyle` from checkstyle-tester configs because the check is being removed from Checkstyle.

Also updates the example config to use `SummaryJavadoc` instead.