### PR TITLE
minor: suppress MissingCtor temporarily

### DIFF
--- a/patch-diff-report-tool/config/suppressions.xml
+++ b/patch-diff-report-tool/config/suppressions.xml
@@ -17,4 +17,6 @@
     <!-- Until https://github.com/checkstyle/checkstyle/issues/3496 and when we have time to fix this in sevntu-->
     <suppress checks="ReturnCount" files=".*CheckstyleRecord\.java|DiffReport\.java|MergedConfigurationModule\.java"/>
 
+    <!-- temporal suppression until we have time to fix it -->
+    <suppress checks="MissingCtor" files=".*"/>
 </suppressions>


### PR DESCRIPTION
Temporary suppression for MissingCtor until explicit constructors are added throughout the repository.

Related:
checkstyle/checkstyle#20813