### PR TITLE
config: Added new check OpenjdkMethodParameterAlignment

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -628,6 +628,7 @@
       <property name="tokens" value="METHOD_REF"/>
       <property name="option" value="nl"/>
     </module>
+    <module name="OpenjdkMethodParameterAlignment"/>
     <module name="OperatorWrap">
       <property name="tokens" value="ASSIGN"/>
       <property name="tokens" value="DIV_ASSIGN"/>


### PR DESCRIPTION
Adds the new check `OpenjdkMethodParameterAlignment` to `checkstyle-tester/checks-nonjavadoc-error.xml`.

Required by https://github.com/checkstyle/checkstyle/pull/20953 (issue https://github.com/checkstyle/checkstyle/issues/20638).

To be merged right after checkstyle/checkstyle#20953.