### PR TITLE
config: new check RedundantModifierCompactSource

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -501,6 +501,7 @@
     <module name="ClassMemberImpliedModifier"/>
     <module name="ModifierOrder"/>
     <module name="RedundantModifier"/>
+    <module name="RedundantModifierCompactSource"/>
     <module name="InterfaceMemberImpliedModifier"/>
     <module name="AnnotatedDeclarationVisibility"/>
 


### PR DESCRIPTION
Add `RedundantModifierCompactSource` to the non-Javadoc error tester configuration.\n\nPart of checkstyle/checkstyle#20943.