### PR TITLE
supplemental: resolve OpenjdkMethodThrowsAlignment violations

### DIFF
--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/FilesystemUtils.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/FilesystemUtils.java
@@ -97,7 +97,8 @@ public final class FilesystemUtils {
      *         thrown on filesystem error.
      */
     public static void exportResource(String resourceName,
-            Path destination) throws IOException {
+            Path destination)
+                    throws IOException {
         try (InputStream in = FilesystemUtils.class
                 .getResourceAsStream(resourceName);
                 OutputStream out = Files.newOutputStream(destination)) {

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleConfigurationsParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleConfigurationsParser.java
@@ -190,7 +190,8 @@ public final class CheckstyleConfigurationsParser {
      *         on internal StAX failure.
      */
     private static void processModuleTag(XMLEventReader reader, StartElement startElement,
-            ConfigurationModule parent) throws XMLStreamException {
+            ConfigurationModule parent)
+                    throws XMLStreamException {
         String childModuleName = null;
         final Iterator<Attribute> attributes = startElement
                 .getAttributes();

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/parser/CheckstyleTextParser.java
@@ -122,7 +122,8 @@ public final class CheckstyleTextParser {
      *             if there is a problem accessing a file.
      */
     private static void parseDifference(DiffReport diffReport, StringListIterator baseReader,
-            Path baseReport, StringListIterator patchReader, Path patchReport) throws IOException {
+            Path baseReport, StringListIterator patchReader, Path patchReport)
+                    throws IOException {
         final int order = baseReader.peek().compareTo(patchReader.peek());
 
         if (order == 0) {
@@ -154,7 +155,8 @@ public final class CheckstyleTextParser {
      *             if there is a problem accessing a file.
      */
     private static void parseDifferenceFile(DiffReport diffReport, String filePath,
-            Path baseReport, Path patchReport) throws IOException {
+            Path baseReport, Path patchReport)
+                    throws IOException {
         final File baseFile = new File(baseReport.toFile(), filePath);
         final File patchFile = new File(patchReport.toFile(), filePath);
 

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/SiteGenerator.java
@@ -81,7 +81,8 @@ public final class SiteGenerator {
      *         on failure to write site to disc.
      */
     public static void generate(DiffReport diffReport, MergedConfigurationModule diffConfiguration,
-            CliOptions options) throws IOException {
+            CliOptions options)
+                    throws IOException {
         // setup thymeleaf engine
         final TemplateEngine tplEngine = getTemplateEngine();
         // setup xreference generator

--- a/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/TextTransform.java
+++ b/patch-diff-report-tool/src/main/java/com/github/checkstyle/site/TextTransform.java
@@ -97,7 +97,8 @@ public final class TextTransform {
      *             if there is an error reading.
      */
     private void transform(Reader sourceReader, Writer destWriter, Locale outputLocale,
-            String outputEncoding) throws IOException {
+            String outputEncoding)
+                    throws IOException {
         locale = outputLocale;
         encoding = outputEncoding;
 
@@ -139,7 +140,8 @@ public final class TextTransform {
      *             if there is an error reading the file.
      */
     public void transform(String sourceFile, String destFile, Locale outputLocale,
-            String inputEncoding, String outputEncoding) throws IOException {
+            String inputEncoding, String outputEncoding)
+                    throws IOException {
         final File dest = new File(destFile);
 
         fileName = dest.getName();


### PR DESCRIPTION
This PR resolves all the violations due to the new check `OpenjdkMethodThrowsAlignmentCheck`.