### PR TITLE
config: restore IllegalBlockTag in no-exception tester

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -292,6 +292,7 @@
         <property name="ignoreSetter" value="true"/>
         <property name="setterCanReturnItsClass" value="true"/>
     </module>
+    <module name="IllegalBlockTag"/>
     <module name="IllegalCatch">
         <property name="illegalClassNames" value="java.lang.Exception, java.lang.Throwable, java.lang.RuntimeException, java.lang.NullPointerException"/>
     </module>


### PR DESCRIPTION
### Companion PR
https://github.com/checkstyle/checkstyle/pull/21117

Restores `<module name="IllegalBlockTag"/>` in `checkstyle-tester/checks-nonjavadoc-error.xml` after temporary removal in c393402.

**Please merge only after** checkstyle/checkstyle#21117 is merged (so other PRs are not blocked by an unknown Check name).

Suppressions for IllegalBlockTag in patch-diff-report-tool / releasenotes-builder are already on master from #1113.