### PR TITLE
config: move UnnecessaryFullyQualifiedType check under import.

### DIFF
--- a/checkstyle-tester/checks-nonjavadoc-error.xml
+++ b/checkstyle-tester/checks-nonjavadoc-error.xml
@@ -69,7 +69,6 @@
     <property name="requiredTranslations" value="de, fr, fi, es, pt, ja, tr, zh"/>
   </module>
   <module name="UniqueProperties"/>
-  <module name="UnnecessaryFullyQualifiedType"/>
   <module name="OrderedProperties"/>
 
   <!-- Regexp -->
@@ -423,6 +422,7 @@
       <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
     <module name="RedundantImport"/>
+    <module name="UnnecessaryFullyQualifiedType"/>
     <module name="UnusedImports"/>
 
     <!-- Javadoc Comments -->


### PR DESCRIPTION
From https://app.circleci.com/pipelines/github/checkstyle/checkstyle/50882/workflows/7f9cf5d2-8418-4d20-a3c3-e9827d0ddc7a/jobs/1796123  the  check was under miscleanous update it to import.