### PR TITLE
config: add apereo-cas project for module import diff reports

### DIFF
--- a/checkstyle-tester/projects-to-test-on-for-github-action.properties
+++ b/checkstyle-tester/projects-to-test-on-for-github-action.properties
@@ -45,3 +45,6 @@ openjdk25|git|https://github.com/openjdk/jdk25u.git|master|**/test/langtools/jdk
 
 Hartshorn|git|https://github.com/Dockbox-OSS/Hartshorn|develop/0.7.0||
 camunda|git|https://github.com/camunda/camunda|main||
+
+# Largest real-world user of Java 25 module imports (import module)
+apereo-cas|git|https://github.com/apereo/cas.git|957bb1ea4a5bd696de282867599c882e824db317||


### PR DESCRIPTION
Adds the Apereo CAS project to the GitHub-action tester list, pinned to the current HEAD commit so regression diffs stay reproducible.

CAS is the largest real-world user of Java 25 module imports, thousandsof its  Java files use `import module`, making it useful for diff reports of the new ModuleImportOrder check (checkstyle/checkstyle#19967). 

