### PR TITLE
config: IllegalBlockTag no-exception + suppressions

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -292,6 +292,7 @@
         <property name="ignoreSetter" value="true"/>
         <property name="setterCanReturnItsClass" value="true"/>
     </module>
+    <module name="IllegalBlockTag"/>
     <module name="IllegalCatch">
         <property name="illegalClassNames" value="java.lang.Exception, java.lang.Throwable, java.lang.RuntimeException, java.lang.NullPointerException"/>
     </module>

--- a/patch-diff-report-tool/config/suppressions.xml
+++ b/patch-diff-report-tool/config/suppressions.xml
@@ -12,9 +12,10 @@
     <suppress checks="NPathComplexity" files="CliArgsValidator.java" />
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="Javadoc|MultipleStringLiterals|WriteTag|MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
+    <suppress checks="Javadoc|MultipleStringLiterals|WriteTag|IllegalBlockTag|MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
 
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]main[\\/]java[\\/]com[\\/]github[\\/]checkstyle[\\/]"/>
+    <suppress checks="IllegalBlockTag" files=".*[\\/]src[\\/]main[\\/]java[\\/]com[\\/]github[\\/]checkstyle[\\/]"/>
 
     <!-- Until https://github.com/checkstyle/checkstyle/issues/3496 and when we have time to fix this in sevntu-->
     <suppress checks="ReturnCount" files=".*CheckstyleRecord\.java|DiffReport\.java|MergedConfigurationModule\.java"/>

--- a/releasenotes-builder/config/suppressions.xml
+++ b/releasenotes-builder/config/suppressions.xml
@@ -16,7 +16,9 @@
     <suppress checks="MultipleStringLiterals" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]test[\\/]"/>
+    <suppress checks="IllegalBlockTag" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]main[\\/]java[\\/]com[\\/]github[\\/]checkstyle[\\/]"/>
+    <suppress checks="IllegalBlockTag" files=".*[\\/]src[\\/]main[\\/]java[\\/]com[\\/]github[\\/]checkstyle[\\/]"/>
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="AnonInnerLength" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="IllegalCatch" files=".*[\\/]src[\\/]test[\\/]"/>


### PR DESCRIPTION
### Companion PR
https://github.com/checkstyle/checkstyle/pull/21117

- Adds `IllegalBlockTag` to `checkstyle-tester/checks-nonjavadoc-error.xml`
- Suppresses `IllegalBlockTag` in releasenotes-builder / patch-diff-report-tool (same paths as WriteTag)