### PR TITLE
config: Update Maven version from 3.8.8 to 3.8.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ branches:
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.8" )) {
+      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.9" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://archive.apache.org/dist/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.zip',
+          'https://archive.apache.org/dist/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
@@ -27,7 +27,7 @@ install:
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\groovy-bin.zip", "C:\groovy")
       }
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.8
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.9
   - cmd: SET GROOVY_HOME=C:\groovy\groovy-5.0.0
   - cmd: SET PATH=%GROOVY_HOME%\bin;%JAVA_HOME%\bin;%M2_HOME%\bin;%PATH%
   - cmd: git config --global core.autocrlf
@@ -36,7 +36,7 @@ install:
   - cmd: groovy -version
 
 cache:
-  - C:\maven\apache-maven-3.8.8
+  - C:\maven\apache-maven-3.8.9
   - C:\groovy\groovy-5.0.0
   - C:\Users\appveyor\.m2
 
@@ -101,7 +101,7 @@ build_script:
   # We need to use cmd there as ps1 is failing each time error output appear from any command line
   - appveyor.cmd
   - ps: echo "Size of caches (bytes):"
-  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.8' | Measure-Object -Property Length -Sum
+  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.9' | Measure-Object -Property Length -Sum
   - ps: Get-ChildItem -Recurse 'C:\groovy\groovy-5.0.0' | Measure-Object -Property Length -Sum
   - ps: Get-ChildItem -Recurse 'C:\Users\appveyor\.m2' | Measure-Object -Property Length -Sum
 


### PR DESCRIPTION
https://ci.appveyor.com/project/Checkstyle/contribution/builds/54617935/job/bes7fqsd8gs41jyw

```
maven-pmd-plugin:3.28.0:check (default) @ checkstyle ---
[INFO] Skipping PMD execution
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:09 min
[INFO] Finished at: 2026-08-28T00:38:52Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.spotbugs:spotbugs-maven-plugin:4.10.4.0:check (default) on project checkstyle: The plugin com.github.spotbugs:spotbugs-maven-plugin:4.10.4.0 requires Maven version 3.8.9 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.spotbugs:spotbugs-maven-plugin:4.10.4.0:check (default) on project checkstyle: The plugin com.github.spotbugs:spotbugs-maven-plugin:4.10.4.0 requires Maven version 3.8.9
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:187)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.PluginIncompatibleException: The plugin com.github.spotbugs:spotbugs-maven-plugin:4.10.4.0 requires Maven version 3.8.9
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.checkRequiredMavenVersion (DefaultMavenPluginManager.java:309)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:183)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds
```